### PR TITLE
Fix/native vpc tunnel key ipcache

### DIFF
--- a/Documentation/cmdref/cilium-dbg_bpf_ipcache_delete.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_ipcache_delete.md
@@ -19,6 +19,7 @@ cilium bpf ipcache delete 10.244.3.110/32 --clusterid 1
 ```
       --clusterid uint16   Cluster ID
   -h, --help               help for delete
+      --vni uint32         native-vpc VNI of the entry (0 = the unscoped ipcache)
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium-dbg_bpf_ipcache_update.md
+++ b/Documentation/cmdref/cilium-dbg_bpf_ipcache_update.md
@@ -23,6 +23,7 @@ cilium bpf ipcache update 10.244.3.110/32 --tunnelendpoint 172.21.0.2 --identity
       --identity uint32         Identity
       --skiptunnel              Skip tunnel
       --tunnelendpoint string   Tunnel endpoint
+      --vni uint32              native-vpc VNI of the entry (0 = the unscoped ipcache)
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -83,6 +83,7 @@ get started and experiment with Cilium.
    network/l2-announcements
    network/node-ipam
    network/pod-annotations
+   network/native-vpc
    network/multicast
 
 .. toctree::

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -1034,16 +1034,23 @@ apply unchanged:
   node sets removes the failure mode, and
   ``cilium_native_vpc_overlapping_ips`` already exposes the precondition.
 
-An operator that does not need fragmented traffic can additionally set
-``--enable-ipv4-fragment-tracking=false``, which trades the collision for
-dropping non-first fragments (``DROP_FRAG_NOSUPPORT``) - a fail-closed choice.
+**This is fixed**: ``struct ipv4_frag_id`` carries a VNI field when the
+datapath is compiled with the node-level ``ENABLE_NATIVE_VPC`` define, and
+``pkg/maps/fragmap`` selects the matching key layout when creating the map.
+Deployments without native-vpc keep the upstream layout byte for byte (12
+bytes; 16 with the VNI), which the align checker enforces.
 
-The bounded fix is to add a VNI field to ``struct ipv4_frag_id`` (and to
-``pkg/maps/fragmap.FragmentKey4``) under a node-level ``ENABLE_NATIVE_VPC``
-define, mirroring how ``VniKey`` extends the ipcache key: the field is only
-compiled in when the mode is enabled, so non-native-vpc deployments keep a
-byte-identical map. It is a follow-up rather than part of this change because
-it alters a map shared by five BPF programs and needs datapath validation.
+Only ``bpf_lxc`` knows the VNI (it is per-endpoint load-time config); every
+other program writes and reads with VNI 0 and therefore has its own key
+namespace. A datagram whose fragments were classified by different programs
+would then miss the map and be dropped (``DROP_FRAG_NOT_FOUND``) instead of
+being misclassified - the fail-closed direction. This does not occur in a
+native-vpc deployment, where the pod path is bpf_lxc only: kube-ovn owns the
+host and tunnel datapath, and the agent runs with no devices attached.
+
+An operator that does not need fragmented traffic at all can additionally set
+``--enable-ipv4-fragment-tracking=false``, which drops non-first fragments
+outright (``DROP_FRAG_NOSUPPORT``).
 
 Lifecycle plane
 ---------------

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -530,7 +530,10 @@ restarts converge).
 |    |                      | exported as cilium_native_vpc_overlapping_ips;    |
 |    |                      | NAT is inert because its features are rejected    |
 +----+----------------------+---------------------------------------------------+
-| 6  | service / LB         | rejected at startup (test-covered both ways)      |
+| 6  | service / LB         | rejected at startup (test-covered both ways) and  |
+|    |                      | the datapath skips service translation for VPC    |
+|    |                      | endpoints, since ClusterIP is programmed even     |
+|    |                      | with kube-proxy replacement disabled              |
 +----+----------------------+---------------------------------------------------+
 | 7  | encryption / egress  | rejected at startup (test-covered both ways)      |
 |    | gateway / masquerade |                                                   |
@@ -922,10 +925,65 @@ Service and load-balancing plane
 Scope: service frontends, backends and their BPF maps.
 
 Backends are keyed by ``(IP, port, protocol)``, so two pods of different VPCs
-sharing an IP would collapse into a single backend entry and receive each
-other's traffic. Native-vpc therefore **rejects kube-proxy replacement and
-socket LB at startup**; service load balancing is left to kube-proxy (or to
-kube-ovn), which resolves backends in the VPC's own routing domain.
+sharing an IP collapse into a single backend entry. Worse, a backend address is
+just an IP: whichever pod owns that IP **in the sender's own VPC** is what
+kube-ovn delivers to. Translating a service address for a VPC endpoint can
+therefore silently redirect a client of one tenant to a pod of another.
+
+Native-vpc closes this on two levels:
+
+* **Configuration**: kube-proxy replacement and socket LB are rejected at
+  startup.
+* **Datapath**: disabling kube-proxy replacement is *not* sufficient. Only
+  NodePort and HostPort frontends are gated by it; ClusterIP frontends and
+  their backends are still reflected into the load-balancing tables and
+  programmed into the BPF maps, and ``bpf_lxc`` calls ``lb4_lookup_service()``
+  unconditionally on pod egress. ``bpf_lxc`` therefore skips the service lookup
+  entirely when the endpoint has a VNI (``CONFIG(native_vpc_vni) > 0``),
+  exactly like it skips the endpoint-map fast path. Service load balancing is
+  left to kube-ovn (or kube-proxy), which resolves backends inside the VPC's
+  own routing domain.
+
+Consumers of the load-balancing tables that remain active are VPC-agnostic by
+nature and unaffected: Hubble's service enrichment resolves *frontends*
+(cluster-scoped VIPs, never pod addresses), and the health checker as well as
+NodePort/HostPort reflection are gated by kube-proxy replacement.
+CiliumLocalRedirectPolicy is *not* gated by it, but it redirects to a backend
+address and is therefore ineffective (and would be unsafe) for VPC endpoints
+under the datapath rule above.
+
+Why ``kubeProxyReplacement: false`` is not enough
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This is worth spelling out, because the natural assumption is that disabling
+kube-proxy replacement disables Cilium's service handling:
+
+#. the load-balancing control plane (reflectors, maps, reconciler) is
+   registered unconditionally in the agent, so the BPF service and backend maps
+   are created and populated;
+#. only NodePort, LoadBalancer and HostPort frontends are gated by kube-proxy
+   replacement - **ClusterIP frontends are reflected unconditionally**, i.e.
+   every ClusterIP service of the cluster ends up in the BPF maps;
+#. ``bpf_lxc`` compiles per-packet load balancing whenever socket LB is not
+   *fully* enabled (``#if !defined(ENABLE_SOCKET_LB_FULL) || ...``), and also
+   whenever SCTP support is enabled - both of which hold for a kube-ovn
+   chaining deployment with ``socketLB.enabled: false`` and
+   ``sctp.enabled: true``.
+
+Without the datapath rule above, a pod of VPC B connecting to a ClusterIP
+therefore had its destination rewritten by Cilium to a backend pod address of,
+say, VPC A - and kube-ovn then resolved that address inside VPC B, either
+dropping the packet or delivering it to whatever pod owns the same IP there.
+
+Operators can verify the state on a node with:
+
+.. code-block:: shell-session
+
+    # the maps exist and are populated even with kubeProxyReplacement=false
+    $ cilium-dbg bpf lb list | head
+    # after the fix, traffic from a VPC pod to a ClusterIP must leave the pod
+    # untranslated (kube-ovn / kube-proxy resolves it):
+    $ cilium-dbg monitor --type trace | grep <clusterIP>
 
 Encryption, egress gateway and masquerade plane
 -----------------------------------------------

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -696,6 +696,17 @@ Forwarding plane
 
 Scope: BPF maps and programs.
 
+Not writing VPC endpoints into the endpoint map also settles the bare-address
+lookups elsewhere in the datapath. ``bpf_host`` and ``bpf_overlay`` look an
+address up in that map to deliver it locally, with no scope to offer; whether
+they are on the path at all depends on the deployment (``devices`` and whether
+Cilium's own tunnel is in use). The question no longer has to be answered per
+deployment: the map holds no VPC endpoint, so those lookups cannot find one and
+fall through to the stack, which is where kube-ovn expects the traffic. The
+identity lookups on the same paths read the unscoped ipcache, which holds no
+VPC address either, so they resolve to the world identity rather than to
+another VPC's pod.
+
 The endpoint map (``cilium_lxc``) is the one place where the address is the
 whole key, with no room for a scope. Endpoints in a VPC therefore have no entry
 in it: three pods sharing an address would be one entry, so it could only ever
@@ -861,6 +872,15 @@ proxy.
   of them and the first CNI DEL would remove the route the others still need.
   kube-ovn owns routing in this deployment, so the mode is refused rather than
   quietly producing a shared route.
+* **DNS proxy (fails closed, and says so).** The DNS proxy is reached from the
+  host namespace and has only the address of the connection to attribute it to
+  an endpoint. That is enough while an address belongs to one endpoint, and
+  stops being enough the moment several VPCs use it, so the lookup refuses to
+  answer rather than applying another VPC's rules and the query is dropped. The
+  refusal used to be indistinguishable from an unknown address; it now names
+  the reason, because the two call for opposite reactions - one is a missing
+  endpoint, the other is DNS policy that cannot be applied to that address at
+  all. Rules themselves are held per endpoint ID, so they are never mixed up.
 * **L7 proxy (enforced).** A redirected connection is proxied from the host
   network namespace to the original destination address, and the policy the
   proxy applies is found again by the endpoint's address. With overlapping VPC

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -1156,6 +1156,28 @@ backfills it) and then Cilium; the VNI is re-read on restore. A VNI change on a
 running endpoint is deliberately not hot-applied, and an annotation that
 disappears never downgrades a running endpoint to the plain scheme.
 
+The re-read on restore takes a scope, it does not swap one. An endpoint that
+has no VNI yet adopts the annotation's - that is the backfill the sequence
+above exists for. An endpoint that already has one keeps it even if the
+annotation now names another VPC, and says so in the log. The asymmetry is not
+caution for its own sake: the VNI identity label, the numeric identity, the
+CiliumEndpoint annotation other nodes read and the loaded datapath
+configuration all derive from the VNI, and the re-read derives none of them
+again. Adopting a different scope there publishes the address in a VPC while
+the endpoint's identity still names the previous one, so the address ends up in
+both. Moving a pod between VPCs is therefore a recreation, which is also the
+only form in which every derived value is rebuilt.
+
+The pod watcher follows the same rule from the other side. Its entries are
+placeholders that carry ``reserved:unmanaged`` until the endpoint resolves an
+identity, and their scope is taken from the endpoint when there is one. For a
+pod on this node it defers to the endpoint even before the endpoint exists,
+because pod events are delivered before endpoint restore completes: reading the
+annotation in that window would publish exactly the scope the endpoint is about
+to refuse. Pods on other nodes keep using the annotation, which is the only
+signal available there, and the CiliumEndpoint entry - written from the remote
+endpoint's real VNI - takes precedence over it.
+
 Audit result ledger
 ===================
 
@@ -1221,6 +1243,15 @@ look for when reviewing a change.
 | life      | a mode downgrade left        | state that outlives a mode switch    |
 |           | endpoints half configured    | must be re-evaluated against the     |
 |           |                              | mode, not restored blindly           |
++-----------+------------------------------+--------------------------------------+
+| control   | the restore re-read adopted  | a value that other state is derived  |
+|           | a *different* VNI, moving    | from cannot be swapped in isolation; |
+|           | the endpoint between VPCs    | either rebuild the derived state or  |
+|           | while its identity, its CEP  | refuse the change                    |
+|           | annotation and its datapath  |                                      |
+|           | config still named the old   |                                      |
+|           | one - the address then       |                                      |
+|           | existed in both VPCs         |                                      |
 +-----------+------------------------------+--------------------------------------+
 | control   | both watchers decided        | "does this entry still exist?" is a  |
 |           | whether an old entry         | question about the key, and the key  |

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -771,6 +771,18 @@ one flat key space - correct when the entries live in two different BPF maps.
 The Go and C key layouts are pinned by a test on the real invariant: the LPM
 static prefix must equal the bit offset of the IP inside the key data.
 
+Ordering, because it decides which of these guards is load-bearing. A container
+that restarts in place keeps its pod sandbox, so no CNI call happens at all and
+nothing here is touched - the endpoint, its identifiers and its ipcache entry
+are the same objects before and after. A pod that is recreated does go through
+CNI DEL and CNI ADD, and the two are ordered per pod by kubelet, with the
+address only becoming free for another pod once DEL has returned. What is *not* ordered
+that way is Cilium's own teardown: the endpoint stops its controllers with
+RemoveAll rather than waiting for them, so CNI DEL returns while the removal of
+the ipcache entry is still pending. The new endpoint can therefore register the
+address before the old one's teardown reaches it, and every guard described
+here exists for that window.
+
 An address outlives the pod that used it. Once released it can be given to
 another pod, whose endpoint registers the same (VNI, IP) key, while the
 previous endpoint is still being torn down on its own schedule. Every removal
@@ -779,6 +791,14 @@ watchers already matched on the pod, and the local identity synchronizer now
 does the same, so a late teardown cannot take the entry of whoever holds the
 address now. For an endpoint in a VPC that matters more than elsewhere, because
 losing the scoped entry leaves no bare-address entry to fall back on.
+
+Naming the pod is not always enough: a pod that comes back under its own name,
+on its own address, in its own VPC has the same namespace, name, address and
+VNI as the endpoint it replaces, and only a different endpoint. The
+synchronizer therefore records which endpoint registered each key and refuses a
+removal from any other, which is the same shape as the precondition upstream
+already puts on deleting a CiliumEndpoint - it deletes by UID rather than by
+name for exactly this reason.
 
 The endpoint manager's identifier index follows the same rule from both ends.
 An endpoint in a VPC registers ``vni-ipv4:<vni>:<ip>`` and no bare-address

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -526,8 +526,9 @@ restarts converge).
 |    |                      | host-namespace L7 proxy                           |
 +----+----------------------+---------------------------------------------------+
 | 5  | conntrack / NAT      | **incomplete by design** (the CT key has no VNI); |
-|    |                      | the precondition is detected and reported; NAT is |
-|    |                      | inert because its features are rejected           |
+|    |                      | mitigated by scheduling; the precondition is      |
+|    |                      | exported as cilium_native_vpc_overlapping_ips;    |
+|    |                      | NAT is inert because its features are rejected    |
 +----+----------------------+---------------------------------------------------+
 | 6  | service / LB         | rejected at startup (test-covered both ways)      |
 +----+----------------------+---------------------------------------------------+
@@ -855,26 +856,65 @@ protocol, direction flags); upstream only extends it with a *cluster* scope
 (``cilium_per_cluster_ct_*``, a statically sized map-of-maps for ClusterMesh),
 which does not generalise to hundreds of logical switches.
 
-Consequences to be aware of:
+Failure mode
+~~~~~~~~~~~~
 
-* Two local endpoints of different VPCs that share an IP can share a CT entry
-  if they also talk to the same peer address, port and protocol with the same
-  ephemeral source port. The shared entry carries the connection state and the
-  peer identity, so the second connection can be treated as established (policy
-  is only evaluated on the first packet of a connection) and reply packets can
-  be attributed to the peer identity of the other VPC.
-* The agent detects and reports the precondition: whenever a local endpoint is
-  exposed with an IP that another local endpoint already uses in a different
-  VNI, a warning naming both endpoint ids is logged. No overlap on a node means
-  no CT ambiguity on that node.
+Two local endpoints of different VPCs that share an IP can share a CT entry if
+they also talk to the same peer address, port and protocol with the same
+ephemeral source port. The shared entry carries the connection state, the peer
+identity and any proxy redirect, so:
+
+* the second connection can be treated as established, and Cilium only
+  evaluates policy on the first packet of a connection - i.e. it can bypass the
+  policy of its own VPC;
+* reply packets can be attributed to the peer identity of the other VPC.
+
+**Likelihood.** This is not a rare corner case in the deployments native-vpc
+targets. Mirrored VPCs typically have not only overlapping *pod* subnets but
+also the same service addresses, so two pods that share an IP frequently talk
+to the same destination IP and port; the only remaining degree of freedom is
+the ephemeral source port (roughly 28 000 values), which collides with
+noticeable probability after a few hundred connections. Treat co-scheduling of
+overlapping IPs as unsafe rather than unlikely.
+
+Scope: conntrack state is per node, so the collision requires the two endpoints
+to be **on the same node**.
+
+Mitigations available today
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* **Scheduling.** Do not co-schedule pods with overlapping IPs from different
+  VPCs on the same node (pod anti-affinity, or a kube-ovn/scheduler policy that
+  keeps overlapping subnets on disjoint node sets). This removes the failure
+  mode entirely.
+* **Detection.** The agent detects the precondition - an IP used by more than
+  one local endpoint in different VNIs - and both logs it (with both endpoint
+  ids) and exports it as ``cilium_native_vpc_overlapping_ips``. Alert on
+  ``> 0``: a zero value means there is no CT ambiguity on that node.
 * The NAT maps are inert in the supported configuration: BPF masquerade,
-  kube-proxy replacement and socket LB are rejected at startup (see below), and
-  kube-ovn performs SNAT itself.
+  kube-proxy replacement and socket LB are rejected at startup, and kube-ovn
+  performs SNAT itself.
 
-A future fix requires either a VNI field in the CT tuple (a change to the
-core datapath key layout shared by CT, NAT, DSR and service handling) or a
-per-VNI map-of-maps with dynamic inner-map management. Neither is part of this
-feature.
+Bounded fix plan (follow-up)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The proper fix is per-VNI conntrack state. The hook already exists:
+``select_ct_map4()``/``select_ct_map6()`` in ``bpf_lxc.c`` choose the CT map at
+runtime and already perform a map-in-map lookup for the ClusterMesh case, and a
+missing map is already handled as a fail-closed drop
+(``DROP_CT_NO_MAP_FOUND``). A follow-up therefore needs:
+
+#. a ``HASH_OF_MAPS`` outer map keyed by VNI (the existing per-cluster maps are
+   an ``ARRAY_OF_MAPS`` with statically declared inner maps, which does not
+   scale to many logical switches);
+#. agent-side inner-map lifecycle (create on the first endpoint of a VNI,
+   remove when the last one goes away);
+#. CT garbage collection over the inner maps, reusing the per-cluster GC
+   machinery in ``pkg/maps/ctmap``;
+#. sizing: inner maps divide the CT budget per VNI.
+
+Adding a VNI field to ``struct ipv4_ct_tuple`` instead would touch the key
+layout shared by CT, NAT, DSR and service handling, and is not recommended.
 
 Service and load-balancing plane
 --------------------------------

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -780,6 +780,22 @@ proxy.
   `CIDR/FQDN boundary`_. They are correct for destinations outside the VPC
   address space (the normal use) and cannot distinguish two VPCs that overlap
   on the same prefix.
+* **Identity space (capacity boundary).** The identity is derived from the
+  label set, so adding the VNI label multiplies the number of cluster-wide
+  identities by the number of VNIs that share a label set: N workloads
+  replicated across M VPCs consume N*M identities instead of N. The
+  cluster-wide space is ``256..65535`` (with ClusterMesh it is smaller,
+  ``2^(16-clusterIDShift)`` per cluster), so a deployment must size
+  ``VNIs x distinct label sets`` against it. Local (CIDR/FQDN) identities are
+  unaffected because they are node-local.
+* **Identity management mode (rejected at startup).** The VNI identity label is
+  computed by the *agent* from the pod annotation. The operator's
+  CiliumIdentity controller derives identities from pod and namespace labels
+  only; with ``--identity-management-mode=operator`` (or ``both``) it would
+  create identities without the VNI label, consider the agent's VNI-scoped
+  identities unused and garbage collect them - silently merging all VPCs into
+  one identity. native-vpc therefore requires the default (agent-managed)
+  mode and refuses to start otherwise.
 * **L7 proxy (deployment boundary).** A redirected connection is proxied from
   the host network namespace to the original destination address. With
   overlapping VPC subnets the host cannot resolve which VPC that address
@@ -803,6 +819,29 @@ catches:
 * an *optional* interface that the production type stops implementing silently
   degrades the consumer to a bare-IP path. All of them now have compile-time
   assertions (``pkg/hubble/parser/cell``, ``pkg/endpointmanager``).
+
+Seams
+~~~~~
+
+*Upstream* (control -> policy): the VNI reaches the policy plane only as an
+identity label. The label is injected by the endpoint metadata resolver and is
+hard-kept by ``pkg/labelsfilter`` in native-vpc mode, so it cannot be filtered
+away by a user label whitelist or an explicit ignore rule. Because the identity
+key is the sorted label list, two pods that differ only by VNI necessarily get
+different numeric identities (test-covered in ``pkg/identity/key``).
+
+*Cross-component*: identity **allocation** must stay agent-side. The operator's
+CiliumIdentity controller derives identities from pod and namespace labels and
+knows nothing about the annotation, so operator-managed CIDs are rejected at
+startup (see above). The operator's identity *garbage collector* is safe: it
+works on identity usage (CiliumEndpoint references and heartbeats), not on
+recomputed label sets.
+
+*Downstream* (policy -> forwarding/observability): the policy map is keyed by
+identity, so the VNI never appears in the datapath policy lookup - the
+VNI-scoped ipcache is what selects the right identity in the first place. Hubble
+policy correlation is keyed by endpoint id plus remote identity, both of which
+are VNI-exact.
 
 Conntrack and NAT plane
 -----------------------

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -186,6 +186,14 @@ Writers (key construction)
 +--------------------------------------+-----------+------------------------------------------+
 | CiliumEndpoint watcher register       | yes       | ``ip@vni:N`` key                         |
 +--------------------------------------+-----------+------------------------------------------+
+| CEP VNI annotation (write)            | yes       | ``native-vpc.cilium.io/vni`` written at   |
+|                                      |           | CEP create and backfilled by an escaped  |
+|                                      |           | JSON-Patch (RFC 6901) on existing CEPs   |
++--------------------------------------+-----------+------------------------------------------+
+| CEP informer transform                | yes       | keeps *only* that annotation; dropping   |
+|                                      |           | it would leave every remote endpoint     |
+|                                      |           | without a VNI (CES is rejected at start) |
++--------------------------------------+-----------+------------------------------------------+
 | CiliumEndpoint watcher old-IP delete  | yes       | uses the OLD CEP's VNI                   |
 +--------------------------------------+-----------+------------------------------------------+
 | CiliumEndpoint watcher delete         | yes       | key from the deleted CEP's VNI           |
@@ -248,9 +256,17 @@ Readers (lookup)
 +--------------------------------------+-----------+------------------------------------------+
 | Hubble remote endpoint               | yes       | VNI derived from the identity VNI label  |
 +--------------------------------------+-----------+------------------------------------------+
-| L7 proxy accesslog (epinfo)          | yes*      | identity/labels resolve for a single-VNI |
-|                                      |           | entry; overlapping IPs stay ambiguous    |
-|                                      |           | and the local endpoint ID is best-effort |
+| L7 proxy accesslog (epinfo)          | yes       | records the endpoint's VNI on the log    |
+|                                      |           | record (endpoint VNI, else the           |
+|                                      |           | unambiguous ipcache entry's VNI)         |
++--------------------------------------+-----------+------------------------------------------+
+| Hubble L7 parser (DNS/HTTP flows)    | yes       | resolves pod metadata/workload with the  |
+|                                      |           | recorded (VNI, IP) and sets ``vni_id``   |
+|                                      |           | on both flow endpoints                   |
++--------------------------------------+-----------+------------------------------------------+
+| ipam API delete ("IP in use")        | yes       | VNI-agnostic in-use check (fails open on |
+|                                      |           | overlap on purpose: it is a guard, not   |
+|                                      |           | an identity lookup)                      |
 +--------------------------------------+-----------+------------------------------------------+
 | DNS proxy (fqdn)                     | yes       | same unambiguous bare-IP resolution      |
 +--------------------------------------+-----------+------------------------------------------+
@@ -307,6 +323,12 @@ Requirements
   does not match key"). Mixed-version native-vpc operation is unsupported.
   Clustermesh peers must not consume this VPC-scoped address space (VPC is not
   ClusterMesh; see the consumer checklist).
+* CiliumEndpoint CRD mode is required and **CiliumEndpointSlice must stay
+  disabled** (``--enable-cilium-endpoint-slice=false``, the default). A CES
+  packs endpoints as ``CoreCiliumEndpoint``, which carries no object metadata
+  and therefore cannot transport the per-endpoint VNI annotation; the agent
+  refuses to start with both enabled instead of silently registering remote
+  endpoints without a VNI.
 * Cilium must run as a **chained** CNI plugin behind kube-ovn (the primary
   CNI): ``--cni-chaining-mode=generic-veth`` with
   ``--cni-chaining-target`` pointing at the kube-ovn network, so that the

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -1,0 +1,380 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+.. _native_vpc:
+
+*************************
+Native VPC Mode (kube-ovn)
+*************************
+
+Cilium can run in native-vpc mode on top of a kube-ovn underlay that provides
+multiple VPCs and overlapping subnets. Cilium deliberately does **not** model
+the kube-ovn VPC object: a VPC is an aggregate that can contain several
+subnets, while each OVN logical switch/subnet has its own tunnel_key/VNI
+(Virtual Network Identifier). The data-plane key is therefore (VNI, IP), not
+(VPC, IP) and not bare IP. Every control/cache/forwarding/observability
+consumer described below uses that VNI scope.
+
+This document describes the tunnel_key contract between kube-ovn and Cilium,
+and the recovery procedure when it is temporarily violated.
+
+The tunnel_key annotation
+=========================
+
+kube-ovn writes the VNI of a pod's OVN subnet as the pod annotation
+``ovn.kubernetes.io/tunnel_key`` (the annotation key is configurable on the
+Cilium side via ``--native-vpc-vni-annotation``). Cilium reads this
+annotation to place the pod in its logical-switch/VNI scope:
+
+* endpoint creation reads it into the endpoint's ``VNIID``;
+* the pod watcher reads it to register VNI-scoped ipcache entries;
+* the datapath loads it into ``bpf_lxc`` as the per-endpoint
+  ``CONFIG(native_vpc_vni)`` value (one compiled template serves all VNIs).
+
+kube-ovn side guarantees
+========================
+
+kube-ovn guarantees that every non-hostNetwork pod on an OVN subnet carries a
+**non-zero** ``ovn.kubernetes.io/tunnel_key`` annotation by the time its
+network is configured (CNI ADD):
+
+1. **Normal pod creation flow.** The kube-ovn controller refuses to allocate
+   an IP (it requeues without persisting anything) while the subnet's tunnel
+   key has not been synced from OVN SB (``status.tunnelKey == 0``), and writes
+   the ``tunnel_key`` annotation in the same atomic patch as
+   ``ovn.kubernetes.io/allocated=true``. The kube-ovn CNI server blocks until
+   the pod is allocated, and Cilium (chained after kube-ovn, the primary CNI)
+   only runs once kube-ovn's CNI ADD has succeeded, so Cilium always observes
+   the annotation.
+
+2. **kube-ovn-controller restart flow.** Pods created before the subnet
+   tunnel key was synced (or before this behavior existed) may keep a missing
+   annotation forever, because the allocation path never re-patches
+   already-allocated pods. On startup the kube-ovn controller's init flow
+   enqueues such pods into a dedicated repair queue
+   (``enqueuePodTunnelKeyRepair``) and the repair worker patches the
+   annotation from ``subnet.Status.TunnelKey``, retrying until the key is
+   available.
+
+A zero or missing annotation therefore only occurs for pods that are not in
+an OVN logical-switch/VNI scope (hostNetwork pods, non-OVN/vlan subnets) or
+for legacy pods before the backfill above has run.
+
+Cilium side decision table
+==========================
+
+On endpoint creation and on every endpoint restore, Cilium re-reads the
+``tunnel_key`` annotation and applies the following decision table (the
+annotation is the single source of truth):
+
+* annotation **absent** -> the pod uses the native (non-VPC) scheme
+  (``VNIID = 0``), which is the normal case for hostNetwork pods and non-OVN
+  subnets;
+* annotation present and **valid** (``0 < VNI <= 16777215``) -> ``VNIID`` is
+  set to the annotation value;
+* annotation present and **0 / unparsable / out of range** -> an error is
+  logged and the pod falls back to the native scheme. A zero tunnel_key
+  violates the kube-ovn guarantee (kube-ovn only ever writes a non-zero key),
+  so the kube-ovn side must be investigated.
+
+When ``VNIID`` drops to 0 (annotation removed or broken), the endpoint also
+loses its ``vni:io-cilium-native-vpc-vni=<vni>`` identity label: the
+metadata resolver removes any
+stale label and re-resolves the identity, so the endpoint fully returns to
+the native scheme on all planes (identity, local ipcache registration and
+``CONFIG(native_vpc_vni)`` datapath value). The resolver also removes the
+legacy, semantically-wrong ``vpc:vpc=<vni>`` label during upgrade.
+
+Recovery procedure
+==================
+
+If a running pod ever ends up missing its ``tunnel_key`` annotation (for
+example a legacy pod created before the kube-ovn backfill existed), run the
+fallback sequence:
+
+1. **Restart kube-ovn-controller** - its init flow backfills the missing
+   ``tunnel_key`` annotations on all pods of the affected subnets.
+2. **Restart Cilium** - the agent re-reads the annotations on endpoint
+   restore and re-flushes the resources tied to the ``tunnel_key`` + IP pair
+   on all three planes:
+
+   * **control plane**: the endpoint's ``VNIID`` is re-read from the
+     annotation before the endpoint is exposed to the endpoint manager, and
+     the ``vni:io-cilium-native-vpc-vni=<vni>`` identity label is
+     re-injected by the metadata
+     resolver, so identities are separated per logical switch/VNI again;
+   * **cache plane**: the local ipcache registration (identity sync) and the
+     pod watcher's VNI-scoped entries are re-created from the annotation;
+   * **forwarding plane**: endpoint reload rewrites the per-endpoint
+     ``CONFIG(native_vpc_vni)`` load-time value in ``bpf_lxc`` (without
+     recompiling a per-VNI template), and the ipcache listener repopulates the VNI-scoped
+     ipcache map (``cilium_ipcache_vni``), keyed by (VNI, IP) so that
+     overlapping IPs from different logical switches/VPCs coexist.
+
+Policy and security-group semantics
+===================================
+
+Native-vpc mode injects a
+``vni:io-cilium-native-vpc-vni=<vni>`` identity label (source ``vni``, key
+``io-cilium-native-vpc-vni``) into every OVN endpoint's identity. The
+Cilium-owned key avoids collision with a user Kubernetes label named ``vni``.
+This is an internal data-plane
+scope, not a kube-ovn VPC identifier: two subnets in the same VPC normally
+have different VNIs and therefore different Cilium identities even when every
+other label and IP are equal.
+
+Generic CNP selectors keep their normal label semantics. For example,
+``fromEndpoints: {sg: web}`` selects every identity carrying ``sg=web``;
+Cilium does not silently add a VPC constraint. This is acceptable for the
+current deployment requirement because kube-ovn does not provide direct
+inter-VPC reachability; traffic between VPCs goes through an explicit
+interconnection/gateway path and is not a direct (VNI, IP) peer lookup.
+
+If a platform later needs SG policy scoped to one subnet/logical switch, its
+SG-to-CNP translator can explicitly select
+``io-cilium-native-vpc-vni: "36"``. If one SG spans a
+whole kube-ovn VPC with several subnets, the selector must include the set of
+that VPC's subnet VNIs (for example a ``matchExpressions`` ``In`` list), not a
+single value mislabeled as a VPC id. Future inter-VPC policy must explicitly
+model the interconnection gateway and both endpoint-side VNI scopes.
+
+CIDR/FQDN boundary
+------------------
+
+``fromCIDR`` / ``toCIDR`` and the FQDN identity-to-prefix table use plain IP
+prefixes rather than (VNI, IP) keys. They cannot precisely distinguish the
+same prefix/IP on two logical switches. This is not required by the current
+feature (there is no direct inter-VPC communication); endpoint/SG membership
+inside the cluster should use VNI-distinct endpoint identities. If direct
+cross-VPC or VNI-aware CIDR/FQDN policy is added later, the CIDR/FQDN identity
+and DNS-policy protocols must be extended to carry VNI; a /32 workaround must
+not be used.
+
+Identity resolution chain: consumer checklist
+=============================================
+
+The core invariant of native-vpc mode is:
+
+  **Every consumer that maps an IP to an identity/metadata must query with the
+  key (VNI, IP) - never with the bare IP alone** - because the same IP can
+  exist in multiple VPCs.
+
+Use the following table when reviewing any change that touches the identity
+resolution chain; every new consumer (or new lookup path in an existing
+consumer) must be added to it and marked VNI-aware. The four review questions
+per consumer: (1) write key carries VNI? (2) read key carries VNI? (3) delete
+uses the same key as write? (4) plain fallback can hit a foreign-VPC same-IP
+entry?
+
+Writers (key construction)
+--------------------------
+
++--------------------------------------+-----------+------------------------------------------+
+| Consumer                             | VNI-aware | Notes                                    |
++======================================+===========+==========================================+
+| endpoint create (parseVNIFromPod)    | yes       | reads tunnel_key into ``VNIID``          |
++--------------------------------------+-----------+------------------------------------------+
+| pod watcher register                  | yes       | ``ip@vni:N`` key                         |
++--------------------------------------+-----------+------------------------------------------+
+| pod watcher delete                    | yes       | key from the current annotation VNI      |
++--------------------------------------+-----------+------------------------------------------+
+| pod watcher old-IP delete             | yes*      | uses the NEW pod's VNI (VNI immutable    |
+|                                      |           | per kube-ovn, so old==new in practice)   |
++--------------------------------------+-----------+------------------------------------------+
+| CiliumEndpoint watcher register       | yes       | ``ip@vni:N`` key                         |
++--------------------------------------+-----------+------------------------------------------+
+| CiliumEndpoint watcher old-IP delete  | yes       | uses the OLD CEP's VNI                   |
++--------------------------------------+-----------+------------------------------------------+
+| CiliumEndpoint watcher delete         | yes       | key from the deleted CEP's VNI           |
++--------------------------------------+-----------+------------------------------------------+
+| local identity sync (upsertLocal)     | yes       | ``ip@vni:N`` key; VNI=0 rejected in      |
+|                                      |           | native-vpc (documented constraint)       |
++--------------------------------------+-----------+------------------------------------------+
+| kvstore identity sync (Upsert)        | yes       | ``IPIdentityPair.Vni`` + scoped key      |
++--------------------------------------+-----------+------------------------------------------+
+| kvstore watcher (OnUpdate/OnDelete)   | yes       | key rebuilt from ``pair.Vni``            |
++--------------------------------------+-----------+------------------------------------------+
+| ipcache BPF listener                  | yes       | routes to cilium_ipcache_vni by Vni      |
++--------------------------------------+-----------+------------------------------------------+
+| node/policy/apiserver UpsertMetadata  | n/a       | node IPs, CIDRs, kube-apiserver (non-VPC)|
++--------------------------------------+-----------+------------------------------------------+
+| local identity restorer (dump)        | n/a*      | dumps only the plain map; VNI entries    |
+|                                      |           | are rebuilt by the endpoint identity sync|
++--------------------------------------+-----------+------------------------------------------+
+
+Readers (lookup)
+-----------------
+
++--------------------------------------+-----------+------------------------------------------+
+| Consumer                             | VNI-aware | Notes                                    |
++======================================+===========+==========================================+
+| datapath egress (bpf_lxc from_lxc)   | yes       | VNI map first, plain fallback            |
++--------------------------------------+-----------+------------------------------------------+
+| datapath ingress (bpf_lxc tail_*)    | yes       | VNI map first, plain fallback            |
++--------------------------------------+-----------+------------------------------------------+
+| datapath bpf_host                    | deploy    | plain lookups; must not be on the         |
+|                                      |           | VNI-scoped pod data path (kube-ovn owns  |
+|                                      |           | the host datapath)                        |
++--------------------------------------+-----------+------------------------------------------+
+| datapath bpf_overlay                 | deploy    | plain lookups; only if Cilium tunneling   |
+|                                      |           | is enabled (native-vpc uses kube-ovn      |
+|                                      |           | Geneve, whose VNI scopes a logical switch)|
++--------------------------------------+-----------+------------------------------------------+
+| policy computation (CIDR shadow)     | yes       | shadow checks use ``KeyWithVNI``         |
++--------------------------------------+-----------+------------------------------------------+
+| fromEndpoints/toEndpoints selectors  | yes       | identities carry the internal VNI label; |
+|                                      |           | selectors keep normal label semantics    |
++--------------------------------------+-----------+------------------------------------------+
+| endpointmanager index (writer)       | yes       | ``vni-ipv4/6:<vni>:<ip>`` aux keys;      |
+|                                      |           | native-vpc endpoints are *not* under the |
+|                                      |           | bare ``ipv4:/ipv6:`` keys                |
++--------------------------------------+-----------+------------------------------------------+
+| endpointmanager LookupIP* (readers:  | yes*      | bare-IP lookups fall back to the per-IP  |
+| DNS proxy source EP, Hubble local,   |           | VNI key index when exactly one VNI uses  |
+| L7 accesslog, fqdn service, ipam API)|           | the IP on the node; overlapping IPs stay |
+|                                      |           | a deliberate miss (fail closed)          |
++--------------------------------------+-----------+------------------------------------------+
+| DNS proxy restored endpoints         | yes*      | per-IP *list* of restored endpoints; the |
+| (restart window)                     |           | bare-IP fallback resolves only when the  |
+|                                      |           | list has exactly one entry, so restored  |
+|                                      |           | DNS rules never leak across VNIs         |
++--------------------------------------+-----------+------------------------------------------+
+| Hubble local endpoint                | yes*      | exact VNI lookup when context exists;    |
+|                                      |           | bare-IP single-VNI fallback only;        |
+|                                      |           | overlap falls back to remote resolution  |
++--------------------------------------+-----------+------------------------------------------+
+| Hubble remote endpoint               | yes       | VNI derived from the identity VNI label  |
++--------------------------------------+-----------+------------------------------------------+
+| L7 proxy accesslog (epinfo)          | yes*      | identity/labels resolve for a single-VNI |
+|                                      |           | entry; overlapping IPs stay ambiguous    |
+|                                      |           | and the local endpoint ID is best-effort |
++--------------------------------------+-----------+------------------------------------------+
+| DNS proxy (fqdn)                     | yes       | same unambiguous bare-IP resolution      |
++--------------------------------------+-----------+------------------------------------------+
+| monitor events (IPCacheNotification) | yes       | carries the VNI (agent JSON + hubble     |
+|                                      |           | flowpb field 9)                          |
++--------------------------------------+-----------+------------------------------------------+
+| cilium-dbg bpf ipcache list          | yes       | dumps both the plain and VNI-scoped maps |
++--------------------------------------+-----------+------------------------------------------+
+| ipcache API / list handler           | yes       | IPListEntry carries ``vniID``             |
++--------------------------------------+-----------+------------------------------------------+
+| envoy NPHDS (L7)                     | yes       | host lists are organized per identity     |
+|                                      |           | (VNI-distinct); envoy matches by the      |
+|                                      |           | packet's identity, not by bare IP         |
++--------------------------------------+-----------+------------------------------------------+
+| WireGuard agent                      | yes       | only consumes hostIP (peer routing) and   |
+|                                      |           | bare-IP AllowedIPs (idempotent)           |
++--------------------------------------+-----------+------------------------------------------+
+| FQDN identity-to-IP table (service)  | no*       | bare prefixes; overlapping IPs appear     |
+|                                      |           | under every VNI identity; fix requires    |
+|                                      |           | the DNS-client protocol to carry VNI      |
++--------------------------------------+-----------+------------------------------------------+
+| ipcache metadata machinery           | n/a       | node/CIDR prefixes (non-VPC)             |
++--------------------------------------+-----------+------------------------------------------+
+| clustermesh kvstoremesh reflector    | deploy    | VNI-scoped keys are reflected to remote   |
+|                                      |           | clusters; native-vpc must NOT be combined |
+|                                      |           | with clustermesh (VPC != ClusterMesh)     |
++--------------------------------------+-----------+------------------------------------------+
+| ipsec datapath                       | deploy    | kube-ovn underlay does not use Cilium     |
+|                                      |           | ipsec; not a supported combination        |
++--------------------------------------+-----------+------------------------------------------+
+
+``yes*`` / ``no*`` mark items that are correct or acceptable under the
+kube-ovn guarantee (annotation/VNI immutable per pod), or that are mitigated
+by a VNI-distinct identity elsewhere in the flow. ``deploy`` items must be
+verified per deployment: bpf_host/bpf_overlay must not sit on the VNI-scoped
+pod packet path (kube-ovn owns the host-side and tunnel-side datapath; Cilium's
+per-endpoint bpf_lxc and the VNI-scoped ipcache are authoritative for pod
+identity).
+
+Non-VPC entities (node IPs, host, world, service/CIDR prefixes) stay in the
+plain ipcache and are resolved by the plain fallback of the lookups above; they must
+never be queried through the VNI-scoped maps.
+
+Requirements
+============
+
+* kube-ovn with the tunnel_key backfill support (see the kube-ovn side
+  guarantees above).
+* **All Cilium agents must be upgraded before native-vpc is enabled.** The
+  kvstore IP identity format is a stable API: native-vpc adds
+  ``IPIdentityPair.Vni`` and scopes physical keys as ``<ip>@vni:<N>``. An
+  older agent that does not understand ``Vni`` computes a bare-IP
+  ``GetKeyName`` and rejects the scoped key during ``Unmarshal`` ("IP address
+  does not match key"). Mixed-version native-vpc operation is unsupported.
+  Clustermesh peers must not consume this VPC-scoped address space (VPC is not
+  ClusterMesh; see the consumer checklist).
+* Cilium must run as a **chained** CNI plugin behind kube-ovn (the primary
+  CNI): ``--cni-chaining-mode=generic-veth`` with
+  ``--cni-chaining-target`` pointing at the kube-ovn network, so that the
+  kube-ovn CNI ADD (which blocks until the pod is allocated and annotated)
+  completes before Cilium creates the endpoint.
+* Cilium must use ``--routing-mode=native``. kube-ovn owns the host-side and
+  Geneve tunnel datapath; Cilium tunneling/bpf_overlay performs plain-IP
+  lookups and is rejected by native-vpc startup validation.
+* Enable native-vpc mode and configure the annotation key:
+
+  .. code-block:: shell-session
+
+      $ helm upgrade cilium cilium/cilium --namespace kube-system \
+          --set nativeVPC.enabled=true \
+          --set nativeVPC.vniAnnotation="ovn.kubernetes.io/tunnel_key"
+
+  or via agent flags ``--enable-native-vpc`` and
+  ``--native-vpc-vni-annotation``. ``nativeVPC.enabled`` requires
+  ``nativeVPC.vniAnnotation`` to be non-empty (the agent fails to start
+  otherwise).
+
+Review and verification gates
+=============================
+
+The four-plane narrative (control/cache/forwarding/observability) describes
+recovery, but is not sufficient for completeness. Review every reader and
+writer in the identity-resolution-chain table above and require the following
+checks before merge:
+
+* Go build/tests and formatting:
+
+  .. code-block:: shell-session
+
+      $ go build ./...
+      $ go test ./pkg/ipcache/... ./pkg/hubble/... ./pkg/endpoint/... \
+          ./pkg/endpointmanager/ ./pkg/k8s/watchers/ ./pkg/labelsfilter/ ...
+      $ gofmt -l pkg/ daemon/ api/
+
+* Real datapath compilation (``go build`` cannot validate BPF preprocessing or
+  verifier-visible configuration):
+
+  .. code-block:: shell-session
+
+      $ make -B -C bpf bpf_lxc.o
+
+* Load-time config generation must match the compiled BPF object exactly, and
+  template/runtime tests must prove that VNI does not split the template cache
+  but does change the endpoint reload hash:
+
+  .. code-block:: shell-session
+
+      $ cd pkg/datapath/config
+      $ go run github.com/cilium/cilium/tools/dpgen \
+          -path ../../../bpf/bpf_lxc.o -embed Node -kind object \
+          -name BPFLXC -out /tmp/lxc_config.go
+      $ diff -u lxc_config.go /tmp/lxc_config.go
+      $ go test ../loader -run 'TestWrap|TestHashEndpoint|TestHashTemplate'
+
+* Generated API files must be produced by the pinned toolchains and a second
+  run must produce no diff:
+
+  .. code-block:: shell-session
+
+      $ make -C api/v1 proto
+      $ make generate-api
+      $ git diff --exit-code -- api/v1/flow/flow.pb.go \
+          api/v1/models/ip_list_entry.go api/v1/server/embedded_spec.go
+
+  When checking an uncommitted change, compare file checksums before/after the
+  second generator run rather than requiring the working-tree diff to be
+  empty.

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -696,6 +696,15 @@ Forwarding plane
 
 Scope: BPF maps and programs.
 
+The endpoint map (``cilium_lxc``) is the one place where the address is the
+whole key, with no room for a scope. Endpoints in a VPC therefore have no entry
+in it: three pods sharing an address would be one entry, so it could only ever
+answer for whichever of them regenerated last, and the CNI DEL of that one would
+take the entry away from the two still running. The datapath agrees - bpf_lxc
+takes the local-delivery fast path only when its compiled VNI is zero - so
+nothing is lost by leaving the map to the endpoints that a bare address does
+identify. The host entries it also holds are node-scoped and unaffected.
+
 +--------------------------------------+--------------------------------------------------+
 | File                                 | Result                                           |
 +======================================+==================================================+
@@ -838,13 +847,17 @@ proxy.
   identities unused and garbage collect them - silently merging all VPCs into
   one identity. native-vpc therefore requires the default (agent-managed)
   mode and refuses to start otherwise.
-* **L7 proxy (deployment boundary).** A redirected connection is proxied from
-  the host network namespace to the original destination address. With
-  overlapping VPC subnets the host cannot resolve which VPC that address
-  belongs to, so L7 policy (HTTP rules, and the DNS proxy when the DNS server
-  itself lives in a VPC subnet) must not be applied to VPC-internal
-  destinations. L7 policy toward destinations outside the VPC address space is
-  unaffected.
+* **L7 proxy (enforced).** A redirected connection is proxied from the host
+  network namespace to the original destination address, and the policy the
+  proxy applies is found again by the endpoint's address. With overlapping VPC
+  subnets that address identifies three endpoints, so the policies of the
+  endpoints sharing it would overwrite each other in the proxy and the last one
+  to regenerate would decide what is enforced for all of them - including
+  replacing an L7 policy with an L3/L4 one. An endpoint in a VPC therefore has
+  no policy pushed to the proxy at all, and a policy that only the proxy could
+  enforce is refused with an error naming the endpoint and its VPC rather than
+  applied to whichever endpoint shares the address. This is what makes the
+  boundary observable instead of merely documented.
 
 Assembly (hive) plane
 ---------------------
@@ -1243,6 +1256,17 @@ look for when reviewing a change.
 | life      | a mode downgrade left        | state that outlives a mode switch    |
 |           | endpoints half configured    | must be re-evaluated against the     |
 |           |                              | mode, not restored blindly           |
++-----------+------------------------------+--------------------------------------+
+| forwarding| the endpoint map is keyed by | a key with no room for the scope     |
+|           | address alone, so the pods   | cannot describe a scoped resource:   |
+|           | sharing one across VPCs      | do not write it rather than write an |
+|           | overwrote each other; only   | entry that answers for whoever wrote |
+|           | the last one written existed | last                                 |
++-----------+------------------------------+--------------------------------------+
+| policy    | the proxy policy is found by | a resource identified by address     |
+|           | endpoint address, so the     | downstream is as ambiguous as the    |
+|           | endpoints sharing one pushed | address; refuse rather than let the  |
+|           | over each other              | last writer decide for all           |
 +-----------+------------------------------+--------------------------------------+
 | control   | the restore re-read adopted  | a value that other state is derived  |
 |           | a *different* VNI, moving    | from cannot be swapped in isolation; |

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -127,6 +127,8 @@ Hubble performs to enrich a flow is scoped by (VNI, IP). The chain is:
    the peer of an endpoint in ``cilium_ipcache_vni`` with that endpoint's own
    ``CONFIG(native_vpc_vni)``. For encapsulated packets that Cilium itself
    decodes, the overlay VNI of the tunnel header takes precedence.
+   Socket-level events (``TraceSock``) derive the same scope from their cgroup
+   id through the pod's endpoint, and debug events from their endpoint id.
    For L7 events the VNI is recorded on the proxy access-log record
    (``accesslog.EndpointInfo.VNIID``) from the resolved endpoint, or from the
    unambiguous ipcache entry.
@@ -305,8 +307,19 @@ Readers (lookup)
 |                                      |           | metadata when the flow has VNI context;  |
 |                                      |           | otherwise VNI from the identity label    |
 +--------------------------------------+-----------+------------------------------------------+
-| Hubble sock parser (socketLB)        | yes*      | no VNI context in TraceSock events;      |
-|                                      |           | socketLB is not used with kube-ovn       |
+| Hubble sock parser (socketLB)        | yes       | VNI from the exact cgroup -> pod ->      |
+|                                      |           | endpoint context of the event            |
++--------------------------------------+-----------+------------------------------------------+
+| Hubble debug events                  | yes       | endpoint resolved by id, VNI reported    |
++--------------------------------------+-----------+------------------------------------------+
+| Hubble policy correlation            | yes       | keyed by endpoint id + remote identity,  |
+|                                      |           | both VNI-exact (never by IP)             |
++--------------------------------------+-----------+------------------------------------------+
+| Hubble DNS names (SourceNames)       | yes       | per-endpoint DNS cache, keyed by the     |
+|                                      |           | resolved endpoint id                     |
++--------------------------------------+-----------+------------------------------------------+
+| Hubble service enrichment            | n/a       | service VIPs are cluster-scoped, not in  |
+|                                      |           | the VPC address space                    |
 +--------------------------------------+-----------+------------------------------------------+
 | Hubble metrics context               | yes       | ``vni`` context identifier and           |
 |                                      |           | ``source_vni``/``destination_vni``       |

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -225,162 +225,162 @@ entry?
 Writers (key construction)
 --------------------------
 
-+--------------------------------------+-----------+------------------------------------------+
-| Consumer                             | VNI-aware | Notes                                    |
-+======================================+===========+==========================================+
-| endpoint create (parseVNIFromPod)    | yes       | reads tunnel_key into ``VNIID``          |
-+--------------------------------------+-----------+------------------------------------------+
-| pod watcher register                  | yes       | ``ip@vni:N`` key                         |
-+--------------------------------------+-----------+------------------------------------------+
-| pod watcher delete                    | yes       | key from the current annotation VNI      |
-+--------------------------------------+-----------+------------------------------------------+
-| pod watcher old-IP delete             | yes*      | uses the NEW pod's VNI (VNI immutable    |
-|                                      |           | per kube-ovn, so old==new in practice)   |
-+--------------------------------------+-----------+------------------------------------------+
-| CiliumEndpoint watcher register       | yes       | ``ip@vni:N`` key                         |
-+--------------------------------------+-----------+------------------------------------------+
-| CEP VNI annotation (write)            | yes       | ``native-vpc.cilium.io/vni`` written at   |
-|                                      |           | CEP create and backfilled by an escaped  |
-|                                      |           | JSON-Patch (RFC 6901) on existing CEPs   |
-+--------------------------------------+-----------+------------------------------------------+
-| CEP informer transform                | yes       | keeps *only* that annotation; dropping   |
-|                                      |           | it would leave every remote endpoint     |
-|                                      |           | without a VNI (CES is rejected at start) |
-+--------------------------------------+-----------+------------------------------------------+
-| CiliumEndpoint watcher old-IP delete  | yes       | uses the OLD CEP's VNI                   |
-+--------------------------------------+-----------+------------------------------------------+
-| CiliumEndpoint watcher delete         | yes       | key from the deleted CEP's VNI           |
-+--------------------------------------+-----------+------------------------------------------+
-| local identity sync (upsertLocal)     | yes       | ``ip@vni:N`` key; VNI=0 rejected in      |
-|                                      |           | native-vpc (documented constraint)       |
-+--------------------------------------+-----------+------------------------------------------+
-| kvstore identity sync (Upsert)        | yes       | ``IPIdentityPair.Vni`` + scoped key      |
-+--------------------------------------+-----------+------------------------------------------+
-| kvstore watcher (OnUpdate/OnDelete)   | yes       | key rebuilt from ``pair.Vni``            |
-+--------------------------------------+-----------+------------------------------------------+
-| ipcache BPF listener                  | yes       | routes to cilium_ipcache_vni by Vni      |
-+--------------------------------------+-----------+------------------------------------------+
-| node/policy/apiserver UpsertMetadata  | n/a       | node IPs, CIDRs, kube-apiserver (non-VPC)|
-+--------------------------------------+-----------+------------------------------------------+
-| local identity restorer (dump)        | n/a*      | dumps only the plain map; VNI entries    |
-|                                      |           | are rebuilt by the endpoint identity sync|
-+--------------------------------------+-----------+------------------------------------------+
++--------------------------------------+-----------+-------------------------------------------+
+| Consumer                             | VNI-aware | Notes                                     |
++======================================+===========+===========================================+
+| endpoint create (parseVNIFromPod)    | yes       | reads tunnel_key into ``VNIID``           |
++--------------------------------------+-----------+-------------------------------------------+
+| pod watcher register                 | yes       | ``ip@vni:N`` key                          |
++--------------------------------------+-----------+-------------------------------------------+
+| pod watcher delete                   | yes       | key from the current annotation VNI       |
++--------------------------------------+-----------+-------------------------------------------+
+| pod watcher old-IP delete            | yes*      | uses the NEW pod's VNI (VNI immutable     |
+|                                      |           | per kube-ovn, so old==new in practice)    |
++--------------------------------------+-----------+-------------------------------------------+
+| CiliumEndpoint watcher register      | yes       | ``ip@vni:N`` key                          |
++--------------------------------------+-----------+-------------------------------------------+
+| CEP VNI annotation (write)           | yes       | ``native-vpc.cilium.io/vni`` written at   |
+|                                      |           | CEP create and backfilled by an escaped   |
+|                                      |           | JSON-Patch (RFC 6901) on existing CEPs    |
++--------------------------------------+-----------+-------------------------------------------+
+| CEP informer transform               | yes       | keeps *only* that annotation; dropping    |
+|                                      |           | it would leave every remote endpoint      |
+|                                      |           | without a VNI (CES is rejected at start)  |
++--------------------------------------+-----------+-------------------------------------------+
+| CiliumEndpoint watcher old-IP delete | yes       | uses the OLD CEP's VNI                    |
++--------------------------------------+-----------+-------------------------------------------+
+| CiliumEndpoint watcher delete        | yes       | key from the deleted CEP's VNI            |
++--------------------------------------+-----------+-------------------------------------------+
+| local identity sync (upsertLocal)    | yes       | ``ip@vni:N`` key; VNI=0 rejected in       |
+|                                      |           | native-vpc (documented constraint)        |
++--------------------------------------+-----------+-------------------------------------------+
+| kvstore identity sync (Upsert)       | yes       | ``IPIdentityPair.Vni`` + scoped key       |
++--------------------------------------+-----------+-------------------------------------------+
+| kvstore watcher (OnUpdate/OnDelete)  | yes       | key rebuilt from ``pair.Vni``             |
++--------------------------------------+-----------+-------------------------------------------+
+| ipcache BPF listener                 | yes       | routes to cilium_ipcache_vni by Vni       |
++--------------------------------------+-----------+-------------------------------------------+
+| node/policy/apiserver UpsertMetadata | n/a       | node IPs, CIDRs, kube-apiserver (non-VPC  |
++--------------------------------------+-----------+-------------------------------------------+
+| local identity restorer (dump)       | n/a*      | dumps only the plain map; VNI entries     |
+|                                      |           | are rebuilt by the endpoint identity sync |
++--------------------------------------+-----------+-------------------------------------------+
 
 Readers (lookup)
 -----------------
 
-+--------------------------------------+-----------+------------------------------------------+
-| Consumer                             | VNI-aware | Notes                                    |
-+======================================+===========+==========================================+
-| datapath egress (bpf_lxc from_lxc)   | yes       | VNI map first, plain fallback            |
-+--------------------------------------+-----------+------------------------------------------+
-| datapath ingress (bpf_lxc tail_*)    | yes       | VNI map first, plain fallback            |
-+--------------------------------------+-----------+------------------------------------------+
-| datapath bpf_host                    | deploy    | plain lookups; must not be on the         |
-|                                      |           | VNI-scoped pod data path (kube-ovn owns  |
-|                                      |           | the host datapath)                        |
-+--------------------------------------+-----------+------------------------------------------+
-| datapath bpf_overlay                 | deploy    | plain lookups; only if Cilium tunneling   |
-|                                      |           | is enabled (native-vpc uses kube-ovn      |
-|                                      |           | Geneve, whose VNI scopes a logical switch)|
-+--------------------------------------+-----------+------------------------------------------+
-| policy computation (CIDR shadow)     | yes       | shadow checks use ``KeyWithVNI``         |
-+--------------------------------------+-----------+------------------------------------------+
-| fromEndpoints/toEndpoints selectors  | yes       | identities carry the internal VNI label; |
-|                                      |           | selectors keep normal label semantics    |
-+--------------------------------------+-----------+------------------------------------------+
-| endpointmanager index (writer)       | yes       | ``vni-ipv4/6:<vni>:<ip>`` aux keys;      |
-|                                      |           | native-vpc endpoints are *not* under the |
-|                                      |           | bare ``ipv4:/ipv6:`` keys                |
-+--------------------------------------+-----------+------------------------------------------+
-| endpointmanager LookupIP* (readers:  | yes*      | bare-IP lookups fall back to the per-IP  |
-| DNS proxy source EP, Hubble local,   |           | VNI key index when exactly one VNI uses  |
-| L7 accesslog, fqdn service, ipam API)|           | the IP on the node; overlapping IPs stay |
-|                                      |           | a deliberate miss (fail closed)          |
-+--------------------------------------+-----------+------------------------------------------+
-| DNS proxy restored endpoints         | yes*      | per-IP *list* of restored endpoints; the |
-| (restart window)                     |           | bare-IP fallback resolves only when the  |
-|                                      |           | list has exactly one entry, so restored  |
-|                                      |           | DNS rules never leak across VNIs         |
-+--------------------------------------+-----------+------------------------------------------+
-| Hubble VNI context (L3/L4)            | yes       | the emitting endpoint's VNI is read from |
-|                                      |           | the event's endpoint id, exactly like    |
-|                                      |           | bpf_lxc uses CONFIG(native_vpc_vni)      |
-+--------------------------------------+-----------+------------------------------------------+
-| Hubble local endpoint                | yes       | exact (VNI, IP) lookup; falls back only  |
-|                                      |           | to the key-exact plain scope for non-VPC |
-|                                      |           | peers, never to a bare-IP guess          |
-+--------------------------------------+-----------+------------------------------------------+
-| Hubble remote endpoint               | yes       | key-exact (VNI, IP) ipcache identity +   |
-|                                      |           | metadata when the flow has VNI context;  |
-|                                      |           | otherwise VNI from the identity label    |
-+--------------------------------------+-----------+------------------------------------------+
-| Hubble sock parser (socketLB)        | yes       | VNI from the exact cgroup -> pod ->      |
-|                                      |           | endpoint context of the event            |
-+--------------------------------------+-----------+------------------------------------------+
-| Hubble debug events                  | yes       | endpoint resolved by id, VNI reported    |
-+--------------------------------------+-----------+------------------------------------------+
-| Hubble policy correlation            | yes       | keyed by endpoint id + remote identity,  |
-|                                      |           | both VNI-exact (never by IP)             |
-+--------------------------------------+-----------+------------------------------------------+
-| Hubble DNS names (SourceNames)       | yes       | per-endpoint DNS cache, keyed by the     |
-|                                      |           | resolved endpoint id                     |
-+--------------------------------------+-----------+------------------------------------------+
-| Hubble flowlog export                 | deploy    | ``fieldMask``/``fieldAggregate`` must    |
-|                                      |           | include ``source.vni_id`` and            |
-|                                      |           | ``destination.vni_id``                   |
-+--------------------------------------+-----------+------------------------------------------+
-| Hubble service enrichment            | n/a       | service VIPs are cluster-scoped, not in  |
-|                                      |           | the VPC address space                    |
-+--------------------------------------+-----------+------------------------------------------+
-| Hubble metrics context               | yes       | ``vni`` context identifier and           |
-|                                      |           | ``source_vni``/``destination_vni``       |
-|                                      |           | labelsContext values                     |
-+--------------------------------------+-----------+------------------------------------------+
-| Hubble flow filters                  | yes       | ``vni_id`` is filterable via the CEL     |
-|                                      |           | filter and via the VNI identity label    |
-+--------------------------------------+-----------+------------------------------------------+
-| L7 proxy accesslog (epinfo)          | yes       | records the endpoint's VNI on the log    |
-|                                      |           | record (endpoint VNI, else the           |
-|                                      |           | unambiguous ipcache entry's VNI)         |
-+--------------------------------------+-----------+------------------------------------------+
-| Hubble L7 parser (DNS/HTTP flows)    | yes       | resolves pod metadata/workload with the  |
-|                                      |           | recorded (VNI, IP) and sets ``vni_id``   |
-|                                      |           | on both flow endpoints                   |
-+--------------------------------------+-----------+------------------------------------------+
-| ipam API delete ("IP in use")        | yes       | VNI-agnostic in-use check (fails open on |
-|                                      |           | overlap on purpose: it is a guard, not   |
-|                                      |           | an identity lookup)                      |
-+--------------------------------------+-----------+------------------------------------------+
-| DNS proxy (fqdn)                     | yes       | same unambiguous bare-IP resolution      |
-+--------------------------------------+-----------+------------------------------------------+
-| monitor events (IPCacheNotification) | yes       | carries the VNI (agent JSON + hubble     |
-|                                      |           | flowpb field 9)                          |
-+--------------------------------------+-----------+------------------------------------------+
-| cilium-dbg bpf ipcache list          | yes       | dumps both the plain and VNI-scoped maps |
-+--------------------------------------+-----------+------------------------------------------+
-| ipcache API / list handler           | yes       | IPListEntry carries ``vniID``             |
-+--------------------------------------+-----------+------------------------------------------+
-| envoy NPHDS (L7)                     | yes       | host lists are organized per identity     |
-|                                      |           | (VNI-distinct); envoy matches by the      |
-|                                      |           | packet's identity, not by bare IP         |
-+--------------------------------------+-----------+------------------------------------------+
-| WireGuard agent                      | yes       | only consumes hostIP (peer routing) and   |
-|                                      |           | bare-IP AllowedIPs (idempotent)           |
-+--------------------------------------+-----------+------------------------------------------+
-| FQDN identity-to-IP table (service)  | no*       | bare prefixes; overlapping IPs appear     |
-|                                      |           | under every VNI identity; fix requires    |
-|                                      |           | the DNS-client protocol to carry VNI      |
-+--------------------------------------+-----------+------------------------------------------+
-| ipcache metadata machinery           | n/a       | node/CIDR prefixes (non-VPC)             |
-+--------------------------------------+-----------+------------------------------------------+
-| clustermesh kvstoremesh reflector    | deploy    | VNI-scoped keys are reflected to remote   |
-|                                      |           | clusters; native-vpc must NOT be combined |
-|                                      |           | with clustermesh (VPC != ClusterMesh)     |
-+--------------------------------------+-----------+------------------------------------------+
-| ipsec datapath                       | deploy    | kube-ovn underlay does not use Cilium     |
-|                                      |           | ipsec; not a supported combination        |
-+--------------------------------------+-----------+------------------------------------------+
++---------------------------------------+-----------+-------------------------------------------+
+| Consumer                              | VNI-aware | Notes                                     |
++=======================================+===========+===========================================+
+| datapath egress (bpf_lxc from_lxc)    | yes       | VNI map first, plain fallback             |
++---------------------------------------+-----------+-------------------------------------------+
+| datapath ingress (bpf_lxc tail_*)     | yes       | VNI map first, plain fallback             |
++---------------------------------------+-----------+-------------------------------------------+
+| datapath bpf_host                     | deploy    | plain lookups; must not be on the         |
+|                                       |           | VNI-scoped pod data path (kube-ovn owns   |
+|                                       |           | the host datapath)                        |
++---------------------------------------+-----------+-------------------------------------------+
+| datapath bpf_overlay                  | deploy    | plain lookups; only if Cilium tunneling   |
+|                                       |           | is enabled (native-vpc uses kube-ovn      |
+|                                       |           | Geneve, whose VNI scopes a logical switch |
++---------------------------------------+-----------+-------------------------------------------+
+| policy computation (CIDR shadow)      | yes       | shadow checks use ``KeyWithVNI``          |
++---------------------------------------+-----------+-------------------------------------------+
+| fromEndpoints/toEndpoints selectors   | yes       | identities carry the internal VNI label;  |
+|                                       |           | selectors keep normal label semantics     |
++---------------------------------------+-----------+-------------------------------------------+
+| endpointmanager index (writer)        | yes       | ``vni-ipv4/6:<vni>:<ip>`` aux keys;       |
+|                                       |           | native-vpc endpoints are *not* under the  |
+|                                       |           | bare ``ipv4:/ipv6:`` keys                 |
++---------------------------------------+-----------+-------------------------------------------+
+| endpointmanager LookupIP* (readers:   | yes*      | bare-IP lookups fall back to the per-IP   |
+| DNS proxy source EP, Hubble local,    |           | VNI key index when exactly one VNI uses   |
+| L7 accesslog, fqdn service, ipam API) |           | the IP on the node; overlapping IPs stay  |
+|                                       |           | a deliberate miss (fail closed)           |
++---------------------------------------+-----------+-------------------------------------------+
+| DNS proxy restored endpoints          | yes*      | per-IP *list* of restored endpoints; the  |
+| (restart window)                      |           | bare-IP fallback resolves only when the   |
+|                                       |           | list has exactly one entry, so restored   |
+|                                       |           | DNS rules never leak across VNIs          |
++---------------------------------------+-----------+-------------------------------------------+
+| Hubble VNI context (L3/L4)            | yes       | the emitting endpoint's VNI is read from  |
+|                                       |           | the event's endpoint id, exactly like     |
+|                                       |           | bpf_lxc uses CONFIG(native_vpc_vni)       |
++---------------------------------------+-----------+-------------------------------------------+
+| Hubble local endpoint                 | yes       | exact (VNI, IP) lookup; falls back only   |
+|                                       |           | to the key-exact plain scope for non-VPC  |
+|                                       |           | peers, never to a bare-IP guess           |
++---------------------------------------+-----------+-------------------------------------------+
+| Hubble remote endpoint                | yes       | key-exact (VNI, IP) ipcache identity +    |
+|                                       |           | metadata when the flow has VNI context;   |
+|                                       |           | otherwise VNI from the identity label     |
++---------------------------------------+-----------+-------------------------------------------+
+| Hubble sock parser (socketLB)         | yes       | VNI from the exact cgroup -> pod ->       |
+|                                       |           | endpoint context of the event             |
++---------------------------------------+-----------+-------------------------------------------+
+| Hubble debug events                   | yes       | endpoint resolved by id, VNI reported     |
++---------------------------------------+-----------+-------------------------------------------+
+| Hubble policy correlation             | yes       | keyed by endpoint id + remote identity,   |
+|                                       |           | both VNI-exact (never by IP)              |
++---------------------------------------+-----------+-------------------------------------------+
+| Hubble DNS names (SourceNames)        | yes       | per-endpoint DNS cache, keyed by the      |
+|                                       |           | resolved endpoint id                      |
++---------------------------------------+-----------+-------------------------------------------+
+| Hubble flowlog export                 | deploy    | ``fieldMask``/``fieldAggregate`` must     |
+|                                       |           | include ``source.vni_id`` and             |
+|                                       |           | ``destination.vni_id``                    |
++---------------------------------------+-----------+-------------------------------------------+
+| Hubble service enrichment             | n/a       | service VIPs are cluster-scoped, not in   |
+|                                       |           | the VPC address space                     |
++---------------------------------------+-----------+-------------------------------------------+
+| Hubble metrics context                | yes       | ``vni`` context identifier and            |
+|                                       |           | ``source_vni``/``destination_vni``        |
+|                                       |           | labelsContext values                      |
++---------------------------------------+-----------+-------------------------------------------+
+| Hubble flow filters                   | yes       | ``vni_id`` is filterable via the CEL      |
+|                                       |           | filter and via the VNI identity label     |
++---------------------------------------+-----------+-------------------------------------------+
+| L7 proxy accesslog (epinfo)           | yes       | records the endpoint's VNI on the log     |
+|                                       |           | record (endpoint VNI, else the            |
+|                                       |           | unambiguous ipcache entry's VNI)          |
++---------------------------------------+-----------+-------------------------------------------+
+| Hubble L7 parser (DNS/HTTP flows)     | yes       | resolves pod metadata/workload with the   |
+|                                       |           | recorded (VNI, IP) and sets ``vni_id``    |
+|                                       |           | on both flow endpoints                    |
++---------------------------------------+-----------+-------------------------------------------+
+| ipam API delete ("IP in use")         | yes       | VNI-agnostic in-use check (fails open on  |
+|                                       |           | overlap on purpose: it is a guard, not    |
+|                                       |           | an identity lookup)                       |
++---------------------------------------+-----------+-------------------------------------------+
+| DNS proxy (fqdn)                      | yes       | same unambiguous bare-IP resolution       |
++---------------------------------------+-----------+-------------------------------------------+
+| monitor events (IPCacheNotification)  | yes       | carries the VNI (agent JSON + hubble      |
+|                                       |           | flowpb field 9)                           |
++---------------------------------------+-----------+-------------------------------------------+
+| cilium-dbg bpf ipcache list           | yes       | dumps both the plain and VNI-scoped maps  |
++---------------------------------------+-----------+-------------------------------------------+
+| ipcache API / list handler            | yes       | IPListEntry carries ``vniID``             |
++---------------------------------------+-----------+-------------------------------------------+
+| envoy NPHDS (L7)                      | yes       | host lists are organized per identity     |
+|                                       |           | (VNI-distinct); envoy matches by the      |
+|                                       |           | packet's identity, not by bare IP         |
++---------------------------------------+-----------+-------------------------------------------+
+| WireGuard agent                       | yes       | only consumes hostIP (peer routing) and   |
+|                                       |           | bare-IP AllowedIPs (idempotent)           |
++---------------------------------------+-----------+-------------------------------------------+
+| FQDN identity-to-IP table (service)   | no*       | bare prefixes; overlapping IPs appear     |
+|                                       |           | under every VNI identity; fix requires    |
+|                                       |           | the DNS-client protocol to carry VNI      |
++---------------------------------------+-----------+-------------------------------------------+
+| ipcache metadata machinery            | n/a       | node/CIDR prefixes (non-VPC)              |
++---------------------------------------+-----------+-------------------------------------------+
+| clustermesh kvstoremesh reflector     | deploy    | VNI-scoped keys are reflected to remote   |
+|                                       |           | clusters; native-vpc must NOT be combined |
+|                                       |           | with clustermesh (VPC != ClusterMesh)     |
++---------------------------------------+-----------+-------------------------------------------+
+| ipsec datapath                        | deploy    | kube-ovn underlay does not use Cilium     |
+|                                       |           | ipsec; not a supported combination        |
++---------------------------------------+-----------+-------------------------------------------+
 
 ``yes*`` / ``no*`` mark items that are correct or acceptable under the
 kube-ovn guarantee (annotation/VNI immutable per pod), or that are mitigated
@@ -433,6 +433,173 @@ Requirements
   ``--native-vpc-vni-annotation``. ``nativeVPC.enabled`` requires
   ``nativeVPC.vniAnnotation`` to be non-empty (the agent fails to start
   otherwise).
+
+Plane-by-plane verification
+===========================
+
+The consumer checklist above is organised by data structure. This section is
+the *process* view used to sign off the feature: the four planes are audited
+one by one, every file that reads or writes an IP-keyed structure in that plane
+is enumerated, and each item is answered with the same four questions.
+
+Method
+------
+
+For every item in a plane:
+
+1. **Write key** - does the writer include the VNI in the key?
+2. **Read key** - does the reader include the VNI in the key?
+3. **Delete key** - is the delete key identical to the write key (no leak, no
+   deletion of a foreign VPC's entry)?
+4. **Fallback** - can a plain/bare-IP fallback path return an entry that
+   belongs to a different VPC? If yes it must fail closed instead.
+
+Plus, per plane, the boundary cases: VNI absent (0), VNI invalid or out of
+range (> 16777215), VNI unavailable at the moment of the decision (pod store
+down), agent restart, and mixed VPC/non-VPC entities.
+
+Control plane
+-------------
+
+Scope: turning the ``tunnel_key`` annotation into an endpoint property, an
+identity label, a CiliumEndpoint annotation, and endpoint-manager identifiers.
+
++-----------------------------------------------+--------------------------------------------------+
+| File                                          | Result                                           |
++===============================================+==================================================+
+| ``pkg/annotation/k8s.go``                     | annotation keys (pod ``tunnel_key`` is           |
+|                                               | configurable, CEP ``native-vpc.cilium.io/vni``   |
+|                                               | is fixed)                                        |
++-----------------------------------------------+--------------------------------------------------+
+| ``pkg/endpoint/api/endpoint_api_manager.go``  | reads the annotation before conflict detection;  |
+|                                               | rejects missing/0/unparsable/out-of-range;       |
+|                                               | conflict detection keyed by (VNI, IP);           |
+|                                               | ``requireVNI`` fails closed when the pod         |
+|                                               | metadata is unavailable                          |
++-----------------------------------------------+--------------------------------------------------+
+| ``pkg/endpoint/endpoint.go``                  | ``VNIID``, ``SyncVNIFromPodAnnotation`` decision |
+|                                               | table, VNI identity label add/remove             |
++-----------------------------------------------+--------------------------------------------------+
+| ``pkg/endpoint/identifiers.go``,              | ``vni-ipv4/6:<vni>:<ip>`` identifiers, mutually  |
+| ``pkg/endpoint/id/id.go``                     | exclusive with the bare ``ipv4:/ipv6:`` ones     |
++-----------------------------------------------+--------------------------------------------------+
+| ``pkg/endpoint/restore.go``,                  | VNI re-read from the annotation on restore       |
+| ``daemon/cmd/endpoint_restore.go``            | before the endpoint is exposed                   |
++-----------------------------------------------+--------------------------------------------------+
+| ``pkg/endpointmanager/manager.go``            | aux identifier index + per-IP VNI index for the  |
+|                                               | explicit bare-IP fallback; compile-time          |
+|                                               | assertion that the VNI lookups are implemented   |
++-----------------------------------------------+--------------------------------------------------+
+| ``pkg/endpointmanager/endpointsynchronizer``  | writes the CEP VNI annotation at create and      |
+|                                               | backfills it with an RFC 6901 escaped patch      |
++-----------------------------------------------+--------------------------------------------------+
+| ``pkg/k8s/factory_functions.go``              | CEP informer transform keeps the VNI annotation  |
++-----------------------------------------------+--------------------------------------------------+
+| ``pkg/k8s/watchers/{pod,cilium_endpoint}.go`` | VNI-scoped ipcache registration/deletion         |
++-----------------------------------------------+--------------------------------------------------+
+| ``pkg/labels``, ``pkg/labelsfilter``,         | ``vni:io-cilium-native-vpc-vni`` is an identity  |
+| ``pkg/identity``                              | label and cannot be filtered out                 |
++-----------------------------------------------+--------------------------------------------------+
+| ``pkg/option/config.go``                      | startup validation: annotation key required,     |
+|                                               | native routing required, CES rejected            |
++-----------------------------------------------+--------------------------------------------------+
+
+Defects found and fixed during this audit: the CEP informer transform dropped
+the annotation (remote endpoints silently lost their VNI); the CEP backfill
+patch used an unescaped JSON Pointer (the whole patch, including the status
+update, failed); endpoint creation fell back to the plain-IP scheme when the
+pod metadata was unavailable instead of failing closed.
+
+Cache plane
+-----------
+
+Scope: the userspace ipcache, the endpoint-manager indexes and the kvstore
+representation.
+
++----------------------------------------------+--------------------------------------------------+
+| File                                         | Result                                           |
++==============================================+==================================================+
+| ``pkg/ipcache/ipcache.go``                   | ``<ip>@vni:<vni>`` keys, per-IP VNI index,       |
+|                                              | key-exact lookups, unambiguous fallback,         |
+|                                              | shadowing checks keyed by (VNI, prefix)          |
++----------------------------------------------+--------------------------------------------------+
+| ``pkg/ipcache/ipcache.go`` (dump)            | full dump strips the VNI suffix and carries the  |
+|                                              | VNI in the identity; never panics on a key       |
++----------------------------------------------+--------------------------------------------------+
+| ``pkg/ipcache/ipcache.go`` (raw-key readers) | ``LookupByIdentity`` (DNS rule restoration) and  |
+|                                              | ``LookupByHostRLocked`` (WireGuard) return plain |
+|                                              | addresses, never internal keys                   |
++----------------------------------------------+--------------------------------------------------+
+| ``pkg/ipcache/metadata.go``                  | metadata layer is keyed by ``PrefixCluster`` and |
+|                                              | only holds non-VPC prefixes (nodes, CIDRs,       |
+|                                              | kube-apiserver); VNI keys never reach it         |
++----------------------------------------------+--------------------------------------------------+
+| ``pkg/ipcache/kvstore.go``                   | ``IPIdentityPair.Vni`` + scoped physical key     |
++----------------------------------------------+--------------------------------------------------+
+| ``pkg/ipcache/restore``                      | dumps only the plain map; VNI entries are        |
+|                                              | rebuilt by the endpoint identity sync            |
++----------------------------------------------+--------------------------------------------------+
+| ``pkg/fqdn/dnsproxy/proxy.go``               | restored endpoints are a per-IP list; resolves   |
+|                                              | only when a single endpoint uses the IP          |
++----------------------------------------------+--------------------------------------------------+
+
+Defects found and fixed during this audit: the full ipcache dump panicked on
+VNI keys (``MustParseAddrCluster``), which crashed the agent on ``cilium-dbg ip
+list`` / any listener registration; two readers returned raw ``<ip>@vni:<vni>``
+strings to consumers that parse them as addresses (DNS rule restoration lost
+every VPC IP, WireGuard could append a zero-value prefix).
+
+Named ports remain a cluster-wide aggregate (as they are across namespaces
+today); this is unchanged by native-vpc.
+
+Forwarding plane
+----------------
+
+Scope: BPF maps and programs.
+
++--------------------------------------+--------------------------------------------------+
+| File                                 | Result                                           |
++======================================+==================================================+
+| ``bpf/lib/eps.h``,                   | ``cilium_ipcache_vni`` LPM keyed by (VNI, IP),   |
+| ``pkg/maps/ipcache/ipcache.go``      | layout pinned by a Go/C size test                |
++--------------------------------------+--------------------------------------------------+
+| ``bpf/bpf_lxc.c``                    | egress and ingress resolve the peer in the VNI   |
+|                                      | map first; the endpoint-map fast path is skipped |
+|                                      | when the endpoint has a VNI                      |
++--------------------------------------+--------------------------------------------------+
+| ``bpf/include/bpf/config/lxc.h``,    | per-endpoint load-time ``native_vpc_vni``; one   |
+| ``pkg/datapath/{config,loader}``     | template serves all VNIs, endpoint hash includes |
+|                                      | the VNI                                          |
++--------------------------------------+--------------------------------------------------+
+| ``pkg/datapath/ipcache/listener.go`` | routes upserts/deletes to the VNI map by         |
+|                                      | ``Identity.Vni``; same key for both              |
++--------------------------------------+--------------------------------------------------+
+| ``pkg/ipcache/cell/cell.go``         | the VNI map is recreated at startup in           |
+|                                      | native-vpc mode and repopulated by the full dump |
++--------------------------------------+--------------------------------------------------+
+| ``pkg/maps/lxcmap/lxcmap.go``        | ``cilium_lxc`` is keyed by the bare IP: it is    |
+|                                      | not authoritative for native-vpc pods (bpf_lxc   |
+|                                      | skips it) and deletion is compare-and-delete so  |
+|                                      | one VPC cannot remove another VPC's entry        |
++--------------------------------------+--------------------------------------------------+
+
+Defect found and fixed during this audit: endpoint teardown deleted the
+``cilium_lxc`` entry of an overlapping IP owned by another VPC's endpoint.
+
+Observability plane
+-------------------
+
+See `Observability: the (VNI, IP) chain in Hubble`_ for the narrative; the
+files are ``pkg/hubble/parser/{threefour,seven,sock,debug,agent,common}``,
+``pkg/hubble/parser/cell``, ``pkg/hubble/metrics/api/context.go``,
+``pkg/monitor/api/types.go``, ``pkg/proxy/accesslog``, ``api/v1/flow`` and
+``cilium-dbg/cmd/bpf_ipcache_{list,get}.go``.
+
+Defects found and fixed during this audit: L7 flows had no VNI and lost all pod
+metadata; L3/L4 flows never had a VNI context (the only source was a tunnel
+header Cilium never sees under kube-ovn); socket-level flows had no VNI and
+could be enriched with a foreign VPC's pod; debug events did not report the
+VNI; ``cilium-dbg bpf ipcache get`` could not see VNI entries.
 
 Review and verification gates
 =============================

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -6,9 +6,9 @@
 
 .. _native_vpc:
 
-*************************
+**************************
 Native VPC Mode (kube-ovn)
-*************************
+**************************
 
 Cilium can run in native-vpc mode on top of a kube-ovn underlay that provides
 multiple VPCs and overlapping subnets. Cilium deliberately does **not** model
@@ -123,7 +123,7 @@ fallback sequence:
      overlapping IPs from different logical switches/VPCs coexist.
 
 Observability: the (VNI, IP) chain in Hubble
-===========================================
+============================================
 
 Every Hubble flow of a native-vpc endpoint carries its VNI, and every lookup
 Hubble performs to enrich a flow is scoped by (VNI, IP). The chain is:
@@ -450,7 +450,7 @@ Requirements
 Plane-by-plane verification
 ===========================
 
-The consumer checklist above is organised by data structure. This section is
+The consumer checklist above is organized by data structure. This section is
 the *process* view used to sign off the feature: the four planes are audited
 one by one, every file that reads or writes an IP-keyed structure in that plane
 is enumerated, and each item is answered with the same four questions.
@@ -501,7 +501,7 @@ axes: **completeness** (every read/write site of the plane is covered),
 restarts converge).
 
 +----+----------------------+---------------------------------------------------+
-| #  | Plane                | Sign-off                                          |
+| No | Plane                | Sign-off                                          |
 +====+======================+===================================================+
 | 1  | control              | complete; correct (creation and restore both fail |
 |    |                      | closed: a missing annotation rejects the endpoint |
@@ -527,7 +527,7 @@ restarts converge).
 +----+----------------------+---------------------------------------------------+
 | 5  | conntrack / NAT      | **incomplete by design** (the CT key has no VNI); |
 |    |                      | mitigated by scheduling; the precondition is      |
-|    |                      | exported as cilium_native_vpc_overlapping_ips;    |
+|    |                      | exported as ``cilium_native_vpc_overlapping_ips``;|
 |    |                      | NAT is inert because its features are rejected    |
 +----+----------------------+---------------------------------------------------+
 | 6  | service / LB         | rejected at startup (test-covered both ways) and  |
@@ -893,7 +893,7 @@ from them.
 The CT key is the bare 5-tuple (``struct ipv4_ct_tuple``: addresses, ports,
 protocol, direction flags); upstream only extends it with a *cluster* scope
 (``cilium_per_cluster_ct_*``, a statically sized map-of-maps for ClusterMesh),
-which does not generalise to hundreds of logical switches.
+which does not generalize to hundreds of logical switches.
 
 Failure mode
 ~~~~~~~~~~~~
@@ -989,7 +989,7 @@ address and is therefore ineffective (and would be unsafe) for VPC endpoints
 under the datapath rule above.
 
 Why ``kubeProxyReplacement: false`` is not enough
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This is worth spelling out, because the natural assumption is that disabling
 kube-proxy replacement disables Cilium's service handling:
@@ -1152,65 +1152,65 @@ The plane-by-plane review found the following defects. They are listed because
 each one is a class of mistake that can recur: the pattern column says what to
 look for when reviewing a change.
 
-+-------+------------------------------+--------------------------------------+
-| Plane | Defect                       | Pattern                              |
-+=======+==============================+======================================+
-| assy  | the agent could not start:   | a hive constructor may only take     |
-|       | an unexported interface was  | types some cell provides; no         |
-|       | a constructor parameter      | package-level test catches this      |
-+-------+------------------------------+--------------------------------------+
-| cache | the full ipcache dump        | code that parses a *key* must strip  |
-|       | panicked on VNI keys, which  | the VNI suffix; the dump path is as  |
-|       | crashed the agent from       | important as the incremental one     |
-|       | ``cilium-dbg ip list``       |                                      |
-+-------+------------------------------+--------------------------------------+
-| ctrl  | remote endpoints silently    | an informer transform that drops     |
-|       | lost their VNI (the CEP      | metadata also drops the scope        |
-|       | informer transform dropped   |                                      |
-|       | annotations)                 |                                      |
-+-------+------------------------------+--------------------------------------+
-| svc   | ClusterIP was translated for | disabling a feature flag does not    |
-|       | VPC endpoints, redirecting a | necessarily disable its datapath:    |
-|       | tenant to another tenant's   | verify what is still reflected and   |
-|       | pod                          | still compiled in                    |
-+-------+------------------------------+--------------------------------------+
-| ctrl  | three annotation parsers     | one source of truth needs one        |
-|       | validated differently, so    | decision table, shared by every      |
-|       | the cache plane could hold a | plane that reads it                  |
-|       | scope no endpoint had        |                                      |
-+-------+------------------------------+--------------------------------------+
-| ctrl  | creation and restore fell    | on a missing scope, fail closed;     |
-|       | back to the plain scheme     | never merge into the shared scope    |
-|       | when the annotation was      |                                      |
-|       | unavailable                  |                                      |
-+-------+------------------------------+--------------------------------------+
-| fwd   | the VNI LPM key had its      | an LPM static prefix must equal the  |
-|       | padding after the IP, which  | bit offset of the address inside the |
-|       | inflated the static prefix   | key; assert that, not the constant   |
-+-------+------------------------------+--------------------------------------+
-| fwd   | endpoint teardown deleted    | a map keyed by bare IP needs         |
-|       | another VPC's cilium_lxc     | compare-and-delete when IPs overlap  |
-|       | entry                        |                                      |
-+-------+------------------------------+--------------------------------------+
-| pol   | operator-managed identities  | anything that recomputes identities  |
-|       | would drop the VNI label and | outside the agent does not know the  |
-|       | garbage collect the agent's  | annotation                           |
-|       | identities                   |                                      |
-+-------+------------------------------+--------------------------------------+
-| enc   | SRv6 and VTEP select by bare | enumerate *all* address-keyed        |
-|       | IP but were not rejected     | features, not the well known ones    |
-+-------+------------------------------+--------------------------------------+
-| enc   | the IPv4 fragment key had no | any map keyed by a tuple that        |
-|       | VPC scope                    | contains an address needs the scope  |
-+-------+------------------------------+--------------------------------------+
-| obs   | L7 flows had no VNI and no   | an enrichment path must consume the  |
-|       | pod metadata; L3/L4 flows    | scope from the event, not re-derive  |
-|       | never had a VNI context      | it from an address                   |
-+-------+------------------------------+--------------------------------------+
-| life  | a mode downgrade left        | state that outlives a mode switch    |
-|       | endpoints half configured    | must be re-evaluated against the     |
-|       |                              | mode, not restored blindly           |
-+-------+------------------------------+--------------------------------------+
++-----------+------------------------------+--------------------------------------+
+| Plane     | Defect                       | Pattern                              |
++===========+==============================+======================================+
+| assembly  | the agent could not start:   | a hive constructor may only take     |
+|           | an unexported interface was  | types some cell provides; no         |
+|           | a constructor parameter      | package-level test catches this      |
++-----------+------------------------------+--------------------------------------+
+| cache     | the full ipcache dump        | code that parses a *key* must strip  |
+|           | panicked on VNI keys, which  | the VNI suffix; the dump path is as  |
+|           | crashed the agent from       | important as the incremental one     |
+|           | ``cilium-dbg ip list``       |                                      |
++-----------+------------------------------+--------------------------------------+
+| control   | remote endpoints silently    | an informer transform that drops     |
+|           | lost their VNI (the CEP      | metadata also drops the scope        |
+|           | informer transform dropped   |                                      |
+|           | annotations)                 |                                      |
++-----------+------------------------------+--------------------------------------+
+| service   | ClusterIP was translated for | disabling a feature flag does not    |
+|           | VPC endpoints, redirecting a | necessarily disable its datapath:    |
+|           | tenant to another tenant's   | verify what is still reflected and   |
+|           | pod                          | still compiled in                    |
++-----------+------------------------------+--------------------------------------+
+| control   | three annotation parsers     | one source of truth needs one        |
+|           | validated differently, so    | decision table, shared by every      |
+|           | the cache plane could hold a | plane that reads it                  |
+|           | scope no endpoint had        |                                      |
++-----------+------------------------------+--------------------------------------+
+| control   | creation and restore fell    | on a missing scope, fail closed;     |
+|           | back to the plain scheme     | never merge into the shared scope    |
+|           | when the annotation was      |                                      |
+|           | unavailable                  |                                      |
++-----------+------------------------------+--------------------------------------+
+| forwarding| the VNI LPM key had its      | an LPM static prefix must equal the  |
+|           | padding after the IP, which  | bit offset of the address inside the |
+|           | inflated the static prefix   | key; assert that, not the constant   |
++-----------+------------------------------+--------------------------------------+
+| forwarding| endpoint teardown deleted    | a map keyed by bare IP needs         |
+|           | another VPC's cilium_lxc     | compare-and-delete when IPs overlap  |
+|           | entry                        |                                      |
++-----------+------------------------------+--------------------------------------+
+| policy    | operator-managed identities  | anything that recomputes identities  |
+|           | would drop the VNI label and | outside the agent does not know the  |
+|           | garbage collect the agent's  | annotation                           |
+|           | identities                   |                                      |
++-----------+------------------------------+--------------------------------------+
+| encryption| SRv6 and VTEP select by bare | enumerate *all* address-keyed        |
+|           | IP but were not rejected     | features, not the well known ones    |
++-----------+------------------------------+--------------------------------------+
+| encryption| the IPv4 fragment key had no | any map keyed by a tuple that        |
+|           | VPC scope                    | contains an address needs the scope  |
++-----------+------------------------------+--------------------------------------+
+| obs       | L7 flows had no VNI and no   | an enrichment path must consume the  |
+|           | pod metadata; L3/L4 flows    | scope from the event, not re-derive  |
+|           | never had a VNI context      | it from an address                   |
++-----------+------------------------------+--------------------------------------+
+| life      | a mode downgrade left        | state that outlives a mode switch    |
+|           | endpoints half configured    | must be re-evaluated against the     |
+|           |                              | mode, not restored blindly           |
++-----------+------------------------------+--------------------------------------+
 
 Two gaps remain by design and are documented with their mitigations: conntrack
 state (the CT key cannot express the scope; mitigated by scheduling and the

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -718,8 +718,35 @@ Scope: BPF maps and programs.
 |                                      | one VPC cannot remove another VPC's entry        |
 +--------------------------------------+--------------------------------------------------+
 
-Defect found and fixed during this audit: endpoint teardown deleted the
-``cilium_lxc`` entry of an overlapping IP owned by another VPC's endpoint.
+Seams
+~~~~~
+
+*Upstream* (cache -> forwarding): the listener picks the map from
+``Identity.Vni`` for both upserts and deletions, so a deletion always targets
+the map the entry was written to (test-covered, including two VPCs sharing an
+IP). An entry never "moves" between the two maps, because the VNI is part of
+the ipcache key: a scope change is a delete of one key plus an upsert of
+another.
+
+The shadow/revive relationship between an endpoint IP and an equally-sized CIDR
+entry is resolved *within* one VNI scope (the lookup uses
+``KeyWithVNI(prefix, keyVNI)``), which is what keeps that logic - designed for
+one flat key space - correct when the entries live in two different BPF maps.
+
+The Go and C key layouts are pinned by a test on the real invariant: the LPM
+static prefix must equal the bit offset of the IP inside the key data.
+
+*Downstream* (forwarding -> policy/observability): the VNI-scoped lookup yields
+the peer identity that feeds the identity-keyed policy map, and the trace/drop
+events carry the endpoint id from which the observability plane derives the
+VNI. Neither consumer sees the (VNI, IP) key itself.
+
+Defects found and fixed during this audit: endpoint teardown deleted the
+``cilium_lxc`` entry of an overlapping IP owned by another VPC's endpoint; the
+VNI key placed its padding *after* the IP field, which inflated the LPM static
+prefix by 16 bits - host prefixes matched by accident (the extra bits land on
+zeroed padding) but any shorter prefix would only have matched addresses whose
+remaining bytes are zero.
 
 Observability plane
 -------------------

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -771,6 +771,16 @@ one flat key space - correct when the entries live in two different BPF maps.
 The Go and C key layouts are pinned by a test on the real invariant: the LPM
 static prefix must equal the bit offset of the IP inside the key data.
 
+The endpoint manager's identifier index follows the same rule from both ends.
+An endpoint in a VPC registers ``vni-ipv4:<vni>:<ip>`` and no bare-address
+identifier, so that index is the only way to resolve it by address. The set that was registered is kept, because recomputing the identifiers at
+removal time would derive them from an endpoint whose fields may have moved on. And the
+removal only drops a reference that still points at the endpoint being removed:
+a pod deleted and recreated on the same address in the same VPC produces a
+successor that registers the same identifier before the predecessor finishes
+being torn down, and removing it then would leave the running pod with no
+identifier at all.
+
 *Downstream* (forwarding -> policy/observability): the VNI-scoped lookup yields
 the peer identity that feeds the identity-keyed policy map, and the trace/drop
 events carry the endpoint id from which the observability plane derives the
@@ -1318,6 +1328,12 @@ look for when reviewing a change.
 |           | endpoint address, so the     | downstream is as ambiguous as the    |
 |           | endpoints sharing one pushed | address; refuse rather than let the  |
 |           | over each other              | last writer decide for all           |
++-----------+------------------------------+--------------------------------------+
+| control   | an endpoint removed its aux  | a key can belong to a successor by   |
+|           | identifiers by recomputing   | the time a predecessor is cleaned    |
+|           | them, and removed them even  | up: snapshot what was registered,    |
+|           | when a successor already     | and remove only what still points at |
+|           | owned the key                | the one being removed                |
 +-----------+------------------------------+--------------------------------------+
 | control   | the restore re-read adopted  | a value that other state is derived  |
 |           | a *different* VNI, moving    | from cannot be swapped in isolation; |

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -985,14 +985,16 @@ Operators can verify the state on a node with:
     # untranslated (kube-ovn / kube-proxy resolves it):
     $ cilium-dbg monitor --type trace | grep <clusterIP>
 
-Encryption, egress gateway and masquerade plane
------------------------------------------------
+Encryption, egress gateway, masquerade and other address-keyed features
+-----------------------------------------------------------------------
 
 All of these select traffic or peers by the bare IP:
 
 * the egress gateway matches the source IP of a pod,
 * BPF masquerade and the NAT maps work on the bare tuple,
-* IPsec and WireGuard select the peer by node/endpoint IP.
+* IPsec and WireGuard select the peer by node/endpoint IP,
+* SRv6 maps a **source IP** to a VRF (``cilium_srv6_vrf_v4``),
+* the VTEP integration maps bare CIDRs to tunnel endpoints.
 
 They are rejected at startup together with the LB features above, so that an
 unsupported combination fails immediately and deterministically instead of
@@ -1002,6 +1004,46 @@ mixing two VPCs at runtime:
 
     $ cilium-agent --enable-native-vpc ... --kube-proxy-replacement
     level=fatal msg="native-vpc mode is incompatible with kube-proxy replacement: ..."
+
+Verified as *not* address-keyed, and therefore unaffected: the bandwidth
+manager (``cilium_throttle`` is keyed by endpoint id and direction) and the
+policy map (keyed by identity).
+
+IPv4 fragment tracking
+~~~~~~~~~~~~~~~~~~~~~~
+
+``cilium_ipv4_frag_datagrams`` records the L4 ports of a fragmented datagram so
+that non-first fragments can still be classified. Its key is
+``{daddr, saddr, id, proto}`` - **no VNI** - and fragment tracking is enabled by
+default (``--enable-ipv4-fragment-tracking``).
+
+This is the same collision class as conntrack: two pods that share a source IP
+in different VPCs, sending fragmented datagrams to the same destination and
+protocol, can collide on the 16-bit IP identifier, and the later first-fragment
+overwrites the entry. The non-first fragments of the other datagram are then
+classified with the wrong ports, which feeds the wrong ports into the policy
+and conntrack lookups.
+
+Two properties bound the exposure, and both mitigations of the conntrack plane
+apply unchanged:
+
+* the map is an LRU map holding only datagrams that are currently being
+  reassembled, so the collision window is short - unlike a conntrack entry,
+  which lives for the duration of a connection;
+* the map is per node, so keeping overlapping IPs of different VPCs on disjoint
+  node sets removes the failure mode, and
+  ``cilium_native_vpc_overlapping_ips`` already exposes the precondition.
+
+An operator that does not need fragmented traffic can additionally set
+``--enable-ipv4-fragment-tracking=false``, which trades the collision for
+dropping non-first fragments (``DROP_FRAG_NOSUPPORT``) - a fail-closed choice.
+
+The bounded fix is to add a VNI field to ``struct ipv4_frag_id`` (and to
+``pkg/maps/fragmap.FragmentKey4``) under a node-level ``ENABLE_NATIVE_VPC``
+define, mirroring how ``VniKey`` extends the ipcache key: the field is only
+compiled in when the mode is enabled, so non-native-vpc deployments keep a
+byte-identical map. It is a follow-up rather than part of this change because
+it alters a map shared by five BPF programs and needs datapath validation.
 
 Lifecycle plane
 ---------------

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -732,6 +732,17 @@ IP). An entry never "moves" between the two maps, because the VNI is part of
 the ipcache key: a scope change is a delete of one key plus an upsert of
 another.
 
+That property has a consequence for every writer: whether an old entry is
+still needed cannot be decided by looking at the address. Both watchers used
+to compare bare addresses when reconciling an update, which is correct only
+while the address is the whole key. Under a scope change the address is
+unchanged and the key is not, so the entry of the abandoned scope survived -
+and, in the pod watcher, the entry of the new scope was never written and the
+deletion targeted a key that had never existed. The rule is that the old keys
+are rebuilt with the VNI they were written under and compared against the keys
+actually written, which is also what makes the code identical to the upstream
+one when the mode is off, ``KeyWithVNI`` being the identity function there.
+
 The shadow/revive relationship between an endpoint IP and an equally-sized CIDR
 entry is resolved *within* one VNI scope (the lookup uses
 ``KeyWithVNI(prefix, keyVNI)``), which is what keeps that logic - designed for
@@ -1210,6 +1221,16 @@ look for when reviewing a change.
 | life      | a mode downgrade left        | state that outlives a mode switch    |
 |           | endpoints half configured    | must be re-evaluated against the     |
 |           |                              | mode, not restored blindly           |
++-----------+------------------------------+--------------------------------------+
+| control   | both watchers decided        | "does this entry still exist?" is a  |
+|           | whether an old entry         | question about the key, and the key  |
+|           | survived by comparing bare   | is the (VNI, IP) pair; an unchanged  |
+|           | addresses, so a pod that     | address proves nothing               |
+|           | changed VPC kept its old     |                                      |
+|           | entry (and the pod watcher   |                                      |
+|           | also skipped the new one     |                                      |
+|           | and deleted with the wrong   |                                      |
+|           | VNI)                         |                                      |
 +-----------+------------------------------+--------------------------------------+
 
 Two gaps remain by design and are documented with their mitigations: conntrack

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -1221,8 +1221,11 @@ Pre-production acceptance
 =========================
 
 The unit tests prove the key construction; the following must be checked on a
-real cluster with two VPCs that share a subnet, because they exercise the
-interaction of all planes:
+real cluster, because they exercise the interaction of all planes. The runnable
+suite lives in ``test/native-vpc/`` (``./run-all.sh``): it creates three VPCs
+whose subnets share one CIDR, pins a client and a server of every VPC to the
+same two addresses, applies a deny / port-scoped / unrestricted policy
+respectively, and then asserts each item below. The checks are:
 
 #. **Isolation.** Two pods with the same IP in different VPCs, each with a
    policy selecting ``sg=web``: traffic inside each VPC is allowed, and the

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -771,6 +771,15 @@ one flat key space - correct when the entries live in two different BPF maps.
 The Go and C key layouts are pinned by a test on the real invariant: the LPM
 static prefix must equal the bit offset of the IP inside the key data.
 
+An address outlives the pod that used it. Once released it can be given to
+another pod, whose endpoint registers the same (VNI, IP) key, while the
+previous endpoint is still being torn down on its own schedule. Every removal
+therefore names the owner as well as the key: the CiliumEndpoint and pod
+watchers already matched on the pod, and the local identity synchronizer now
+does the same, so a late teardown cannot take the entry of whoever holds the
+address now. For an endpoint in a VPC that matters more than elsewhere, because
+losing the scoped entry leaves no bare-address entry to fall back on.
+
 The endpoint manager's identifier index follows the same rule from both ends.
 An endpoint in a VPC registers ``vni-ipv4:<vni>:<ip>`` and no bare-address
 identifier, so that index is the only way to resolve it by address. The set that was registered is kept, because recomputing the identifiers at
@@ -1328,6 +1337,11 @@ look for when reviewing a change.
 |           | endpoint address, so the     | downstream is as ambiguous as the    |
 |           | endpoints sharing one pushed | address; refuse rather than let the  |
 |           | over each other              | last writer decide for all           |
++-----------+------------------------------+--------------------------------------+
+| cache     | teardown removed the ipcache | the same, one layer down: a delete   |
+|           | entry of whichever pod holds | that names only the key removes      |
+|           | the address now, not of the  | whatever holds it now - name the     |
+|           | pod it was created for       | owner as well                        |
 +-----------+------------------------------+--------------------------------------+
 | control   | an endpoint removed its aux  | a key can belong to a successor by   |
 |           | identifiers by recomputing   | the time a predecessor is cleaned    |

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -761,11 +761,38 @@ files are ``pkg/hubble/parser/{threefour,seven,sock,debug,agent,common}``,
 ``pkg/monitor/api/types.go``, ``pkg/proxy/accesslog``, ``api/v1/flow`` and
 ``cilium-dbg/cmd/bpf_ipcache_{list,get}.go``.
 
+Seams
+~~~~~
+
+*Upstream* (every other plane -> observability): the observability plane never
+re-derives the (VNI, IP) pair itself. It consumes an exact context produced by
+the plane below - the endpoint id in a datapath event, the cgroup id of a
+socket event, the endpoint of an L7 access-log record - and only then queries
+the cache plane with the resulting (VNI, IP) key. This is what keeps it correct
+without duplicating the decision table.
+
+*Interactions with the later planes*:
+
+* the service plane change (no service translation for VPC endpoints) also
+  improves the flow record: a flow from a VPC pod to a ClusterIP now carries
+  the ClusterIP itself, so Hubble's service enrichment - which resolves
+  *frontends* - annotates it with the service name, instead of showing a
+  post-translation backend address;
+* the conntrack plane exports its precondition as
+  ``cilium_native_vpc_overlapping_ips`` (enabled by default), which is the
+  alertable signal for the one gap that cannot be closed in the key space;
+* the fragment-key change adds a VNI to a map that tools may dump; the map
+  layout is therefore selected from the *pinned map* rather than from the
+  process configuration, so ``cilium-dbg`` (which does not share the agent's
+  config) keeps decoding it correctly.
+
 Defects found and fixed during this audit: L7 flows had no VNI and lost all pod
 metadata; L3/L4 flows never had a VNI context (the only source was a tunnel
 header Cilium never sees under kube-ovn); socket-level flows had no VNI and
 could be enriched with a foreign VPC's pod; debug events did not report the
-VNI; ``cilium-dbg bpf ipcache get`` could not see VNI entries.
+VNI; ``cilium-dbg bpf ipcache get`` could not see VNI entries; and
+``cilium-dbg bpf frag list`` would have decoded the VNI-scoped fragment map
+with the wrong key layout.
 
 Policy plane
 ------------

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -1145,6 +1145,109 @@ backfills it) and then Cilium; the VNI is re-read on restore. A VNI change on a
 running endpoint is deliberately not hot-applied, and an annotation that
 disappears never downgrades a running endpoint to the plain scheme.
 
+Audit result ledger
+===================
+
+The plane-by-plane review found the following defects. They are listed because
+each one is a class of mistake that can recur: the pattern column says what to
+look for when reviewing a change.
+
++-------+------------------------------+--------------------------------------+
+| Plane | Defect                       | Pattern                              |
++=======+==============================+======================================+
+| assy  | the agent could not start:   | a hive constructor may only take     |
+|       | an unexported interface was  | types some cell provides; no         |
+|       | a constructor parameter      | package-level test catches this      |
++-------+------------------------------+--------------------------------------+
+| cache | the full ipcache dump        | code that parses a *key* must strip  |
+|       | panicked on VNI keys, which  | the VNI suffix; the dump path is as  |
+|       | crashed the agent from       | important as the incremental one     |
+|       | ``cilium-dbg ip list``       |                                      |
++-------+------------------------------+--------------------------------------+
+| ctrl  | remote endpoints silently    | an informer transform that drops     |
+|       | lost their VNI (the CEP      | metadata also drops the scope        |
+|       | informer transform dropped   |                                      |
+|       | annotations)                 |                                      |
++-------+------------------------------+--------------------------------------+
+| svc   | ClusterIP was translated for | disabling a feature flag does not    |
+|       | VPC endpoints, redirecting a | necessarily disable its datapath:    |
+|       | tenant to another tenant's   | verify what is still reflected and   |
+|       | pod                          | still compiled in                    |
++-------+------------------------------+--------------------------------------+
+| ctrl  | three annotation parsers     | one source of truth needs one        |
+|       | validated differently, so    | decision table, shared by every      |
+|       | the cache plane could hold a | plane that reads it                  |
+|       | scope no endpoint had        |                                      |
++-------+------------------------------+--------------------------------------+
+| ctrl  | creation and restore fell    | on a missing scope, fail closed;     |
+|       | back to the plain scheme     | never merge into the shared scope    |
+|       | when the annotation was      |                                      |
+|       | unavailable                  |                                      |
++-------+------------------------------+--------------------------------------+
+| fwd   | the VNI LPM key had its      | an LPM static prefix must equal the  |
+|       | padding after the IP, which  | bit offset of the address inside the |
+|       | inflated the static prefix   | key; assert that, not the constant   |
++-------+------------------------------+--------------------------------------+
+| fwd   | endpoint teardown deleted    | a map keyed by bare IP needs         |
+|       | another VPC's cilium_lxc     | compare-and-delete when IPs overlap  |
+|       | entry                        |                                      |
++-------+------------------------------+--------------------------------------+
+| pol   | operator-managed identities  | anything that recomputes identities  |
+|       | would drop the VNI label and | outside the agent does not know the  |
+|       | garbage collect the agent's  | annotation                           |
+|       | identities                   |                                      |
++-------+------------------------------+--------------------------------------+
+| enc   | SRv6 and VTEP select by bare | enumerate *all* address-keyed        |
+|       | IP but were not rejected     | features, not the well known ones    |
++-------+------------------------------+--------------------------------------+
+| enc   | the IPv4 fragment key had no | any map keyed by a tuple that        |
+|       | VPC scope                    | contains an address needs the scope  |
++-------+------------------------------+--------------------------------------+
+| obs   | L7 flows had no VNI and no   | an enrichment path must consume the  |
+|       | pod metadata; L3/L4 flows    | scope from the event, not re-derive  |
+|       | never had a VNI context      | it from an address                   |
++-------+------------------------------+--------------------------------------+
+| life  | a mode downgrade left        | state that outlives a mode switch    |
+|       | endpoints half configured    | must be re-evaluated against the     |
+|       |                              | mode, not restored blindly           |
++-------+------------------------------+--------------------------------------+
+
+Two gaps remain by design and are documented with their mitigations: conntrack
+state (the CT key cannot express the scope; mitigated by scheduling and the
+``cilium_native_vpc_overlapping_ips`` alert) and CIDR/FQDN identities plus the
+host-namespace L7 proxy.
+
+Pre-production acceptance
+=========================
+
+The unit tests prove the key construction; the following must be checked on a
+real cluster with two VPCs that share a subnet, because they exercise the
+interaction of all planes:
+
+#. **Isolation.** Two pods with the same IP in different VPCs, each with a
+   policy selecting ``sg=web``: traffic inside each VPC is allowed, and the
+   identities reported by ``cilium-dbg endpoint list`` differ.
+#. **Service.** A pod of a custom VPC connects to a ClusterIP: verify with
+   ``cilium-dbg monitor --type trace`` that the destination is *not* rewritten
+   by Cilium, and that kube-ovn resolves it.
+#. **Observability.** ``hubble observe --from-label
+   'vni:io-cilium-native-vpc-vni=<vni>'`` returns only that VPC's flows, and
+   both L3/L4 and L7 (DNS) flows carry ``vni_id``.
+#. **Restart convergence.** Restart the agent: endpoints keep their VNI (state
+   file), the VNI-scoped ipcache is repopulated
+   (``cilium-dbg bpf ipcache list | grep '@vni:'``), and identities are
+   unchanged.
+#. **Repair.** Remove the annotation from a running pod: the endpoint keeps its
+   VNI and an error is logged; restore it and confirm nothing changed.
+#. **Conntrack precondition.** Schedule two overlapping-IP pods on one node and
+   confirm ``cilium_native_vpc_overlapping_ips`` becomes non-zero; the
+   supported configuration keeps them on disjoint nodes.
+#. **Fragments.** Send a fragmented datagram between overlapping-IP pods in two
+   VPCs simultaneously and confirm both are classified correctly.
+#. **Mode switch.** Disable native-vpc and restart: endpoints return to the
+   plain scheme, ``cilium_ipcache_vni`` is removed, and the fragment map is
+   recreated with the upstream key size.
+
 Review and verification gates
 =============================
 

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -840,16 +840,25 @@ Assembly (hive) plane
 
 Scope: the object graph itself. Native-vpc adds dependencies between cells
 (the identity synchronizer needs the local ipcache, the Hubble parsers need the
-VNI-aware getters), and there are two failure modes that no package-level test
-catches:
+VNI-aware getters), and there are three failure modes that no package-level
+test catches:
 
 * a constructor parameter type that no cell provides makes the **entire agent**
   fail to start (``missing type: ...``). This happened with the local-ipcache
-  interface of the identity synchronizer and is now covered by
-  ``go test ./daemon/cmd/ -run TestAgentCell``;
+  interface of the identity synchronizer. The graph is now verified in both
+  modes: ``go test ./daemon/cmd/ -run TestAgentCell`` builds it with the
+  defaults and with native-vpc enabled, because the mode adds providers and
+  consumers;
 * an *optional* interface that the production type stops implementing silently
-  degrades the consumer to a bare-IP path. All of them now have compile-time
-  assertions (``pkg/hubble/parser/cell``, ``pkg/endpointmanager``).
+  degrades the consumer to a bare-IP path. Every one of them is now guarded:
+  the VNI-aware endpoint and ipcache getters by compile-time assertions
+  (``pkg/hubble/parser/cell``, ``pkg/endpointmanager``), and the exact
+  endpoint-by-id lookup of the L7 access log by declaring it in the consumer's
+  own interface instead of asserting it at the call site;
+* a guard placed inside a conditional branch can be skipped. The
+  identity-management-mode check is therefore evaluated unconditionally rather
+  than only when this agent enforces network policy: the combination is invalid
+  either way, since it is the operator that acts on the identities.
 
 Seams
 ~~~~~

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -1082,12 +1082,59 @@ outright (``DROP_FRAG_NOSUPPORT``).
 Lifecycle plane
 ---------------
 
-Scope: upgrade, restart and repair, i.e. the time dimension of the other
-planes. Covered by `Recovery procedure`_ and `Requirements`_: agents must be
-upgraded before native-vpc is enabled (the kvstore IP format is a stable API),
-a missing annotation is repaired by restarting kube-ovn-controller and then
-Cilium, and a VNI change is not hot-applied - the endpoint is re-read on
-restore.
+Scope: upgrade, restart, repair and mode changes, i.e. the time dimension of
+the other planes. The recovery procedure is described above; this section is
+the state-transition matrix.
+
+Agent restart (mode unchanged)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* the endpoint's ``VNIID`` is part of the serialized endpoint, so it survives a
+  restart even when the pod store is unavailable, and it is re-read from the
+  annotation when the pod *is* available;
+* the VNI-scoped ipcache map is recreated at startup and repopulated from the
+  full ipcache dump; endpoints whose BPF programs have not been regenerated yet
+  keep using the previous map object through their existing file descriptor,
+  exactly like the plain ipcache;
+* the CiliumEndpoint VNI annotation is re-asserted (created or backfilled).
+
+Enabling or disabling the mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* two map layouts depend on the mode: the fragment key gains a VNI, and the
+  VNI-scoped ipcache exists at all. A pinned map whose properties no longer
+  match is unpinned and recreated by the map loader (an INFO log names the old
+  and new key sizes), and both maps hold only ephemeral state, so nothing is
+  lost;
+* disabling the mode also sweeps a stale ``cilium_ipcache_vni`` pin, so a later
+  re-enable starts from a clean map rather than inheriting entries of a
+  previous VPC topology;
+* a serialized ``VNIID`` is **not** restored while the mode is off. Restoring
+  it would leave the endpoint half configured - VNI-scoped identifiers and
+  ipcache keys plus a non-zero ``CONFIG(native_vpc_vni)``, but no VNI-scoped
+  map for the agent to write to - and peers would resolve it as world. Dropping
+  it returns the endpoint to the plain scheme on every plane;
+* enabling the mode adds the node-level ``ENABLE_NATIVE_VPC`` define, which
+  changes the datapath hash and therefore regenerates all endpoints.
+
+Upgrade and downgrade of the agent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* all agents must be upgraded before native-vpc is enabled: the kvstore IP
+  identity format is a stable API and an older agent rejects a VNI-scoped key
+  (see `Requirements`_);
+* downgrading to an agent without native-vpc support is safe by construction:
+  the CiliumEndpoint annotation is ignored as an unknown annotation, the
+  serialized ``VNIID`` is an unknown JSON field, and the mode-dependent maps
+  are recreated with the upstream layout.
+
+Repair
+~~~~~~
+
+A missing annotation is repaired by restarting kube-ovn-controller (which
+backfills it) and then Cilium; the VNI is re-read on restore. A VNI change on a
+running endpoint is deliberately not hot-applied, and an annotation that
+disappears never downgrades a running endpoint to the plain scheme.
 
 Review and verification gates
 =============================

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -159,6 +159,14 @@ Hubble performs to enrich a flow is scoped by (VNI, IP). The chain is:
    ``destination_vni`` as ``labelsContext`` values, so that metrics of two VPCs
    that share an IP or a pod name do not collapse into one series.
 
+6. **Flow log export (deployment-configured).** The flowlog exporter trims and
+   aggregates flows with user-supplied proto field paths. In native-vpc mode a
+   ``fieldMask`` must include ``source.vni_id`` and ``destination.vni_id``, and
+   a ``fieldAggregate`` that aggregates on IPs or pod names must include them
+   too - otherwise the exporter itself merges two VPCs that share an IP. This
+   is the one place where the (VNI, IP) pair depends on configuration rather
+   than on agent code.
+
 Policy and security-group semantics
 ===================================
 
@@ -317,6 +325,10 @@ Readers (lookup)
 +--------------------------------------+-----------+------------------------------------------+
 | Hubble DNS names (SourceNames)       | yes       | per-endpoint DNS cache, keyed by the     |
 |                                      |           | resolved endpoint id                     |
++--------------------------------------+-----------+------------------------------------------+
+| Hubble flowlog export                 | deploy    | ``fieldMask``/``fieldAggregate`` must    |
+|                                      |           | include ``source.vni_id`` and            |
+|                                      |           | ``destination.vni_id``                   |
 +--------------------------------------+-----------+------------------------------------------+
 | Hubble service enrichment            | n/a       | service VIPs are cluster-scoped, not in  |
 |                                      |           | the VPC address space                    |

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -407,6 +407,11 @@ Requirements
   does not match key"). Mixed-version native-vpc operation is unsupported.
   Clustermesh peers must not consume this VPC-scoped address space (VPC is not
   ClusterMesh; see the consumer checklist).
+* The following features are **rejected at agent startup** in native-vpc mode,
+  because their state is keyed by the bare IP and would silently mix two VPCs:
+  kube-proxy replacement, socket LB (``--bpf-lb-sock``), the egress gateway,
+  BPF masquerade, IPsec and WireGuard. Service load balancing is left to
+  kube-proxy or kube-ovn, and kube-ovn performs SNAT.
 * CiliumEndpoint CRD mode is required and **CiliumEndpointSlice must stay
   disabled** (``--enable-cilium-endpoint-slice=false``, the default). A CES
   packs endpoints as ``CoreCiliumEndpoint``, which carries no object metadata
@@ -441,6 +446,42 @@ The consumer checklist above is organised by data structure. This section is
 the *process* view used to sign off the feature: the four planes are audited
 one by one, every file that reads or writes an IP-keyed structure in that plane
 is enumerated, and each item is answered with the same four questions.
+
+The ten planes
+--------------
+
+The narrative in this document uses four planes (control, cache, forwarding,
+observability) because those are the ones that had to be *changed* to carry the
+VNI. A complete review needs six more, which are covered by their own sections
+below:
+
++-----------------------------+------------------------------------------------+
+| Plane                       | (VNI, IP) status                               |
++=============================+================================================+
+| control                     | VNI-scoped                                     |
++-----------------------------+------------------------------------------------+
+| cache                       | VNI-scoped                                     |
++-----------------------------+------------------------------------------------+
+| forwarding                  | VNI-scoped (cilium_lxc is not authoritative)   |
++-----------------------------+------------------------------------------------+
+| observability               | VNI-scoped                                     |
++-----------------------------+------------------------------------------------+
+| policy                      | VNI-scoped through identities; CIDR/FQDN and   |
+|                             | the L7 proxy are boundaries                    |
++-----------------------------+------------------------------------------------+
+| conntrack / NAT             | **not** VNI-scoped: known limitation, detected |
+|                             | and reported at runtime                        |
++-----------------------------+------------------------------------------------+
+| service / load balancing    | not VNI-scoped: rejected at startup            |
++-----------------------------+------------------------------------------------+
+| encryption / egress gateway | not VNI-scoped: rejected at startup            |
+| / masquerade                |                                                |
++-----------------------------+------------------------------------------------+
+| lifecycle (upgrade, repair) | procedural, see Recovery procedure             |
++-----------------------------+------------------------------------------------+
+| assembly (hive graph)       | verified by TestAgentCell + compile-time       |
+|                             | assertions on the optional interfaces          |
++-----------------------------+------------------------------------------------+
 
 Method
 ------
@@ -601,6 +642,119 @@ header Cilium never sees under kube-ovn); socket-level flows had no VNI and
 could be enriched with a foreign VPC's pod; debug events did not report the
 VNI; ``cilium-dbg bpf ipcache get`` could not see VNI entries.
 
+Policy plane
+------------
+
+Scope: identity allocation, selectors, the per-endpoint policy map and the L7
+proxy.
+
+* The policy map (``cilium_policy_v2``) is keyed by **identity**, not by IP, and
+  identities are VNI-distinct in native-vpc mode (the VNI identity label is a
+  mandatory identity label, see ``pkg/labelsfilter``). Two pods of different
+  VPCs therefore never share a policy-map entry even with identical IPs and
+  identical Kubernetes labels.
+* ``fromEndpoints``/``toEndpoints`` selectors resolve through the identity
+  layer and are consequently VNI-scoped as well.
+* ``fromCIDR``/``toCIDR`` and FQDN identities are keyed by the bare prefix; see
+  `CIDR/FQDN boundary`_. They are correct for destinations outside the VPC
+  address space (the normal use) and cannot distinguish two VPCs that overlap
+  on the same prefix.
+* **L7 proxy (deployment boundary).** A redirected connection is proxied from
+  the host network namespace to the original destination address. With
+  overlapping VPC subnets the host cannot resolve which VPC that address
+  belongs to, so L7 policy (HTTP rules, and the DNS proxy when the DNS server
+  itself lives in a VPC subnet) must not be applied to VPC-internal
+  destinations. L7 policy toward destinations outside the VPC address space is
+  unaffected.
+
+Assembly (hive) plane
+---------------------
+
+Scope: the object graph itself. Native-vpc adds dependencies between cells
+(the identity synchronizer needs the local ipcache, the Hubble parsers need the
+VNI-aware getters), and there are two failure modes that no package-level test
+catches:
+
+* a constructor parameter type that no cell provides makes the **entire agent**
+  fail to start (``missing type: ...``). This happened with the local-ipcache
+  interface of the identity synchronizer and is now covered by
+  ``go test ./daemon/cmd/ -run TestAgentCell``;
+* an *optional* interface that the production type stops implementing silently
+  degrades the consumer to a bare-IP path. All of them now have compile-time
+  assertions (``pkg/hubble/parser/cell``, ``pkg/endpointmanager``).
+
+Conntrack and NAT plane
+-----------------------
+
+Scope: ``cilium_ct4/6_global``, the NAT maps and the datapath state derived
+from them.
+
+**This is the one plane where the (VNI, IP) pair cannot be expressed today.**
+The CT key is the bare 5-tuple (``struct ipv4_ct_tuple``: addresses, ports,
+protocol, direction flags); upstream only extends it with a *cluster* scope
+(``cilium_per_cluster_ct_*``, a statically sized map-of-maps for ClusterMesh),
+which does not generalise to hundreds of logical switches.
+
+Consequences to be aware of:
+
+* Two local endpoints of different VPCs that share an IP can share a CT entry
+  if they also talk to the same peer address, port and protocol with the same
+  ephemeral source port. The shared entry carries the connection state and the
+  peer identity, so the second connection can be treated as established (policy
+  is only evaluated on the first packet of a connection) and reply packets can
+  be attributed to the peer identity of the other VPC.
+* The agent detects and reports the precondition: whenever a local endpoint is
+  exposed with an IP that another local endpoint already uses in a different
+  VNI, a warning naming both endpoint ids is logged. No overlap on a node means
+  no CT ambiguity on that node.
+* The NAT maps are inert in the supported configuration: BPF masquerade,
+  kube-proxy replacement and socket LB are rejected at startup (see below), and
+  kube-ovn performs SNAT itself.
+
+A future fix requires either a VNI field in the CT tuple (a change to the
+core datapath key layout shared by CT, NAT, DSR and service handling) or a
+per-VNI map-of-maps with dynamic inner-map management. Neither is part of this
+feature.
+
+Service and load-balancing plane
+--------------------------------
+
+Scope: service frontends, backends and their BPF maps.
+
+Backends are keyed by ``(IP, port, protocol)``, so two pods of different VPCs
+sharing an IP would collapse into a single backend entry and receive each
+other's traffic. Native-vpc therefore **rejects kube-proxy replacement and
+socket LB at startup**; service load balancing is left to kube-proxy (or to
+kube-ovn), which resolves backends in the VPC's own routing domain.
+
+Encryption, egress gateway and masquerade plane
+-----------------------------------------------
+
+All of these select traffic or peers by the bare IP:
+
+* the egress gateway matches the source IP of a pod,
+* BPF masquerade and the NAT maps work on the bare tuple,
+* IPsec and WireGuard select the peer by node/endpoint IP.
+
+They are rejected at startup together with the LB features above, so that an
+unsupported combination fails immediately and deterministically instead of
+mixing two VPCs at runtime:
+
+.. code-block:: shell-session
+
+    $ cilium-agent --enable-native-vpc ... --kube-proxy-replacement
+    level=fatal msg="native-vpc mode is incompatible with kube-proxy replacement: ..."
+
+Lifecycle plane
+---------------
+
+Scope: upgrade, restart and repair, i.e. the time dimension of the other
+planes. Covered by `Recovery procedure`_ and `Requirements`_: agents must be
+upgraded before native-vpc is enabled (the kvstore IP format is a stable API),
+a missing annotation is repaired by restarting kube-ovn-controller and then
+Cilium, and a VNI change is not hot-applied - the endpoint is re-read on
+restore.
+
 Review and verification gates
 =============================
 
@@ -608,6 +762,15 @@ The four-plane narrative (control/cache/forwarding/observability) describes
 recovery, but is not sufficient for completeness. Review every reader and
 writer in the identity-resolution-chain table above and require the following
 checks before merge:
+
+* The agent object graph must still build. Constructors registered in a hive
+  cell may only take types that some cell provides: an unexported (or simply
+  unprovided) interface parameter makes the *whole agent* fail to start with
+  ``missing type: ...``, and no unit test of the package involved catches it:
+
+  .. code-block:: shell-session
+
+      $ go test ./daemon/cmd/ -run TestAgentCell
 
 * Go build/tests and formatting:
 

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -114,6 +114,49 @@ fallback sequence:
      ipcache map (``cilium_ipcache_vni``), keyed by (VNI, IP) so that
      overlapping IPs from different logical switches/VPCs coexist.
 
+Observability: the (VNI, IP) chain in Hubble
+===========================================
+
+Every Hubble flow of a native-vpc endpoint carries its VNI, and every lookup
+Hubble performs to enrich a flow is scoped by (VNI, IP). The chain is:
+
+1. **VNI context of the event.** For L3/L4 events (trace/drop/policy-verdict),
+   the notification carries the id of the local endpoint whose BPF program
+   emitted it. The parser resolves that endpoint by id and takes its
+   ``VNIID``. This is exactly the scope the datapath used: ``bpf_lxc`` resolves
+   the peer of an endpoint in ``cilium_ipcache_vni`` with that endpoint's own
+   ``CONFIG(native_vpc_vni)``. For encapsulated packets that Cilium itself
+   decodes, the overlay VNI of the tunnel header takes precedence.
+   For L7 events the VNI is recorded on the proxy access-log record
+   (``accesslog.EndpointInfo.VNIID``) from the resolved endpoint, or from the
+   unambiguous ipcache entry.
+
+2. **Endpoint resolution.** Local endpoints are looked up with the exact
+   (VNI, IP) key. A miss falls back only to the key-exact *plain* scope, which
+   holds non-VPC entities (host, nodes, non-OVN pods); it never degrades to a
+   bare-IP guess that could select an endpoint of another VPC.
+
+3. **Remote peer resolution.** With a VNI context, the identity and the pod
+   metadata are read from the VNI-scoped ipcache entry (``<ip>@vni:<vni>``).
+   Only if that misses does the plain ipcache answer, which is correct because
+   it contains exactly the non-VPC entities. Without VNI context (for example
+   events emitted by the host datapath), the VNI is recovered from the peer
+   identity's ``vni:io-cilium-native-vpc-vni`` label, which is VNI-distinct by
+   construction.
+
+4. **Flow fields.** ``Endpoint.vni_id`` is set on both flow endpoints for
+   L3/L4 and L7 flows, but only for peers that really resolved inside that VPC
+   scope: a node/world peer of a VPC endpoint keeps ``vni_id = 0``.
+   ``IPCacheNotification.vni`` carries the VNI of ipcache agent events.
+
+5. **Filtering and metrics.** Flows can be filtered by VNI without any new API
+   field, either through the VNI identity label
+   (``--from-label 'vni:io-cilium-native-vpc-vni=36'``) or through the CEL
+   filter (``_flow.source.vni_id == uint(36)``). Hubble metrics accept ``vni``
+   as a source/destination context identifier and ``source_vni`` /
+   ``destination_vni`` as ``labelsContext`` values, so that metrics of two VPCs
+   that share an IP or a pod name do not collapse into one series.
+
 Policy and security-group semantics
 ===================================
 
@@ -250,11 +293,27 @@ Readers (lookup)
 |                                      |           | list has exactly one entry, so restored  |
 |                                      |           | DNS rules never leak across VNIs         |
 +--------------------------------------+-----------+------------------------------------------+
-| Hubble local endpoint                | yes*      | exact VNI lookup when context exists;    |
-|                                      |           | bare-IP single-VNI fallback only;        |
-|                                      |           | overlap falls back to remote resolution  |
+| Hubble VNI context (L3/L4)            | yes       | the emitting endpoint's VNI is read from |
+|                                      |           | the event's endpoint id, exactly like    |
+|                                      |           | bpf_lxc uses CONFIG(native_vpc_vni)      |
 +--------------------------------------+-----------+------------------------------------------+
-| Hubble remote endpoint               | yes       | VNI derived from the identity VNI label  |
+| Hubble local endpoint                | yes       | exact (VNI, IP) lookup; falls back only  |
+|                                      |           | to the key-exact plain scope for non-VPC |
+|                                      |           | peers, never to a bare-IP guess          |
++--------------------------------------+-----------+------------------------------------------+
+| Hubble remote endpoint               | yes       | key-exact (VNI, IP) ipcache identity +   |
+|                                      |           | metadata when the flow has VNI context;  |
+|                                      |           | otherwise VNI from the identity label    |
++--------------------------------------+-----------+------------------------------------------+
+| Hubble sock parser (socketLB)        | yes*      | no VNI context in TraceSock events;      |
+|                                      |           | socketLB is not used with kube-ovn       |
++--------------------------------------+-----------+------------------------------------------+
+| Hubble metrics context               | yes       | ``vni`` context identifier and           |
+|                                      |           | ``source_vni``/``destination_vni``       |
+|                                      |           | labelsContext values                     |
++--------------------------------------+-----------+------------------------------------------+
+| Hubble flow filters                  | yes       | ``vni_id`` is filterable via the CEL     |
+|                                      |           | filter and via the VNI identity label    |
 +--------------------------------------+-----------+------------------------------------------+
 | L7 proxy accesslog (epinfo)          | yes       | records the endpoint's VNI on the log    |
 |                                      |           | record (endpoint VNI, else the           |

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -847,6 +847,13 @@ proxy.
   identities unused and garbage collect them - silently merging all VPCs into
   one identity. native-vpc therefore requires the default (agent-managed)
   mode and refuses to start otherwise.
+* **Cluster mesh (rejected at startup).** A VNI is a tunnel key of this
+  cluster's OVN, so it says nothing about another cluster. Remote addresses
+  would therefore arrive either without a scope - landing in the unscoped
+  ipcache, which is what the local datapath falls back to and which must hold
+  no address that a VPC also uses - or carrying a number that means something
+  else where it came from. The check is on the pair that turns cluster mesh on:
+  a cluster ID together with a mesh configuration.
 * **Per-endpoint routes (rejected at startup).** ``enable-endpoint-routes``
   installs a kernel route to each endpoint's address, and the routing table has
   no notion of a VPC: the endpoints sharing an address would install one route

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -76,9 +76,17 @@ annotation is the single source of truth):
 * annotation present and **valid** (``0 < VNI <= 16777215``) -> ``VNIID`` is
   set to the annotation value;
 * annotation present and **0 / unparsable / out of range** -> an error is
-  logged and the pod falls back to the native scheme. A zero tunnel_key
-  violates the kube-ovn guarantee (kube-ovn only ever writes a non-zero key),
-  so the kube-ovn side must be investigated.
+  logged. A zero tunnel_key violates the kube-ovn guarantee (kube-ovn only
+  ever writes a non-zero key), so the kube-ovn side must be investigated.
+
+An endpoint that already has a VNI is never downgraded to the plain scheme by a
+missing or broken annotation: that would merge it with the same IP in another
+VPC and give it a foreign identity. The last known VNI is kept (fail closed;
+at worst the endpoint stays isolated) and the condition is logged as an error.
+Endpoint *creation* is stricter still: a non-hostNetwork pod without a usable
+annotation is rejected, so the CNI ADD is retried instead of creating an
+endpoint outside any VPC. The single authoritative "not in any VPC" signal is
+``pod.spec.hostNetwork``, which is immutable, unlike an annotation.
 
 When ``VNIID`` drops to 0 (annotation removed or broken), the endpoint also
 loses its ``vni:io-cilium-native-vpc-vni=<vni>`` identity label: the
@@ -482,6 +490,61 @@ below:
 | assembly (hive graph)       | verified by TestAgentCell + compile-time       |
 |                             | assertions on the optional interfaces          |
 +-----------------------------+------------------------------------------------+
+
+Ordered sign-off
+----------------
+
+The planes are reviewed in data-flow order. Each one is signed off on three
+axes: **completeness** (every read/write site of the plane is covered),
+**correctness** (keys match, unsafe fallbacks fail closed) and
+**compatibility** (non-native-vpc deployments are unaffected, and upgrades /
+restarts converge).
+
++----+----------------------+---------------------------------------------------+
+| #  | Plane                | Sign-off                                          |
++====+======================+===================================================+
+| 1  | control              | complete; correct (creation and restore both fail |
+|    |                      | closed: a missing annotation rejects the endpoint |
+|    |                      | resp. keeps the last VNI); compatible (VNIID is   |
+|    |                      | serialized, so a restart converges even without   |
+|    |                      | the pod store; inert when the mode is off)        |
++----+----------------------+---------------------------------------------------+
+| 2  | cache                | complete; correct (write/delete symmetry and      |
+|    |                      | per-IP index proven by test); compatible (a zero  |
+|    |                      | VNI produces byte-identical keys and no index)    |
++----+----------------------+---------------------------------------------------+
+| 3  | forwarding           | complete; correct (VNI map first, plain fallback  |
+|    |                      | for non-VPC, endpoint-map fast path skipped);     |
+|    |                      | compatible (the VNI map is pruned from the        |
+|    |                      | program by the loader's reachability analysis     |
+|    |                      | when native_vpc_vni == 0, so non-native-vpc nodes |
+|    |                      | never even create it; map flags match the C side) |
++----+----------------------+---------------------------------------------------+
+| 4  | policy               | complete for identity-based selection; correct    |
+|    |                      | (the identity key includes the VNI label, proven  |
+|    |                      | by test); boundaries: CIDR/FQDN prefixes and the  |
+|    |                      | host-namespace L7 proxy                           |
++----+----------------------+---------------------------------------------------+
+| 5  | conntrack / NAT      | **incomplete by design** (the CT key has no VNI); |
+|    |                      | the precondition is detected and reported; NAT is |
+|    |                      | inert because its features are rejected           |
++----+----------------------+---------------------------------------------------+
+| 6  | service / LB         | rejected at startup (test-covered both ways)      |
++----+----------------------+---------------------------------------------------+
+| 7  | encryption / egress  | rejected at startup (test-covered both ways)      |
+|    | gateway / masquerade |                                                   |
++----+----------------------+---------------------------------------------------+
+| 8  | observability        | complete; correct (every enrichment lookup is     |
+|    |                      | (VNI, IP)- or id-keyed); compatible (the extra    |
+|    |                      | endpoint lookup is skipped when the mode is off)  |
++----+----------------------+---------------------------------------------------+
+| 9  | lifecycle            | restart converges (serialized VNI + annotation    |
+|    |                      | re-read + CEP backfill); upgrade requires all     |
+|    |                      | agents first; downgrade ignores the annotation    |
++----+----------------------+---------------------------------------------------+
+| 10 | assembly (hive)      | TestAgentCell + compile-time assertions on the    |
+|    |                      | optional interfaces                               |
++----+----------------------+---------------------------------------------------+
 
 Method
 ------

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -608,11 +608,42 @@ identity label, a CiliumEndpoint annotation, and endpoint-manager identifiers.
 |                                               | native routing required, CES rejected            |
 +-----------------------------------------------+--------------------------------------------------+
 
+Seams
+~~~~~
+
+*Upstream* (kube-ovn -> Cilium): the ``tunnel_key`` annotation is read by three
+different planes - endpoint creation and restore (control), the pod watcher
+(cache) and, through them, the datapath and observability planes. They now
+share **one** decision table, ``pkg/nativevpc.VNIFromPod``, so a value cannot be
+accepted by one reader and rejected by another. Before, the pod watcher used
+its own parser without a range check, so an out-of-range ``tunnel_key`` would
+register a VPC-scoped ipcache entry under a VNI that no endpoint had.
+
+The API/CNI endpoint-creation request also carries a ``vni-id`` field. It is
+untrusted: the value is only accepted if it matches the annotation, so it can
+neither invent a VPC scope nor satisfy the mandatory-VNI gate when the
+annotation could not be read.
+
+*Downstream* (control -> cache/forwarding/observability): a VNI change is
+propagated by replacing state, never by mutating it in place:
+
+* the identity-sync controller captures the VNI at registration time, so the
+  old controller's ``StopFunc`` deletes exactly the key its ``DoFunc`` wrote
+  (``<ip>@vni:N``) instead of leaking it;
+* the endpoint-manager references are replaced from a snapshot of the
+  previously registered identifiers;
+* the CiliumEndpoint annotation carries the VNI to the cache plane of the other
+  nodes.
+
 Defects found and fixed during this audit: the CEP informer transform dropped
 the annotation (remote endpoints silently lost their VNI); the CEP backfill
 patch used an unescaped JSON Pointer (the whole patch, including the status
 update, failed); endpoint creation fell back to the plain-IP scheme when the
-pod metadata was unavailable instead of failing closed.
+pod metadata was unavailable instead of failing closed; endpoint restore
+*downgraded* a VPC endpoint to the plain scheme when the annotation was
+transiently missing; the three annotation parsers disagreed on validity; the
+API-supplied ``vni-id`` bypassed the "annotation is the single source of truth"
+invariant.
 
 Cache plane
 -----------

--- a/Documentation/network/native-vpc.rst
+++ b/Documentation/network/native-vpc.rst
@@ -847,6 +847,13 @@ proxy.
   identities unused and garbage collect them - silently merging all VPCs into
   one identity. native-vpc therefore requires the default (agent-managed)
   mode and refuses to start otherwise.
+* **Per-endpoint routes (rejected at startup).** ``enable-endpoint-routes``
+  installs a kernel route to each endpoint's address, and the routing table has
+  no notion of a VPC: the endpoints sharing an address would install one route
+  between them, so the last one to regenerate would receive the traffic of all
+  of them and the first CNI DEL would remove the route the others still need.
+  kube-ovn owns routing in this deployment, so the mode is refused rather than
+  quietly producing a shared route.
 * **L7 proxy (enforced).** A redirected connection is proxied from the host
   network namespace to the original destination address, and the policy the
   proxy applies is found again by the endpoint's address. With overlapping VPC
@@ -1190,6 +1197,23 @@ annotation in that window would publish exactly the scope the endpoint is about
 to refuse. Pods on other nodes keep using the annotation, which is the only
 signal available there, and the CiliumEndpoint entry - written from the remote
 endpoint's real VNI - takes precedence over it.
+
+Operator interface
+==================
+
+``cilium bpf ipcache delete`` and ``cilium bpf ipcache update`` act on one key.
+With native-vpc there are two key spaces - the unscoped ipcache holds the
+addresses that are in no VPC (the host, the world, CIDR and FQDN entries), the
+scoped one holds the endpoints - so a command that defaulted to the unscoped map
+would report a deletion that removed nothing, and an update would place a pod
+address into the space the datapath falls back to when a scoped lookup misses,
+which is the one thing that space must never contain.
+
+Both commands therefore take ``--vni``, and when the scoped map exists on the
+node they refuse to run without it, naming the two choices: ``--vni <n>`` for a
+VPC, ``--vni 0`` for the addresses that are in none. The refusal is what makes
+the two spaces visible to whoever is debugging; the listing commands already
+render the scope as part of the address.
 
 Audit result ledger
 ===================

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -480,6 +480,7 @@ Name                                         Labels                             
 ``endpoint_regenerations_total``             ``outcome``                                        Enabled    Count of all endpoint regenerations that have completed
 ``endpoint_regeneration_time_stats_seconds`` ``scope``                                          Enabled    Endpoint regeneration time stats
 ``endpoint_state``                           ``state``                                          Enabled    Count of all endpoints
+``native_vpc_overlapping_ips``                                                                  Enabled    Number of IPs used by more than one local endpoint in different native-vpc VNIs. Alert on ``> 0``: conntrack entries are keyed by the bare 5-tuple, so connections of different VPCs can share CT state on that node (see :ref:`native_vpc`)
 ============================================ ================================================== ========== ========================================================
 
 Services

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -1095,6 +1095,7 @@ Option Value          Description
 ``workload``          Kubernetes pod's workload name and namespace in the form of ``namespace/workload-name``.
 ``workload-name``     Kubernetes pod's workload name (workloads are: Deployment, Statefulset, Daemonset, ReplicationController, CronJob, Job, DeploymentConfig (OpenShift), etc).
 ``app``               Kubernetes pod's app name, derived from pod labels (``app.kubernetes.io/name``, ``k8s-app``, or ``app``).
+``vni``               The native-vpc VNI (kube-ovn ``tunnel_key``) of the endpoint, empty for non-VPC endpoints. See :ref:`native_vpc`.
 ===================== ===================================================================================
 
 When specifying the source and/or destination context, multiple contexts can be
@@ -1128,12 +1129,14 @@ Option Value                   Description
 ``source_workload``            The name of the source pod's workload (Deployment, Statefulset, Daemonset, ReplicationController, CronJob, Job, DeploymentConfig (OpenShift)).
 ``source_workload_kind``       The kind of the source pod's workload, for example, Deployment, Statefulset, Daemonset, ReplicationController, CronJob, Job, DeploymentConfig (OpenShift).
 ``source_app``                 The app name of the source pod, derived from pod labels (``app.kubernetes.io/name``, ``k8s-app``, or ``app``).
+``source_vni``                 The native-vpc VNI of the flow source, empty for non-VPC endpoints. With overlapping VPC subnets this is what separates two flows sharing an IP.
 ``destination_ip``             The destination IP of the flow.
 ``destination_namespace``      The namespace of the pod if the flow destination is from a Kubernetes pod.
 ``destination_pod``            The pod name if the flow destination is from a Kubernetes pod.
 ``destination_workload``       The name of the destination pod's workload (Deployment, Statefulset, Daemonset, ReplicationController, CronJob, Job, DeploymentConfig (OpenShift)).
 ``destination_workload_kind``  The kind of the destination pod's workload, for example, Deployment, Statefulset, Daemonset, ReplicationController, CronJob, Job, DeploymentConfig (OpenShift).
 ``destination_app``            The app name of the source pod, derived from pod labels (``app.kubernetes.io/name``, ``k8s-app``, or ``app``).
+``destination_vni``            The native-vpc VNI of the flow destination, empty for non-VPC endpoints.
 ``traffic_direction``          Identifies the traffic direction of the flow. Possible values are ``ingress``, ``egress`` and ``unknown``.
 ============================== ===============================================================================
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -890,6 +890,7 @@ unmigrated
 unpaginated
 unparsable
 unpinned
+unscoped
 unselect
 unsettable
 untriaged

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -19,6 +19,7 @@ Checkpatch
 Cheng
 Chewbacca
 Chun
+CiliumEndpoint
 Clientset
 Cloudflare
 ConnectX
@@ -89,9 +90,7 @@ Mellanox
 Meltwater
 Menlo
 MiB
-misclassified
 Monnet
-multi
 Multihop
 Multiprotocol
 Mythbusters
@@ -137,11 +136,13 @@ Triagers
 Twilio
 Uncompress
 Uncordon
-unpinned
 VM
 VMware
+VNI
+VNIID
 VNet
 VPC
+VPCs
 Vagrantcloud
 Vagrantfile
 Vagrantfiles
@@ -154,9 +155,11 @@ Yunsong
 Zannoni
 Zhou
 aarch
+accesslog
 addr
 agentNotReadyTaintKey
 aggregationInterval
+alertable
 alibabacloud
 allocatable
 allocateLoadBalancerNodePorts
@@ -191,6 +194,8 @@ aws
 backend
 backends
 backfill
+backfilled
+backfills
 backoff
 backport
 backported
@@ -238,11 +243,11 @@ cgroup
 cgroups
 chainingTarget
 cheatsheet
+checksums
 ci
 cidr
 cidrs
 ciliumcon
-CiliumEndpoint
 classful
 classid
 cleanBpfState
@@ -351,6 +356,7 @@ enet
 enetc
 eni
 enqueuing
+epinfo
 etcd
 etcdinit
 eth
@@ -368,12 +374,16 @@ externallyCreated
 extraConfig
 facto
 failover
+fallbacks
+falsy
 fcfs
 fec
 fieldAggregate
 filesystem
 filesystems
 firewalling
+flowlog
+flowpb
 fortio
 fqdn
 fromCIDR
@@ -390,6 +400,7 @@ gcc
 gcp
 geneve
 getpeername
+getters
 gettingstarted
 github
 gke
@@ -415,11 +426,12 @@ healthz
 helloworld
 herokuapp
 hexData
+hostIP
+hostNetwork
 hostPath
 hostPort
 hostname
 hostnames
-hostNetwork
 hostns
 hostonlyifs
 hostscope
@@ -514,6 +526,7 @@ kubespray
 kvstore
 kvstoremesh
 kvstores
+labelsContext
 lan
 latencies
 lbipam
@@ -578,6 +591,7 @@ memcd
 microservice
 microservices
 minikube
+misclassified
 misconfiguration
 misconfigured
 misconfigures
@@ -591,6 +605,7 @@ mtk
 mtls
 mtu
 mul
+multi
 multicast
 multicluster
 multicore
@@ -644,12 +659,13 @@ openapi
 openssl
 originatingTLS
 os
-ovn
 oseq
 otx
+ovn
 pahole
 parentRefs
 parsable
+parseVNIFromPod
 parserfactory
 parsers
 passthrough
@@ -679,6 +695,7 @@ preloaded
 preloading
 prem
 prepended
+preprocessing
 prepulls
 prerequirement
 prestop
@@ -726,6 +743,7 @@ repo
 repos
 reproducibility
 reqid
+requeues
 requireIPv
 resizable
 resync
@@ -764,6 +782,7 @@ sid
 sig
 skb
 snat
+socketLB
 socknat
 spinlock
 srv
@@ -797,6 +816,7 @@ supergalatic
 superset
 suricate
 svc
+synchronizer
 syscall
 sysctl
 sysctls
@@ -811,6 +831,7 @@ tcplife
 tcptop
 tcptracer
 tcx
+teardown
 templating
 terminatingTLS
 terminationGracePeriodSeconds
@@ -825,12 +846,14 @@ tiefighter
 tls
 toCIDR
 toCIDRSet
+toEndpoints
 toFQDN
 toFQDNs
 toGroups
 tofqdns
 tolerations
 toolchain
+toolchains
 topologies
 toto
 traceparent
@@ -838,6 +861,7 @@ tracepoint
 tracepoints
 tracestate
 transpiling
+truthy
 tsne
 tunables
 tunings
@@ -852,8 +876,9 @@ unapplied
 unaudited
 uncommented
 uncordon
-unencrypted
 underlay
+unencrypted
+unescaped
 unexported
 unicast
 uninline
@@ -862,8 +887,9 @@ unlabel
 unmanaged
 unmarshalled
 unmigrated
-unparsable
 unpaginated
+unparsable
+unpinned
 unselect
 unsettable
 untriaged
@@ -872,6 +898,9 @@ unwinded
 upgradeCompatibility
 uplink
 uprobes
+upsert
+upsertLocal
+upserts
 upstreamed
 uptime
 uretprobes
@@ -894,11 +923,8 @@ vlan
 vmlinux
 vmxnet
 vni
-VNIID
-VNI
 volumeMounts
 vpc
-VPCs
 vrf
 vrouter
 vtep
@@ -925,5 +951,3 @@ xwing
 yaml
 zsh
 ztunnel
-falsy
-truthy

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -89,6 +89,7 @@ Mellanox
 Meltwater
 Menlo
 MiB
+misclassified
 Monnet
 multi
 Multihop
@@ -136,6 +137,7 @@ Triagers
 Twilio
 Uncompress
 Uncordon
+unpinned
 VM
 VMware
 VNet

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -90,6 +90,7 @@ Meltwater
 Menlo
 MiB
 Monnet
+multi
 Multihop
 Multiprotocol
 Mythbusters
@@ -187,6 +188,7 @@ awk
 aws
 backend
 backends
+backfill
 backoff
 backport
 backported
@@ -238,6 +240,7 @@ ci
 cidr
 cidrs
 ciliumcon
+CiliumEndpoint
 classful
 classid
 cleanBpfState
@@ -414,6 +417,7 @@ hostPath
 hostPort
 hostname
 hostnames
+hostNetwork
 hostns
 hostonlyifs
 hostscope
@@ -638,6 +642,7 @@ openapi
 openssl
 originatingTLS
 os
+ovn
 oseq
 otx
 pahole
@@ -846,6 +851,7 @@ unaudited
 uncommented
 uncordon
 unencrypted
+underlay
 unexported
 unicast
 uninline
@@ -854,6 +860,7 @@ unlabel
 unmanaged
 unmarshalled
 unmigrated
+unparsable
 unpaginated
 unselect
 unsettable
@@ -885,8 +892,11 @@ vlan
 vmlinux
 vmxnet
 vni
+VNIID
+VNI
 volumeMounts
 vpc
+VPCs
 vrf
 vrouter
 vtep

--- a/api/v1/flow/README.md
+++ b/api/v1/flow/README.md
@@ -566,6 +566,7 @@ L7 information for HTTP flows. It corresponds to Cilium&#39;s [accesslog.LogReco
 | encrypt_key | [uint32](#uint32) |  |  |
 | namespace | [string](#string) |  |  |
 | pod_name | [string](#string) |  |  |
+| vni | [uint32](#uint32) |  | vni is the native-vpc VNI (Virtual Network Identifier) of the ipcache entry, so monitor/hubble events can distinguish overlapping IPs from different VPCs. |
 
 
 

--- a/api/v1/flow/flow.pb.go
+++ b/api/v1/flow/flow.pb.go
@@ -4866,15 +4866,19 @@ func (x *EndpointUpdateNotification) GetNamespace() string {
 }
 
 type IPCacheNotification struct {
-	state         protoimpl.MessageState  `protogen:"open.v1"`
-	Cidr          string                  `protobuf:"bytes,1,opt,name=cidr,proto3" json:"cidr,omitempty"`
-	Identity      uint32                  `protobuf:"varint,2,opt,name=identity,proto3" json:"identity,omitempty"`
-	OldIdentity   *wrapperspb.UInt32Value `protobuf:"bytes,3,opt,name=old_identity,json=oldIdentity,proto3" json:"old_identity,omitempty"`
-	HostIp        string                  `protobuf:"bytes,4,opt,name=host_ip,json=hostIp,proto3" json:"host_ip,omitempty"`
-	OldHostIp     string                  `protobuf:"bytes,5,opt,name=old_host_ip,json=oldHostIp,proto3" json:"old_host_ip,omitempty"`
-	EncryptKey    uint32                  `protobuf:"varint,6,opt,name=encrypt_key,json=encryptKey,proto3" json:"encrypt_key,omitempty"`
-	Namespace     string                  `protobuf:"bytes,7,opt,name=namespace,proto3" json:"namespace,omitempty"`
-	PodName       string                  `protobuf:"bytes,8,opt,name=pod_name,json=podName,proto3" json:"pod_name,omitempty"`
+	state       protoimpl.MessageState  `protogen:"open.v1"`
+	Cidr        string                  `protobuf:"bytes,1,opt,name=cidr,proto3" json:"cidr,omitempty"`
+	Identity    uint32                  `protobuf:"varint,2,opt,name=identity,proto3" json:"identity,omitempty"`
+	OldIdentity *wrapperspb.UInt32Value `protobuf:"bytes,3,opt,name=old_identity,json=oldIdentity,proto3" json:"old_identity,omitempty"`
+	HostIp      string                  `protobuf:"bytes,4,opt,name=host_ip,json=hostIp,proto3" json:"host_ip,omitempty"`
+	OldHostIp   string                  `protobuf:"bytes,5,opt,name=old_host_ip,json=oldHostIp,proto3" json:"old_host_ip,omitempty"`
+	EncryptKey  uint32                  `protobuf:"varint,6,opt,name=encrypt_key,json=encryptKey,proto3" json:"encrypt_key,omitempty"`
+	Namespace   string                  `protobuf:"bytes,7,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	PodName     string                  `protobuf:"bytes,8,opt,name=pod_name,json=podName,proto3" json:"pod_name,omitempty"`
+	// vni is the native-vpc VNI (Virtual Network Identifier) of the ipcache
+	// entry, so monitor/hubble events can distinguish overlapping IPs from
+	// different VPCs.
+	Vni           uint32 `protobuf:"varint,9,opt,name=vni,proto3" json:"vni,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4963,6 +4967,13 @@ func (x *IPCacheNotification) GetPodName() string {
 		return x.PodName
 	}
 	return ""
+}
+
+func (x *IPCacheNotification) GetVni() uint32 {
+	if x != nil {
+		return x.Vni
+	}
+	return 0
 }
 
 // Deprecated: Marked as deprecated in flow/flow.proto.
@@ -5741,7 +5752,7 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\x06labels\x18\x02 \x03(\tR\x06labels\x12\x14\n" +
 	"\x05error\x18\x03 \x01(\tR\x05error\x12\x19\n" +
 	"\bpod_name\x18\x04 \x01(\tR\apodName\x12\x1c\n" +
-	"\tnamespace\x18\x05 \x01(\tR\tnamespace\"\x99\x02\n" +
+	"\tnamespace\x18\x05 \x01(\tR\tnamespace\"\xab\x02\n" +
 	"\x13IPCacheNotification\x12\x12\n" +
 	"\x04cidr\x18\x01 \x01(\tR\x04cidr\x12\x1a\n" +
 	"\bidentity\x18\x02 \x01(\rR\bidentity\x12?\n" +
@@ -5751,7 +5762,8 @@ const file_flow_flow_proto_rawDesc = "" +
 	"\vencrypt_key\x18\x06 \x01(\rR\n" +
 	"encryptKey\x12\x1c\n" +
 	"\tnamespace\x18\a \x01(\tR\tnamespace\x12\x19\n" +
-	"\bpod_name\x18\b \x01(\tR\apodName\"G\n" +
+	"\bpod_name\x18\b \x01(\tR\apodName\x12\x10\n" +
+	"\x03vni\x18\t \x01(\rR\x03vni\"G\n" +
 	"\x1dServiceUpsertNotificationAddr\x12\x0e\n" +
 	"\x02ip\x18\x01 \x01(\tR\x02ip\x12\x12\n" +
 	"\x04port\x18\x02 \x01(\rR\x04port:\x02\x18\x01\"\x9e\x03\n" +

--- a/api/v1/flow/flow.proto
+++ b/api/v1/flow/flow.proto
@@ -880,6 +880,10 @@ message IPCacheNotification {
     uint32 encrypt_key = 6;
     string namespace = 7;
     string pod_name = 8;
+    // vni is the native-vpc VNI (Virtual Network Identifier) of the ipcache
+    // entry, so monitor/hubble events can distinguish overlapping IPs from
+    // different VPCs.
+    uint32 vni = 9;
 }
 
 message ServiceUpsertNotificationAddr {

--- a/api/v1/flow/vni_proto_test.go
+++ b/api/v1/flow/vni_proto_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package flow_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+)
+
+// TestIPCacheNotificationVNIContract locks the generated protobuf contract for
+// monitor/Hubble native-vpc events: vni is field 9 and survives wire
+// marshal/unmarshal, while the existing field numbers remain unchanged.
+func TestIPCacheNotificationVNIContract(t *testing.T) {
+	md := (&flowpb.IPCacheNotification{}).ProtoReflect().Descriptor()
+	vni := md.Fields().ByNumber(9)
+	require.NotNil(t, vni)
+	require.Equal(t, protoreflect.Name("vni"), vni.Name())
+
+	in := &flowpb.IPCacheNotification{
+		Cidr:     "192.168.1.2/32",
+		Identity: 100,
+		Vni:      36,
+	}
+	data, err := proto.Marshal(in)
+	require.NoError(t, err)
+	out := &flowpb.IPCacheNotification{}
+	require.NoError(t, proto.Unmarshal(data, out))
+	require.Equal(t, uint32(36), out.GetVni())
+	require.Equal(t, "192.168.1.2/32", out.GetCidr())
+
+	require.Equal(t, protoreflect.Name("cidr"), md.Fields().ByNumber(1).Name())
+	require.Equal(t, protoreflect.Name("pod_name"), md.Fields().ByNumber(8).Name())
+}

--- a/api/v1/models/ip_list_entry.go
+++ b/api/v1/models/ip_list_entry.go
@@ -36,6 +36,11 @@ type IPListEntry struct {
 
 	// metadata
 	Metadata *IPListEntryMetadata `json:"metadata,omitempty"`
+
+	// Native-vpc VNI of the entry; 0 means not VPC-scoped
+	// Maximum: 1.6777215e+07
+	// Minimum: 0
+	VniID *int64 `json:"vniID,omitempty"`
 }
 
 // Validate validates this IP list entry
@@ -51,6 +56,10 @@ func (m *IPListEntry) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateMetadata(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateVniID(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -96,6 +105,22 @@ func (m *IPListEntry) validateMetadata(formats strfmt.Registry) error {
 
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (m *IPListEntry) validateVniID(formats strfmt.Registry) error {
+	if swag.IsZero(m.VniID) { // not required
+		return nil
+	}
+
+	if err := validate.MinimumInt("vniID", "body", *m.VniID, 0, false); err != nil {
+		return err
+	}
+
+	if err := validate.MaximumInt("vniID", "body", *m.VniID, 1.6777215e+07, false); err != nil {
+		return err
 	}
 
 	return nil

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -3459,6 +3459,12 @@ definitions:
       encryptKey:
         description: The context ID for the encryption session
         type: integer
+      vniID:
+        description: Native-vpc VNI of the entry; 0 means not VPC-scoped
+        type: integer
+        format: int64
+        minimum: 0
+        maximum: 16777215
       metadata:
         "$ref": "#/definitions/IPListEntryMetadata"
   IPListEntryMetadata:

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -3319,6 +3319,12 @@ func init() {
         },
         "metadata": {
           "$ref": "#/definitions/IPListEntryMetadata"
+        },
+        "vniID": {
+          "description": "Native-vpc VNI of the entry; 0 means not VPC-scoped",
+          "type": "integer",
+          "format": "int64",
+          "maximum": 16777215
         }
       }
     },
@@ -8740,6 +8746,13 @@ func init() {
         },
         "metadata": {
           "$ref": "#/definitions/IPListEntryMetadata"
+        },
+        "vniID": {
+          "description": "Native-vpc VNI of the entry; 0 means not VPC-scoped",
+          "type": "integer",
+          "format": "int64",
+          "maximum": 16777215,
+          "minimum": 0
         }
       }
     },

--- a/api/v1/standalone-dns-proxy/README.md
+++ b/api/v1/standalone-dns-proxy/README.md
@@ -75,6 +75,7 @@ cilium endpoint ipaddress and ID
 | ----- | ---- | ----- | ----------- |
 | id | [uint64](#uint64) |  |  |
 | ip | [bytes](#bytes) | repeated |  |
+| vni | [uint32](#uint32) |  | Native-vpc VNI; zero means non-VPC endpoint. |
 
 
 
@@ -95,6 +96,7 @@ FQDN-IP mapping goalstate sent from SDP to agent
 | source_identity | [uint32](#uint32) |  | Identity of the client making the DNS request |
 | source_ip | [bytes](#bytes) |  | IP address of the client making the DNS request |
 | response_code | [uint32](#uint32) |  | DNS Response code as specified in RFC2316 |
+| vni | [uint32](#uint32) |  | Native-vpc VNI of the source endpoint; zero means non-VPC |
 
 
 

--- a/api/v1/standalone-dns-proxy/standalone-dns-proxy.pb.go
+++ b/api/v1/standalone-dns-proxy/standalone-dns-proxy.pb.go
@@ -151,6 +151,7 @@ type FQDNMapping struct {
 	SourceIdentity uint32                 `protobuf:"varint,4,opt,name=source_identity,json=sourceIdentity,proto3" json:"source_identity,omitempty"` // Identity of the client making the DNS request
 	SourceIp       []byte                 `protobuf:"bytes,5,opt,name=source_ip,json=sourceIp,proto3" json:"source_ip,omitempty"`                    // IP address of the client making the DNS request
 	ResponseCode   uint32                 `protobuf:"varint,6,opt,name=response_code,json=responseCode,proto3" json:"response_code,omitempty"`       // DNS Response code as specified in RFC2316
+	Vni            uint32                 `protobuf:"varint,7,opt,name=vni,proto3" json:"vni,omitempty"`                                             // Native-vpc VNI of the source endpoint; zero means non-VPC
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -223,6 +224,13 @@ func (x *FQDNMapping) GetSourceIp() []byte {
 func (x *FQDNMapping) GetResponseCode() uint32 {
 	if x != nil {
 		return x.ResponseCode
+	}
+	return 0
+}
+
+func (x *FQDNMapping) GetVni() uint32 {
+	if x != nil {
+		return x.Vni
 	}
 	return 0
 }
@@ -522,6 +530,7 @@ type EndpointInfo struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            uint64                 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
 	Ip            [][]byte               `protobuf:"bytes,2,rep,name=ip,proto3" json:"ip,omitempty"`
+	Vni           uint32                 `protobuf:"varint,3,opt,name=vni,proto3" json:"vni,omitempty"` // Native-vpc VNI; zero means non-VPC endpoint.
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -568,6 +577,13 @@ func (x *EndpointInfo) GetIp() [][]byte {
 		return x.Ip
 	}
 	return nil
+}
+
+func (x *EndpointInfo) GetVni() uint32 {
+	if x != nil {
+		return x.Vni
+	}
+	return 0
 }
 
 // Cilium Identity ID to IP prefix mapping
@@ -631,14 +647,15 @@ const file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDesc = "" +
 	"\x13PolicyStateResponse\x12<\n" +
 	"\bresponse\x18\x01 \x01(\x0e2 .standalonednsproxy.ResponseCodeR\bresponse\x12\x1d\n" +
 	"\n" +
-	"request_id\x18\x02 \x01(\tR\trequestId\"\xbb\x01\n" +
+	"request_id\x18\x02 \x01(\tR\trequestId\"\xcd\x01\n" +
 	"\vFQDNMapping\x12\x12\n" +
 	"\x04fqdn\x18\x01 \x01(\tR\x04fqdn\x12\x1b\n" +
 	"\trecord_ip\x18\x02 \x03(\fR\brecordIp\x12\x10\n" +
 	"\x03ttl\x18\x03 \x01(\rR\x03ttl\x12'\n" +
 	"\x0fsource_identity\x18\x04 \x01(\rR\x0esourceIdentity\x12\x1b\n" +
 	"\tsource_ip\x18\x05 \x01(\fR\bsourceIp\x12#\n" +
-	"\rresponse_code\x18\x06 \x01(\rR\fresponseCode\"U\n" +
+	"\rresponse_code\x18\x06 \x01(\rR\fresponseCode\x12\x10\n" +
+	"\x03vni\x18\a \x01(\rR\x03vni\"U\n" +
 	"\x15UpdateMappingResponse\x12<\n" +
 	"\bresponse\x18\x01 \x01(\x0e2 .standalonednsproxy.ResponseCodeR\bresponse\"\x8d\x01\n" +
 	"\tDNSServer\x12.\n" +
@@ -659,10 +676,11 @@ const file_standalone_dns_proxy_standalone_dns_proxy_proto_rawDesc = "" +
 	"\x1aidentity_to_prefix_mapping\x18\x04 \x03(\v2+.standalonednsproxy.IdentityToPrefixMappingR\x17identityToPrefixMapping\"~\n" +
 	"\x19IdentityToEndpointMapping\x12\x1a\n" +
 	"\bidentity\x18\x01 \x01(\rR\bidentity\x12E\n" +
-	"\rendpoint_info\x18\x02 \x03(\v2 .standalonednsproxy.EndpointInfoR\fendpointInfo\".\n" +
+	"\rendpoint_info\x18\x02 \x03(\v2 .standalonednsproxy.EndpointInfoR\fendpointInfo\"@\n" +
 	"\fEndpointInfo\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x04R\x02id\x12\x0e\n" +
-	"\x02ip\x18\x02 \x03(\fR\x02ip\"M\n" +
+	"\x02ip\x18\x02 \x03(\fR\x02ip\x12\x10\n" +
+	"\x03vni\x18\x03 \x01(\rR\x03vni\"M\n" +
 	"\x17IdentityToPrefixMapping\x12\x1a\n" +
 	"\bidentity\x18\x01 \x01(\rR\bidentity\x12\x16\n" +
 	"\x06prefix\x18\x02 \x03(\fR\x06prefix*\x9f\x02\n" +

--- a/api/v1/standalone-dns-proxy/standalone-dns-proxy.proto
+++ b/api/v1/standalone-dns-proxy/standalone-dns-proxy.proto
@@ -51,6 +51,7 @@ message FQDNMapping {
     uint32 source_identity = 4; // Identity of the client making the DNS request
     bytes source_ip = 5; // IP address of the client making the DNS request
     uint32 response_code = 6; // DNS Response code as specified in RFC2316
+    uint32 vni = 7; // Native-vpc VNI of the source endpoint; zero means non-VPC
 }
 
 // Ack returned by cilium agent to SDP on receiving FQDN-IP mapping update
@@ -91,6 +92,7 @@ message IdentityToEndpointMapping {
 message EndpointInfo {
     uint64 id = 1;
     repeated bytes ip = 2;
+    uint32 vni = 3; // Native-vpc VNI; zero means non-VPC endpoint.
 }
 
 // Cilium Identity ID to IP prefix mapping

--- a/bpf/bpf_alignchecker.c
+++ b/bpf/bpf_alignchecker.c
@@ -33,6 +33,7 @@ add_type(struct ct_entry);
 add_type(struct endpoint_key);
 add_type(struct endpoint_info);
 add_type(struct ipcache_key);
+add_type(struct ipcache_vni_key);
 add_type(struct remote_endpoint_info);
 
 #include "lib/lb.h"

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -176,6 +176,18 @@ static __always_inline int __per_packet_lb_svc_xlate_4(void *ctx, struct iphdr *
 	fraginfo = ipfrag_encode_ipv4(ip4);
 	l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
 
+	/* Native-vpc: never translate a service address for a VPC endpoint.
+	 * Service backends are keyed by (IP, port) with no VPC scope, and the
+	 * backend address would be resolved by kube-ovn inside the *sender's*
+	 * VPC - i.e. a client of one VPC could be redirected to the pod that
+	 * happens to own the same IP in its own VPC. kube-ovn (or kube-proxy)
+	 * owns service load balancing in this mode; leave the packet untouched.
+	 * This mirrors the endpoint-map fast path, which is skipped for the same
+	 * reason.
+	 */
+	if (CONFIG(native_vpc_vni) > 0)
+		goto skip_service_lookup;
+
 	ret = lb4_extract_tuple(ctx, ip4, fraginfo, l4_off, &tuple);
 	if (IS_ERR(ret)) {
 		if (ret == DROP_UNSUPP_SERVICE_PROTO || ret == DROP_UNKNOWN_L4)
@@ -348,6 +360,12 @@ static __always_inline int __per_packet_lb_svc_xlate_6(void *ctx, struct ipv6hdr
 		return ret;
 
 	l4_off = ETH_HLEN + ret;
+
+	/* Native-vpc: never translate a service address for a VPC endpoint
+	 * (see the IPv4 twin for the rationale).
+	 */
+	if (CONFIG(native_vpc_vni) > 0)
+		goto skip_service_lookup;
 
 	ret = lb6_extract_tuple(ctx, ip6, fraginfo, l4_off, &tuple);
 	if (IS_ERR(ret)) {

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -734,7 +734,14 @@ ipv6_forward_to_destination(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 	set_identity_mark(ctx, SECLABEL_IPV6, MARK_MAGIC_IDENTITY);
 #endif
 
-	if (is_defined(ENABLE_ROUTING) || hairpin_flow || is_defined(ENABLE_HOST_ROUTING)) {
+	/* In native-vpc mode, skip the local-endpoint fast path. Different VPCs may
+	 * reuse the same IP on this node, and the endpoint map is keyed by IP only,
+	 * so a local delivery lookup would be ambiguous. Hand the packet to the
+	 * stack instead; kube-ovn delivers it on the correct VPC (by VNI), and the
+	 * destination ingress resolves the source with its own VNI.
+	 */
+	if (CONFIG(native_vpc_vni) == 0 &&
+	    (is_defined(ENABLE_ROUTING) || hairpin_flow || is_defined(ENABLE_HOST_ROUTING))) {
 		const struct endpoint_info *ep;
 		union v6addr daddr;
 
@@ -872,7 +879,15 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 			same_subnet_id = (src_subnet_id == dst_subnet_id) && (src_subnet_id != 0);
 		}
 
-		info = lookup_ip6_remote_endpoint(daddr, 0);
+		/* VNI-first: a stale/foreign plain entry for the same IP must not
+		 * shadow the correct VNI-scoped identity (native-vpc only).
+		 */
+		info = NULL;
+		if (CONFIG(native_vpc_vni) > 0)
+			info = ipcache_lookup6_vni(&cilium_ipcache_vni, daddr,
+						   V6_CACHE_KEY_LEN, CONFIG(native_vpc_vni));
+		if (!info)
+			info = lookup_ip6_remote_endpoint(daddr, 0);
 		if (info) {
 			*dst_sec_identity = info->sec_identity;
 			skip_tunnel = (info->flag_skip_tunnel) || same_subnet_id;
@@ -1210,8 +1225,13 @@ ipv4_forward_to_destination(struct __ctx_buff *ctx, struct iphdr *ip4,
 	 * the ipv4_local_delivery() function to enforce ingress policies for
 	 * that endpoint.
 	 */
-	if (is_defined(ENABLE_ROUTING) || hairpin_flow ||
-	    is_defined(ENABLE_HOST_ROUTING)) {
+	/* In native-vpc mode, skip the local-endpoint fast path (see the IPv6
+	 * twin above for the rationale: same IP may exist in multiple VPCs on
+	 * this node and the endpoint map is keyed by IP only).
+	 */
+	if (CONFIG(native_vpc_vni) == 0 &&
+	    (is_defined(ENABLE_ROUTING) || hairpin_flow ||
+	     is_defined(ENABLE_HOST_ROUTING))) {
 		__be32 daddr = ip4->daddr;
 		const struct endpoint_info *ep;
 
@@ -1442,7 +1462,15 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 	}
 
 	/* Determine the destination category for policy fallback. */
-	info = lookup_ip4_remote_endpoint(ip4->daddr, cluster_id);
+	/* VNI-first: a stale/foreign plain entry for the same IP must not
+	 * shadow the correct VNI-scoped identity (native-vpc only).
+	 */
+	info = NULL;
+	if (CONFIG(native_vpc_vni) > 0)
+		info = ipcache_lookup4_vni(&cilium_ipcache_vni, ip4->daddr,
+					   V4_CACHE_KEY_LEN, CONFIG(native_vpc_vni));
+	if (!info)
+		info = lookup_ip4_remote_endpoint(ip4->daddr, cluster_id);
 	if (info) {
 		*dst_sec_identity = info->sec_identity;
 		skip_tunnel = (info->flag_skip_tunnel) || same_subnet_id;
@@ -2082,7 +2110,15 @@ int tail_ipv6_to_endpoint(struct __ctx_buff *ctx)
 		const union v6addr *src = (union v6addr *)&ip6->saddr;
 		const struct remote_endpoint_info *info;
 
-		info = lookup_ip6_remote_endpoint(src, 0);
+		/* In native-vpc mode, resolve the source against the VNI-scoped
+		 * ipcache using this endpoint's own VNI first (see IPv4 twin).
+		 */
+		info = NULL;
+		if (CONFIG(native_vpc_vni) > 0)
+			info = ipcache_lookup6_vni(&cilium_ipcache_vni, src,
+						   V6_CACHE_KEY_LEN, CONFIG(native_vpc_vni));
+		if (!info)
+			info = lookup_ip6_remote_endpoint(src, 0);
 		if (info != NULL) {
 			__u32 sec_identity = info->sec_identity;
 
@@ -2400,7 +2436,25 @@ int tail_ipv4_to_endpoint(struct __ctx_buff *ctx)
 	if (identity_is_reserved(src_sec_identity)) {
 		const struct remote_endpoint_info *info;
 
-		info = lookup_ip4_remote_endpoint(ip4->saddr, 0);
+		/* In native-vpc mode, resolve the source against the VNI-scoped
+		 * ipcache using this endpoint's own VNI first. This correctly
+		 * attributes same-VPC peers (the common case) even when their IP
+		 * is not present in the plain ipcache due to overlapping VPC
+		 * subnets.
+		 *
+		 * Inter-VPC traffic never reaches this endpoint: whether two VPCs
+		 * can talk is decided by kube-ovn's forwarding plane (logical
+		 * router / ACL), which drops it by default (VPC peering is not
+		 * supported). A VNI-map miss therefore only occurs for non-VPC
+		 * sources (default-subnet pods, nodes, world), which are resolved
+		 * via the plain ipcache below.
+		 */
+		info = NULL;
+		if (CONFIG(native_vpc_vni) > 0)
+			info = ipcache_lookup4_vni(&cilium_ipcache_vni, ip4->saddr,
+						   V4_CACHE_KEY_LEN, CONFIG(native_vpc_vni));
+		if (!info)
+			info = lookup_ip4_remote_endpoint(ip4->saddr, 0);
 		if (info != NULL) {
 			__u32 sec_identity = info->sec_identity;
 

--- a/bpf/include/bpf/config/lxc.h
+++ b/bpf/include/bpf/config/lxc.h
@@ -16,3 +16,9 @@ DECLARE_CONFIG(union v4addr, endpoint_ipv4, "The endpoint's IPv4 address")
 DECLARE_CONFIG(union v6addr, endpoint_ipv6, "The endpoint's IPv6 address")
 
 DECLARE_CONFIG(__u64, endpoint_netns_cookie, "The endpoint's network namespace cookie")
+
+/* Native-vpc VNI of this endpoint. Zero selects the native (non-VPC) scheme.
+ * This is load-time per-endpoint data so one compiled bpf_lxc template serves
+ * every VPC; the loader rewrites it when loading the endpoint program.
+ */
+DECLARE_CONFIG(__u32, native_vpc_vni, "The endpoint's native-vpc VNI")

--- a/bpf/lib/eps.h
+++ b/bpf/lib/eps.h
@@ -206,12 +206,24 @@ ipcache_lookup4(const void *map, __be32 addr, __u32 prefix, __u32 cluster_id)
  * ipcache key to disambiguate overlapping IPs across clusters; here the
  * kube-ovn tunnel_key (VNI) plays that role for VPCs within one cluster. We
  * deliberately do not reuse cluster_id semantics (VPC != ClusterMesh).
+ *
+ * Layout rule (same as struct ipcache_key): every non-IP field must precede
+ * the IP union, because IPCACHE_VNI_STATIC_PREFIX is derived from
+ * sizeof(key) - sizeof(lpm_key) - sizeof(v6addr) and is added to the IP prefix
+ * length. Padding placed *after* the IP would inflate the static prefix and
+ * make any entry shorter than a host prefix match only addresses whose
+ * remaining bytes are zero.
  */
 struct ipcache_vni_key {
 	struct bpf_lpm_trie_key lpm_key;
 	__u32 vni;
 	__u8 pad1;
 	__u8 family;
+	/* pad2 rounds the non-IP part to 8 bytes so that the Go side
+	 * (pkg/maps/ipcache.VniKey, which cannot be packed) has the same layout
+	 * and the same 64-bit static prefix.
+	 */
+	__u8 pad2[2];
 	union {
 		struct {
 			__u32		ip4;
@@ -221,13 +233,6 @@ struct ipcache_vni_key {
 		};
 		union v6addr	ip6;
 	};
-	/* pad2 MUST stay in sync with VniKey.Pad2 in pkg/maps/ipcache: it rounds
-	 * sizeof(struct ipcache_vni_key) to 28 so that the Go side computes the
-	 * same IPCACHE_VNI_STATIC_PREFIX (64 bits). Without it Go computes 64 bits
-	 * while C computes 48, and BPF lookups in cilium_ipcache_vni never match
-	 * Go-written entries.
-	 */
-	__u8 pad2[2];
 } __packed;
 
 struct {
@@ -239,8 +244,10 @@ struct {
 	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
 } cilium_ipcache_vni __section_maps_btf;
 
-/* IPCACHE_VNI_STATIC_PREFIX gets sizeof non-IP, non-prefix part of
- * ipcache_vni_key (vni + pad1 + family).
+/* IPCACHE_VNI_STATIC_PREFIX is the number of key bits that precede the IP:
+ * vni + pad1 + family + pad2. It is derived the same way as
+ * IPCACHE_STATIC_PREFIX, which only holds because every non-IP field comes
+ * before the IP union (see the layout rule above).
  */
 #define IPCACHE_VNI_STATIC_PREFIX					\
 	(8 * (sizeof(struct ipcache_vni_key) - sizeof(struct bpf_lpm_trie_key)	\

--- a/bpf/lib/eps.h
+++ b/bpf/lib/eps.h
@@ -192,3 +192,85 @@ ipcache_lookup4(const void *map, __be32 addr, __u32 prefix, __u32 cluster_id)
 	ipcache_lookup6(&cilium_ipcache_v2, addr, V6_CACHE_KEY_LEN, cluster_id)
 #define lookup_ip4_remote_endpoint(addr, cluster_id) \
 	ipcache_lookup4(&cilium_ipcache_v2, addr, V4_CACHE_KEY_LEN, cluster_id)
+
+/* Native-vpc VNI-scoped ipcache.
+ *
+ * Entries are keyed by (VNI, IP) so that overlapping IPs from different VPCs
+ * can coexist. It is only consulted by native-vpc endpoints
+ * (CONFIG(native_vpc_vni) > 0) to resolve the identity of a peer that is
+ * expected to live in the same VPC
+ * (the endpoint's own VNI). Must be kept in sync with
+ * pkg/maps/ipcache.VniKey.
+ *
+ * This is the "local ClusterID" split: upstream uses a cluster_id field in the
+ * ipcache key to disambiguate overlapping IPs across clusters; here the
+ * kube-ovn tunnel_key (VNI) plays that role for VPCs within one cluster. We
+ * deliberately do not reuse cluster_id semantics (VPC != ClusterMesh).
+ */
+struct ipcache_vni_key {
+	struct bpf_lpm_trie_key lpm_key;
+	__u32 vni;
+	__u8 pad1;
+	__u8 family;
+	union {
+		struct {
+			__u32		ip4;
+			__u32		pad4;
+			__u32		pad5;
+			__u32		pad6;
+		};
+		union v6addr	ip6;
+	};
+	/* pad2 MUST stay in sync with VniKey.Pad2 in pkg/maps/ipcache: it rounds
+	 * sizeof(struct ipcache_vni_key) to 28 so that the Go side computes the
+	 * same IPCACHE_VNI_STATIC_PREFIX (64 bits). Without it Go computes 64 bits
+	 * while C computes 48, and BPF lookups in cilium_ipcache_vni never match
+	 * Go-written entries.
+	 */
+	__u8 pad2[2];
+} __packed;
+
+struct {
+	__uint(type, BPF_MAP_TYPE_LPM_TRIE);
+	__type(key, struct ipcache_vni_key);
+	__type(value, struct remote_endpoint_info);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+	__uint(max_entries, IPCACHE_MAP_SIZE);
+	__uint(map_flags, BPF_F_NO_PREALLOC | BPF_F_RDONLY_PROG_COND);
+} cilium_ipcache_vni __section_maps_btf;
+
+/* IPCACHE_VNI_STATIC_PREFIX gets sizeof non-IP, non-prefix part of
+ * ipcache_vni_key (vni + pad1 + family).
+ */
+#define IPCACHE_VNI_STATIC_PREFIX					\
+	(8 * (sizeof(struct ipcache_vni_key) - sizeof(struct bpf_lpm_trie_key)	\
+	      - sizeof(union v6addr)))
+
+static __always_inline __maybe_unused const struct remote_endpoint_info *
+ipcache_lookup4_vni(const void *map, __be32 addr, __u32 prefix, __u32 vni)
+{
+	struct ipcache_vni_key key = {
+		.lpm_key = { IPCACHE_VNI_STATIC_PREFIX + prefix, {} },
+		.family = ENDPOINT_KEY_IPV4,
+		.ip4 = addr,
+	};
+
+	key.vni = vni;
+	key.ip4 &= GET_PREFIX(prefix);
+	return map_lookup_elem(map, &key);
+}
+
+static __always_inline __maybe_unused const struct remote_endpoint_info *
+ipcache_lookup6_vni(const void *map, const union v6addr *addr,
+		    __u32 prefix, __u32 vni)
+{
+	struct ipcache_vni_key key = {
+		.lpm_key = { IPCACHE_VNI_STATIC_PREFIX + prefix, {} },
+		.family = ENDPOINT_KEY_IPV6,
+		.ip6 = *addr,
+	};
+
+	key.vni = vni;
+	ipv6_addr_clear_suffix(&key.ip6, prefix);
+	return map_lookup_elem(map, &key);
+}

--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -13,12 +13,37 @@
 #define IPV4_SADDR_OFF		offsetof(struct iphdr, saddr)
 #define IPV4_DADDR_OFF		offsetof(struct iphdr, daddr)
 
+#ifdef ENABLE_NATIVE_VPC
+/* Native-vpc: the fragment key is scoped by the VNI of the endpoint that
+ * classifies the datagram. Without it, two pods that share a source IP in
+ * different VPCs and send fragmented datagrams to the same destination can
+ * collide on the 16-bit IP identifier, and the non-first fragments of one
+ * datagram would be classified with the other's L4 ports - feeding the wrong
+ * ports into the policy and conntrack lookups.
+ *
+ * Only bpf_lxc knows the VNI (it is per-endpoint load-time config); every
+ * other program uses 0, which gives them their own key namespace. A datagram
+ * whose fragments are classified by different programs then misses the map
+ * and is dropped (DROP_FRAG_NOT_FOUND) instead of being misclassified, which
+ * is the fail-closed direction. In native-vpc the pod path is bpf_lxc only
+ * (kube-ovn owns the host and tunnel datapath), so this does not occur.
+ */
+# ifdef IS_BPF_LXC
+#  define frag_scope_vni() CONFIG(native_vpc_vni)
+# else
+#  define frag_scope_vni() 0
+# endif
+#endif
+
 struct ipv4_frag_id {
 	__be32	daddr;
 	__be32	saddr;
 	__be16	id;		/* L4 datagram identifier */
 	__u8	proto;
 	__u8	pad;
+#ifdef ENABLE_NATIVE_VPC
+	__u32	vni;		/* native-vpc scope, 0 outside bpf_lxc */
+#endif
 } __packed;
 
 struct ipv4_frag_l4ports {
@@ -114,6 +139,9 @@ ipv4_handle_fragmentation(struct __ctx_buff *ctx,
 		.saddr = ip4->saddr,
 		.id = (__be16)ipfrag_get_id(fraginfo),
 		.proto = ipfrag_get_protocol(fraginfo),
+#ifdef ENABLE_NATIVE_VPC
+		.vni = frag_scope_vni(),
+#endif
 	};
 
 	if (unlikely(!ipfrag_has_l4_header(fraginfo)))

--- a/cilium-dbg/cmd/bpf_ipcache_delete.go
+++ b/cilium-dbg/cmd/bpf_ipcache_delete.go
@@ -12,13 +12,13 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cilium/cilium/pkg/common"
-	"github.com/cilium/cilium/pkg/maps/ipcache"
 )
 
 func init() {
 	BPFIPCacheCmd.AddCommand(bpfIPCacheDeleteCmd)
 
 	bpfIPCacheDeleteCmd.PersistentFlags().Uint16("clusterid", 0, "Cluster ID")
+	bpfIPCacheDeleteCmd.PersistentFlags().Uint32("vni", 0, "native-vpc VNI of the entry (0 = the unscoped ipcache)")
 }
 
 var bpfIPCacheDeleteCmd = &cobra.Command{
@@ -46,8 +46,8 @@ var bpfIPCacheDeleteCmd = &cobra.Command{
 
 		ip := net.IP(prefix.Addr().AsSlice())
 		mask := net.CIDRMask(prefix.Bits(), 32)
-		key := ipcache.NewKey(ip, mask, clusterID)
-		if err := ipcache.IPCacheMap(nil).Delete(&key); err != nil {
+		m, key := ipcacheScope(cmd, ip, mask, clusterID)
+		if err := m.Delete(key); err != nil {
 			fmt.Fprintf(os.Stderr, "Error deleting entry %s: %v\n", key, err)
 			os.Exit(1)
 		}

--- a/cilium-dbg/cmd/bpf_ipcache_get.go
+++ b/cilium-dbg/cmd/bpf_ipcache_get.go
@@ -4,9 +4,12 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"os"
+	"sort"
 	"strings"
 
 	iradix "github.com/hashicorp/go-immutable-radix/v2"
@@ -38,7 +41,19 @@ var bpfIPCacheGetCmd = &cobra.Command{
 
 		bpfIPCache := dumpIPCache()
 
+		// Native-vpc: print every exact VNI-scoped entry for this IP first.
+		// They are keyed by (VNI, IP), so several VPCs may legitimately answer
+		// for the same address and an LPM over the merged key space would hide
+		// all but one of them.
+		vniMatches := lookupVNIEntries(ip)
+		for _, m := range vniMatches {
+			fmt.Printf("%s maps to identity %s\n", m.key, strings.Join(m.value, ","))
+		}
+
 		if len(bpfIPCache) == 0 {
+			if len(vniMatches) > 0 {
+				return
+			}
 			fmt.Fprintf(os.Stderr, "No entries found.\n")
 			os.Exit(1)
 		}
@@ -46,6 +61,9 @@ var bpfIPCacheGetCmd = &cobra.Command{
 		value, exists := getLPMValue(ip, bpfIPCache)
 
 		if !exists {
+			if len(vniMatches) > 0 {
+				return
+			}
 			fmt.Printf("%s does not map to any identity\n", arg)
 			os.Exit(1)
 		}
@@ -73,6 +91,48 @@ func dumpIPCache() map[string][]string {
 	}
 
 	return bpfIPCache
+}
+
+type vniEntry struct {
+	key   string
+	value []string
+}
+
+// lookupVNIEntries returns the entries of the native-vpc VNI-scoped ipcache
+// ("<prefix>@vni:<vni>") whose prefix contains ip. Entries of different VPCs
+// for the same address are all returned: the (VNI, IP) key space is not
+// totally ordered by prefix length, so there is no single "best" match without
+// a VNI. The map is absent on non-native-vpc nodes, which is not an error.
+func lookupVNIEntries(ip net.IP) []vniEntry {
+	dump := make(map[string][]string)
+	if err := ipcache.IPCacheVniMap(nil).Dump(dump); err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			Fatalf("unable to dump native-vpc IPCache: %s\n", err)
+		}
+		return nil
+	}
+
+	var matches []vniEntry
+	for key, value := range dump {
+		prefixStr, _, found := strings.Cut(key, "@vni:")
+		if !found {
+			continue
+		}
+		_, subnet, err := net.ParseCIDR(prefixStr)
+		if err != nil {
+			log.Warn(
+				"unable to parse native-vpc ipcache entry as a CIDR",
+				logfields.Error, err,
+				logfields.Entry, key,
+			)
+			continue
+		}
+		if subnet.Contains(ip) {
+			matches = append(matches, vniEntry{key: key, value: value})
+		}
+	}
+	sort.Slice(matches, func(i, j int) bool { return matches[i].key < matches[j].key })
+	return matches
 }
 
 // getLPMValue calculates the longest prefix matching ip amongst the

--- a/cilium-dbg/cmd/bpf_ipcache_list.go
+++ b/cilium-dbg/cmd/bpf_ipcache_list.go
@@ -4,7 +4,9 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -34,6 +36,14 @@ var bpfIPCacheListCmd = &cobra.Command{
 		bpfIPCacheList := make(map[string][]string)
 		if err := ipcache.IPCacheMap(nil).Dump(bpfIPCacheList); err != nil {
 			fmt.Fprintf(os.Stderr, "error dumping contents of map: %s\n", err)
+			os.Exit(1)
+		}
+		// Also dump the native-vpc VNI-scoped ipcache, if present. cilium-dbg is
+		// a separate process, so the singleton starts closed: calling IsOpen()
+		// here would always skip the map. Dump opens the pinned map itself;
+		// absence is expected on non-native-vpc nodes and is ignored.
+		if err := ipcache.IPCacheVniMap(nil).Dump(bpfIPCacheList); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			fmt.Fprintf(os.Stderr, "error dumping contents of vni map: %s\n", err)
 			os.Exit(1)
 		}
 

--- a/cilium-dbg/cmd/bpf_ipcache_scope.go
+++ b/cilium-dbg/cmd/bpf_ipcache_scope.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/maps/ipcache"
+)
+
+// ipcacheScope resolves which ipcache an operator command must act on.
+//
+// With native-vpc an address belongs to a VPC, and the two maps are separate
+// key spaces: the unscoped map holds the addresses that have no VPC (the host,
+// the world, CIDR and FQDN entries), the scoped one holds the endpoints. A
+// command that silently defaulted to the unscoped map would report success for
+// a deletion that removed nothing, and - worse for an update - would put a pod
+// address into the space the datapath falls back to when a scoped lookup
+// misses, which is exactly what must never contain one.
+//
+// So when the scoped map exists the scope has to be stated: --vni N for a VPC,
+// --vni 0 for the addresses that are in none.
+func ipcacheScope(cmd *cobra.Command, ip net.IP, mask net.IPMask, clusterID uint16) (*ipcache.Map, bpf.MapKey) {
+	vni, err := cmd.Flags().GetUint32("vni")
+	if err != nil {
+		Usagef(cmd, "Invalid VNI. "+usage)
+	}
+
+	if vni > 0 {
+		key := ipcache.NewVniKey(ip, mask, vni)
+		return ipcache.IPCacheVniMap(nil), &key
+	}
+
+	if !cmd.Flags().Changed("vni") && vniIPCacheExists() {
+		fmt.Fprintf(os.Stderr,
+			"This node runs native-vpc, where an address belongs to a VPC and the two ipcaches are separate.\n"+
+				"State the scope: --vni <n> for a VPC, or --vni 0 for the addresses that are in none.\n")
+		os.Exit(1)
+	}
+
+	key := ipcache.NewKey(ip, mask, clusterID)
+	return ipcache.IPCacheMap(nil), &key
+}
+
+// vniIPCacheExists reports whether this node runs with native-vpc, which is
+// visible from the pinned map alone - cilium-dbg does not share the agent's
+// configuration.
+func vniIPCacheExists() bool {
+	dump := map[string][]string{}
+	err := ipcache.IPCacheVniMap(nil).Dump(dump)
+	return !errors.Is(err, fs.ErrNotExist)
+}

--- a/cilium-dbg/cmd/bpf_ipcache_update.go
+++ b/cilium-dbg/cmd/bpf_ipcache_update.go
@@ -23,6 +23,7 @@ func init() {
 	bpfIPCacheUpdateCmd.PersistentFlags().Uint8("encryptkey", 0, "Encrypt key")
 	bpfIPCacheUpdateCmd.PersistentFlags().Bool("skiptunnel", false, "Skip tunnel")
 	bpfIPCacheUpdateCmd.PersistentFlags().Uint16("clusterid", 0, "Cluster ID")
+	bpfIPCacheUpdateCmd.PersistentFlags().Uint32("vni", 0, "native-vpc VNI of the entry (0 = the unscoped ipcache)")
 }
 
 var bpfIPCacheUpdateCmd = &cobra.Command{
@@ -75,13 +76,13 @@ var bpfIPCacheUpdateCmd = &cobra.Command{
 
 		ip := net.IP(prefix.Addr().AsSlice())
 		mask := net.CIDRMask(prefix.Bits(), 32)
-		key := ipcache.NewKey(ip, mask, clusterID)
+		m, key := ipcacheScope(cmd, ip, mask, clusterID)
 		value := ipcache.NewValue(identity, tunnelEndpoint, encryptKey, flags)
-		if err := ipcache.IPCacheMap(nil).Update(&key, &value); err != nil {
+		if err := m.Update(key, &value); err != nil {
 			fmt.Fprintf(os.Stderr, "Error updating entry %s: %v\n", key, err)
 			os.Exit(1)
 		}
 
-		fmt.Printf("Updated entry %s => %s\n", &key, &value)
+		fmt.Printf("Updated entry %s => %s\n", key, &value)
 	},
 }

--- a/cilium-dbg/cmd/ip_list.go
+++ b/cilium-dbg/cmd/ip_list.go
@@ -82,6 +82,20 @@ func getLabels(ni identity.NumericIdentity) []string {
 	return labels.NewLabelsFromModel(id.Payload.Labels).GetPrintableModel()
 }
 
+// cidrOf renders the address of an entry. In native-vpc mode the same address
+// can be present once per VPC, so the VNI scope is appended - without it the
+// listing shows several identical rows that cannot be told apart.
+func cidrOf(entry *models.IPListEntry) string {
+	cidr := ""
+	if entry.Cidr != nil {
+		cidr = *entry.Cidr
+	}
+	if entry.VniID != nil && *entry.VniID > 0 {
+		return fmt.Sprintf("%s@vni:%d", cidr, *entry.VniID)
+	}
+	return cidr
+}
+
 func printEntry(w *tabwriter.Writer, entry *models.IPListEntry) {
 	var src string
 	if entry.Metadata != nil {
@@ -100,9 +114,9 @@ func printEntry(w *tabwriter.Writer, entry *models.IPListEntry) {
 	for _, lbl := range labels {
 		if first {
 			if verbose {
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\n", *entry.Cidr, lbl, src, entry.HostIP, entry.EncryptKey)
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\n", cidrOf(entry), lbl, src, entry.HostIP, entry.EncryptKey)
 			} else {
-				fmt.Fprintf(w, "%s\t%s\t%s\n", *entry.Cidr, lbl, src)
+				fmt.Fprintf(w, "%s\t%s\t%s\n", cidrOf(entry), lbl, src)
 			}
 			first = false
 		} else {

--- a/cilium-dbg/cmd/ip_list_test.go
+++ b/cilium-dbg/cmd/ip_list_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/api/v1/models"
+)
+
+// TestCidrOf pins how the ipcache listing renders an entry. In native-vpc mode
+// the same address exists once per VPC, so the scope has to be part of the
+// rendered address: without it the listing shows several identical rows that
+// an operator cannot tell apart. Entries without a scope must stay unchanged.
+func TestCidrOf(t *testing.T) {
+	cidr := "10.99.0.12/32"
+	vni := func(v int64) *int64 { return &v }
+
+	for _, tc := range []struct {
+		name  string
+		entry *models.IPListEntry
+		want  string
+	}{
+		{
+			name:  "no VPC scope",
+			entry: &models.IPListEntry{Cidr: &cidr},
+			want:  "10.99.0.12/32",
+		},
+		{
+			name:  "zero VNI is not a scope",
+			entry: &models.IPListEntry{Cidr: &cidr, VniID: vni(0)},
+			want:  "10.99.0.12/32",
+		},
+		{
+			name:  "scoped entry",
+			entry: &models.IPListEntry{Cidr: &cidr, VniID: vni(7)},
+			want:  "10.99.0.12/32@vni:7",
+		},
+		{
+			name:  "missing address",
+			entry: &models.IPListEntry{VniID: vni(7)},
+			want:  "@vni:7",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, cidrOf(tc.entry))
+		})
+	}
+
+	// The rendering must match the key format used by the BPF dump and by the
+	// ipcache keys themselves, so that the three views can be correlated.
+	require.Equal(t, "10.99.0.12/32@vni:5", cidrOf(&models.IPListEntry{Cidr: &cidr, VniID: vni(5)}))
+}

--- a/daemon/cmd/cells_test.go
+++ b/daemon/cmd/cells_test.go
@@ -44,3 +44,30 @@ func TestAgentCell(t *testing.T) {
 	err := hive.New(Agent).Populate(hivetest.Logger(t))
 	assert.NoError(t, err, "Populate()")
 }
+
+// TestAgentCellNativeVPC verifies that the agent object graph also builds with
+// native-vpc enabled. The mode adds providers and consumers (the VNI-scoped
+// ipcache map, the local-ipcache adapter of the identity synchronizer) and
+// several consumers reach VNI-aware behavior through optional interfaces; a
+// constructor parameter that no cell provides makes the *whole agent* fail to
+// start, which no package-level test would catch.
+func TestAgentCellNativeVPC(t *testing.T) {
+	defer testutils.GoleakVerifyNone(t, goleakOptions...)
+	defer metrics.Reinitialize()
+
+	logging.SetLogLevelToDebug()
+
+	option.Config.IPv4ServiceRange = AutoCIDR
+	option.Config.IPv6ServiceRange = AutoCIDR
+
+	prevEnabled, prevAnnotation := option.Config.EnableNativeVPC, option.Config.NativeVPCVNIAnnotation
+	option.Config.EnableNativeVPC = true
+	option.Config.NativeVPCVNIAnnotation = "ovn.kubernetes.io/tunnel_key"
+	t.Cleanup(func() {
+		option.Config.EnableNativeVPC = prevEnabled
+		option.Config.NativeVPCVNIAnnotation = prevAnnotation
+	})
+
+	err := hive.New(Agent).Populate(hivetest.Logger(t))
+	assert.NoError(t, err, "Populate() with native-vpc enabled")
+}

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -54,6 +54,13 @@ func nativeVPCDatapathCompatibility(params daemonConfigParams) error {
 		return errors.New("native-vpc mode is incompatible with BPF masquerade: kube-ovn owns SNAT, and the NAT maps are keyed by the bare tuple")
 	case params.IPSecConfig.Enabled(), params.WireguardConfig.Enabled():
 		return errors.New("native-vpc mode is incompatible with Cilium encryption (IPsec/WireGuard): peer selection is keyed by the bare IP")
+	case params.ClusterInfo.ID != 0 && params.ClusterMesh.ClusterMeshConfig != "":
+		// A VNI is a tunnel key of this cluster's OVN, so it says nothing about
+		// another cluster. Remote addresses therefore arrive either without a
+		// scope - landing in the unscoped ipcache, which is what the local
+		// datapath falls back to and which must hold no address that a VPC also
+		// uses - or with a number that means something else where it came from.
+		return errors.New("native-vpc mode is incompatible with cluster mesh: a VNI identifies a VPC of this cluster only, so remote addresses cannot be scoped and would be resolved from the unscoped ipcache")
 	}
 	return nil
 }

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -30,6 +30,27 @@ const (
 )
 
 func initAndValidateDaemonConfig(params daemonConfigParams) error {
+	// Native-vpc: overlapping IPs across VPCs are only safe on the planes that
+	// key their state by (VNI, IP). Datapath features whose state is keyed by
+	// the bare IP (service backends, socket LB, egress gateway source IPs,
+	// encryption peer selection) would silently mix two VPCs, so they are
+	// rejected here rather than failing in a data-dependent way.
+	// See Documentation/network/native-vpc.rst.
+	if params.DaemonConfig.EnableNativeVPC {
+		switch {
+		case params.KPRConfig.KubeProxyReplacement:
+			return fmt.Errorf("native-vpc mode is incompatible with kube-proxy replacement: service backends are keyed by (IP, port), so pods of different VPCs sharing an IP collapse into one backend")
+		case params.KPRConfig.EnableSocketLB:
+			return fmt.Errorf("native-vpc mode is incompatible with socket LB (--bpf-lb-sock): socket-level translation happens before the VPC scope is known")
+		case params.DaemonConfig.EnableEgressGateway:
+			return fmt.Errorf("native-vpc mode is incompatible with the egress gateway: its policies select traffic by the bare source IP")
+		case params.DaemonConfig.EnableBPFMasquerade:
+			return fmt.Errorf("native-vpc mode is incompatible with BPF masquerade: kube-ovn owns SNAT, and the NAT maps are keyed by the bare tuple")
+		case params.IPSecConfig.Enabled(), params.WireguardConfig.Enabled():
+			return fmt.Errorf("native-vpc mode is incompatible with Cilium encryption (IPsec/WireGuard): peer selection is keyed by the bare IP")
+		}
+	}
+
 	// WireGuard and IPSec are mutually exclusive.
 	if params.IPSecConfig.Enabled() && params.WireguardConfig.Enabled() {
 		return fmt.Errorf("WireGuard (--%s) cannot be used with IPsec (--%s)", wgTypes.EnableWireguard, datapath.EnableIPSec)

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -46,6 +46,10 @@ func nativeVPCDatapathCompatibility(params daemonConfigParams) error {
 		return errors.New("native-vpc mode is incompatible with socket LB (--bpf-lb-sock): socket-level translation happens before the VPC scope is known")
 	case params.DaemonConfig.EnableEgressGateway:
 		return errors.New("native-vpc mode is incompatible with the egress gateway: its policies select traffic by the bare source IP")
+	case params.DaemonConfig.EnableSRv6:
+		return errors.New("native-vpc mode is incompatible with SRv6: the VRF mapping selects traffic by the bare source IP")
+	case params.DaemonConfig.EnableVTEP:
+		return errors.New("native-vpc mode is incompatible with the VTEP integration: its mappings are keyed by bare CIDRs")
 	case params.DaemonConfig.EnableBPFMasquerade:
 		return errors.New("native-vpc mode is incompatible with BPF masquerade: kube-ovn owns SNAT, and the NAT maps are keyed by the bare tuple")
 	case params.IPSecConfig.Enabled(), params.WireguardConfig.Enabled():

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
@@ -29,26 +30,35 @@ const (
 	AutoCIDR = "auto"
 )
 
+// nativeVPCDatapathCompatibility rejects the datapath features whose state is
+// keyed by the bare IP (service backends, socket LB, egress gateway source
+// IPs, NAT tuples, encryption peer selection). With overlapping VPC subnets
+// they would silently mix two VPCs, so they must fail at startup rather than
+// in a data-dependent way. See Documentation/network/native-vpc.rst.
+func nativeVPCDatapathCompatibility(params daemonConfigParams) error {
+	if !params.DaemonConfig.EnableNativeVPC {
+		return nil
+	}
+	switch {
+	case params.KPRConfig.KubeProxyReplacement:
+		return errors.New("native-vpc mode is incompatible with kube-proxy replacement: service backends are keyed by (IP, port), so pods of different VPCs sharing an IP collapse into one backend")
+	case params.KPRConfig.EnableSocketLB:
+		return errors.New("native-vpc mode is incompatible with socket LB (--bpf-lb-sock): socket-level translation happens before the VPC scope is known")
+	case params.DaemonConfig.EnableEgressGateway:
+		return errors.New("native-vpc mode is incompatible with the egress gateway: its policies select traffic by the bare source IP")
+	case params.DaemonConfig.EnableBPFMasquerade:
+		return errors.New("native-vpc mode is incompatible with BPF masquerade: kube-ovn owns SNAT, and the NAT maps are keyed by the bare tuple")
+	case params.IPSecConfig.Enabled(), params.WireguardConfig.Enabled():
+		return errors.New("native-vpc mode is incompatible with Cilium encryption (IPsec/WireGuard): peer selection is keyed by the bare IP")
+	}
+	return nil
+}
+
 func initAndValidateDaemonConfig(params daemonConfigParams) error {
 	// Native-vpc: overlapping IPs across VPCs are only safe on the planes that
-	// key their state by (VNI, IP). Datapath features whose state is keyed by
-	// the bare IP (service backends, socket LB, egress gateway source IPs,
-	// encryption peer selection) would silently mix two VPCs, so they are
-	// rejected here rather than failing in a data-dependent way.
-	// See Documentation/network/native-vpc.rst.
-	if params.DaemonConfig.EnableNativeVPC {
-		switch {
-		case params.KPRConfig.KubeProxyReplacement:
-			return fmt.Errorf("native-vpc mode is incompatible with kube-proxy replacement: service backends are keyed by (IP, port), so pods of different VPCs sharing an IP collapse into one backend")
-		case params.KPRConfig.EnableSocketLB:
-			return fmt.Errorf("native-vpc mode is incompatible with socket LB (--bpf-lb-sock): socket-level translation happens before the VPC scope is known")
-		case params.DaemonConfig.EnableEgressGateway:
-			return fmt.Errorf("native-vpc mode is incompatible with the egress gateway: its policies select traffic by the bare source IP")
-		case params.DaemonConfig.EnableBPFMasquerade:
-			return fmt.Errorf("native-vpc mode is incompatible with BPF masquerade: kube-ovn owns SNAT, and the NAT maps are keyed by the bare tuple")
-		case params.IPSecConfig.Enabled(), params.WireguardConfig.Enabled():
-			return fmt.Errorf("native-vpc mode is incompatible with Cilium encryption (IPsec/WireGuard): peer selection is keyed by the bare IP")
-		}
+	// key their state by (VNI, IP).
+	if err := nativeVPCDatapathCompatibility(params); err != nil {
+		return err
 	}
 
 	// WireGuard and IPSec are mutually exclusive.

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -15,6 +15,9 @@ import (
 	"strconv"
 	"strings"
 
+	cmcommon "github.com/cilium/cilium/pkg/clustermesh/common"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+
 	"github.com/cilium/ebpf/rlimit"
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/hive/job"
@@ -1236,6 +1239,8 @@ type daemonConfigParams struct {
 	KPRInitializer  kprinitializer.KPRInitializer
 	IPSecConfig     datapath.IPsecConfig
 	WireguardConfig wgTypes.WireguardConfig
+	ClusterInfo     cmtypes.ClusterInfo
+	ClusterMesh     cmcommon.Config
 }
 
 type daemonParams struct {

--- a/daemon/cmd/endpoint_restore.go
+++ b/daemon/cmd/endpoint_restore.go
@@ -331,6 +331,26 @@ func (r *endpointRestorer) validateEndpoint(ep *endpoint.Endpoint) (valid bool, 
 			return false, err
 		}
 
+		// Native-vpc: re-read the VNI from the pod's tunnel_key annotation
+		// before the endpoint is exposed to the endpoint manager, so the
+		// identifier index (vni-ipv4/6) and the serialized state are built with
+		// the converged VNI (decision table: absent -> native scheme; valid
+		// non-zero -> VNIID; zero/invalid -> error + native fallback, see
+		// endpoint.SyncVNIFromPodAnnotation). This is the control-plane half of
+		// the fallback sequence - restart kube-ovn-controller first (it
+		// backfills the annotations), then restart cilium - which re-flushes
+		// the tunnel_key+IP resources on the control, cache and forwarding
+		// planes after kube-ovn backfills the annotation.
+		if option.Config.EnableNativeVPC && ep.GetPod() != nil {
+			if ep.SyncVNIFromPodAnnotation(ep.GetPod()) {
+				r.logger.Info("Native-vpc VNI refreshed from pod annotation on restore",
+					logfields.EndpointID, ep.ID,
+					logfields.K8sPodName, ep.GetK8sNamespaceAndPodName(),
+					logfields.VNIID, ep.GetVNIID(),
+				)
+			}
+		}
+
 		// Initialize the endpoint's event queue because the following call to
 		// execute the metadata resolver will emit events for the endpoint.
 		// After this endpoint is validated, it'll eventually be restored, in
@@ -366,6 +386,13 @@ func (r *endpointRestorer) getPodForEndpoint(ep *endpoint.Endpoint) error {
 		// if flag CiliumEndpointCRD is disabled,
 		// `GetCachedPod` may return endpoint has moved to another node.
 		return fmt.Errorf("Kubernetes pod %s/%s is not owned by this agent", ep.K8sNamespace, ep.K8sPodName)
+	}
+	// Expose the pod to the endpoint so callers of validateEndpoint (e.g. the
+	// native-vpc VNI re-read before expose) can inspect its annotations.
+	// Only on success: a transient (non-NotFound) informer error must not
+	// clobber the endpoint's pod with nil.
+	if err == nil {
+		ep.SetPod(pod)
 	}
 	return nil
 }

--- a/daemon/cmd/native_vpc_validation_test.go
+++ b/daemon/cmd/native_vpc_validation_test.go
@@ -53,6 +53,16 @@ func TestNativeVPCRejectsBareIPKeyedFeatures(t *testing.T) {
 			wantErr: "egress gateway",
 		},
 		{
+			name:    "srv6",
+			mutate:  func(p *daemonConfigParams) { p.DaemonConfig.EnableSRv6 = true },
+			wantErr: "SRv6",
+		},
+		{
+			name:    "vtep",
+			mutate:  func(p *daemonConfigParams) { p.DaemonConfig.EnableVTEP = true },
+			wantErr: "VTEP",
+		},
+		{
 			name:    "bpf masquerade",
 			mutate:  func(p *daemonConfigParams) { p.DaemonConfig.EnableBPFMasquerade = true },
 			wantErr: "BPF masquerade",

--- a/daemon/cmd/native_vpc_validation_test.go
+++ b/daemon/cmd/native_vpc_validation_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
+	"github.com/cilium/cilium/pkg/kpr"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// TestNativeVPCRejectsBareIPKeyedFeatures pins the startup guard for the
+// planes whose state is keyed by the bare IP (service backends, socket LB,
+// egress gateway, BPF masquerade, encryption). With overlapping VPC subnets
+// they would silently mix two VPCs, so the agent must refuse to start - and
+// must keep starting normally when native-vpc is off.
+func TestNativeVPCRejectsBareIPKeyedFeatures(t *testing.T) {
+	base := func(nativeVPC bool) daemonConfigParams {
+		return daemonConfigParams{
+			DaemonConfig: &option.DaemonConfig{
+				EnableNativeVPC:        nativeVPC,
+				NativeVPCVNIAnnotation: "ovn.kubernetes.io/tunnel_key",
+				RoutingMode:            option.RoutingModeNative,
+			},
+			IPSecConfig:     fakeTypes.IPsecConfig{},
+			WireguardConfig: fakeTypes.WireguardConfig{},
+		}
+	}
+
+	for _, tc := range []struct {
+		name    string
+		mutate  func(p *daemonConfigParams)
+		wantErr string
+	}{
+		{name: "clean", mutate: func(*daemonConfigParams) {}},
+		{
+			name:    "kube-proxy replacement",
+			mutate:  func(p *daemonConfigParams) { p.KPRConfig = kpr.KPRConfig{KubeProxyReplacement: true} },
+			wantErr: "kube-proxy replacement",
+		},
+		{
+			name:    "socket LB",
+			mutate:  func(p *daemonConfigParams) { p.KPRConfig = kpr.KPRConfig{EnableSocketLB: true} },
+			wantErr: "socket LB",
+		},
+		{
+			name:    "egress gateway",
+			mutate:  func(p *daemonConfigParams) { p.DaemonConfig.EnableEgressGateway = true },
+			wantErr: "egress gateway",
+		},
+		{
+			name:    "bpf masquerade",
+			mutate:  func(p *daemonConfigParams) { p.DaemonConfig.EnableBPFMasquerade = true },
+			wantErr: "BPF masquerade",
+		},
+		{
+			name:    "ipsec",
+			mutate:  func(p *daemonConfigParams) { p.IPSecConfig = fakeTypes.IPsecConfig{EnableIPsec: true} },
+			wantErr: "encryption",
+		},
+		{
+			name:    "wireguard",
+			mutate:  func(p *daemonConfigParams) { p.WireguardConfig = fakeTypes.WireguardConfig{EnableWireguard: true} },
+			wantErr: "encryption",
+		},
+	} {
+		t.Run(tc.name+"/native-vpc", func(t *testing.T) {
+			p := base(true)
+			tc.mutate(&p)
+			err := nativeVPCDatapathCompatibility(p)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+
+		t.Run(tc.name+"/native-vpc disabled", func(t *testing.T) {
+			p := base(false)
+			tc.mutate(&p)
+			require.NoError(t, nativeVPCDatapathCompatibility(p),
+				"the guard must not affect deployments without native-vpc")
+		})
+	}
+}

--- a/daemon/cmd/native_vpc_validation_test.go
+++ b/daemon/cmd/native_vpc_validation_test.go
@@ -6,6 +6,9 @@ package cmd
 import (
 	"testing"
 
+	cmcommon "github.com/cilium/cilium/pkg/clustermesh/common"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+
 	"github.com/stretchr/testify/require"
 
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
@@ -61,6 +64,21 @@ func TestNativeVPCRejectsBareIPKeyedFeatures(t *testing.T) {
 			name:    "vtep",
 			mutate:  func(p *daemonConfigParams) { p.DaemonConfig.EnableVTEP = true },
 			wantErr: "VTEP",
+		},
+		{
+			// A VNI names a VPC of this cluster's OVN, so a remote cluster's
+			// addresses can carry no scope that means anything here.
+			name: "cluster mesh",
+			mutate: func(p *daemonConfigParams) {
+				p.ClusterInfo = cmtypes.ClusterInfo{ID: 3}
+				p.ClusterMesh = cmcommon.Config{ClusterMeshConfig: "/var/lib/cilium/clustermesh"}
+			},
+			wantErr: "cluster mesh",
+		},
+		{
+			// One half alone is not cluster mesh.
+			name:   "cluster id without a mesh config",
+			mutate: func(p *daemonConfigParams) { p.ClusterInfo = cmtypes.ClusterInfo{ID: 3} },
 		},
 		{
 			name:    "bpf masquerade",

--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -23,6 +23,13 @@ const (
 	// NetworkPrefix is the common prefix for network related annotations.
 	NetworkPrefix = "network.cilium.io"
 
+	// NativeVPCVNIPrefix is the prefix for the native-vpc VNI annotation written
+	// on CiliumEndpoints. The annotation carries the Virtual Network Identifier
+	// (VNI) of the endpoint so that CiliumEndpoint watchers on other nodes can
+	// register the endpoint IP in the VNI-scoped ipcache (overlapping IPs from
+	// different VPCs).
+	NativeVPCVNIPrefix = "native-vpc.cilium.io"
+
 	// PolicyPrefix is the common prefix for policy related annotations.
 	PolicyPrefix = "policy.cilium.io"
 

--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -30,6 +30,14 @@ const (
 	// different VPCs).
 	NativeVPCVNIPrefix = "native-vpc.cilium.io"
 
+	// CiliumEndpointNativeVPCVNI is the CiliumEndpoint annotation that carries
+	// the native-vpc VNI of the endpoint. It is written by the agent owning the
+	// endpoint (endpointsynchronizer) and read by the CiliumEndpoint watchers of
+	// the other nodes. It must be preserved by the CiliumEndpoint informer
+	// transform (see k8s.TransformToCiliumEndpoint), otherwise remote endpoints
+	// would be registered without a VNI.
+	CiliumEndpointNativeVPCVNI = NativeVPCVNIPrefix + "/vni"
+
 	// PolicyPrefix is the common prefix for policy related annotations.
 	PolicyPrefix = "policy.cilium.io"
 

--- a/pkg/datapath/alignchecker/alignchecker.go
+++ b/pkg/datapath/alignchecker/alignchecker.go
@@ -4,6 +4,8 @@
 package alignchecker
 
 import (
+	"maps"
+
 	check "github.com/cilium/cilium/pkg/alignchecker"
 	"github.com/cilium/cilium/pkg/bpf"
 	lbmap "github.com/cilium/cilium/pkg/loadbalancer/maps"
@@ -31,6 +33,7 @@ var (
 		"ipv6_ct_tuple":        {ctmap.CtKey6Global{}},
 		"ct_entry":             {ctmap.CtEntry{}},
 		"ipcache_key":          {ipcachemap.Key{}},
+		"ipcache_vni_key":      {ipcachemap.VniKey{}},
 		"remote_endpoint_info": {ipcachemap.RemoteEndpointInfo{}},
 		"lb4_key":              {lbmap.Service4Key{}},
 		"lb4_backend":          {lbmap.Backend4ValueV3{}},
@@ -52,7 +55,9 @@ var (
 			srv6map.PolicyValue{},
 			srv6map.SIDKey{},
 		},
-		"macaddr":           {neighborsmap.Value{}},
+		"macaddr": {neighborsmap.Value{}},
+		// Selected at runtime: the C struct gains a VNI field when the
+		// datapath is compiled with ENABLE_NATIVE_VPC (see fragmap).
 		"ipv4_frag_id":      {fragmap.FragmentKey4{}},
 		"ipv4_frag_l4ports": {fragmap.FragmentValue4{}},
 		"ipv6_frag_id":      {fragmap.FragmentKey6{}},
@@ -125,8 +130,13 @@ var (
 // union fields can be referred with special tags - `align:"$union0"`,
 // `align:"$union1"`, etc.
 func CheckStructAlignments(path string) error {
+	// The layout of a few structs depends on the datapath configuration this
+	// node was compiled with, so resolve them now rather than at init time.
+	checks := maps.Clone(toCheck)
+	checks["ipv4_frag_id"] = []any{fragmap.FragmentKey4Type()}
+
 	// Validate alignments of C and Go equivalent structs
-	if err := check.CheckStructAlignments(path, toCheck, true); err != nil {
+	if err := check.CheckStructAlignments(path, checks, true); err != nil {
 		return err
 	}
 	return check.CheckStructAlignments(path, toCheckSizes, false)

--- a/pkg/datapath/alignchecker/native_vpc_test.go
+++ b/pkg/datapath/alignchecker/native_vpc_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package alignchecker
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// TestCheckStructAlignmentsNativeVPC runs the real C/Go alignment check
+// against both datapath variants.
+//
+// bpf_alignchecker.c is compiled on the node with that node's defines, so a
+// struct whose layout depends on the mode (currently ipv4_frag_id, which gains
+// a VNI in native-vpc) must be matched against the Go type of the *same* mode.
+// Getting this wrong makes the agent exit with "C and Go structs alignment
+// check failed", which no unit test on the Go structs alone would catch.
+//
+// The objects are produced by `make -C bpf bpf_alignchecker.o` (plain) and the
+// same command with -DENABLE_NATIVE_VPC=1; the test skips when they are absent
+// so it does not require clang in every environment.
+func TestCheckStructAlignmentsNativeVPC(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		object    string
+		nativeVPC bool
+	}{
+		{name: "plain", object: "../../../bpf/bpf_alignchecker.o"},
+		{name: "native-vpc", object: "/tmp/bpf_alignchecker_nvpc.o", nativeVPC: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := os.Stat(tc.object); err != nil {
+				t.Skipf("%s not built: %v", tc.object, err)
+			}
+			prev := option.Config.EnableNativeVPC
+			option.Config.EnableNativeVPC = tc.nativeVPC
+			t.Cleanup(func() { option.Config.EnableNativeVPC = prev })
+
+			require.NoError(t, CheckStructAlignments(tc.object))
+		})
+	}
+}

--- a/pkg/datapath/config/endpoint.go
+++ b/pkg/datapath/config/endpoint.go
@@ -35,6 +35,7 @@ func Endpoint(ep datapath.EndpointConfiguration, lnc *datapath.LocalNodeConfigur
 
 	cfg.EndpointID = uint16(ep.GetID())
 	cfg.EndpointNetNSCookie = ep.GetEndpointNetNsCookie()
+	cfg.NativeVpcVni = uint32(ep.GetVNIID())
 
 	cfg.SecurityLabel = ep.GetIdentity().Uint32()
 

--- a/pkg/datapath/config/lxc_config.go
+++ b/pkg/datapath/config/lxc_config.go
@@ -46,6 +46,8 @@ type BPFLXC struct {
 	NATIPv4Masquerade [4]byte `config:"nat_ipv4_masquerade"`
 	// Masquerade address for IPv6 traffic.
 	NATIPv6Masquerade [16]byte `config:"nat_ipv6_masquerade"`
+	// The endpoint's native-vpc VNI.
+	NativeVpcVni uint32 `config:"native_vpc_vni"`
 	// The log level for policy verdicts in workload endpoints.
 	PolicyVerdictLogFilter uint32 `config:"policy_verdict_log_filter"`
 	// Whether to redirect to the proxy via cilium_net (hairpin) or via stack.
@@ -64,5 +66,5 @@ func NewBPFLXC(node Node) *BPFLXC {
 		0x0, 0x0, 0x0, 0x0, [8]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
 		[4]byte{0x0, 0x0, 0x0, 0x0},
 		[16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
-		0x0, false, 0x0, 0x0, node}
+		0x0, 0x0, false, 0x0, 0x0, node}
 }

--- a/pkg/datapath/ipcache/cell.go
+++ b/pkg/datapath/ipcache/cell.go
@@ -21,6 +21,7 @@ var Cell = cell.Module(
 	cell.Provide(NewListener),
 	cell.ProvidePrivate(
 		func(reg *metrics.Registry) Map { return ipcacheMap.IPCacheMap(reg) },
+		func(reg *metrics.Registry) VniMap { return ipcacheMap.IPCacheVniMap(reg) },
 		func(agent monitorAgent.Agent) monitorNotify { return agent },
 	),
 

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -27,13 +27,21 @@ type Map interface {
 	Delete(key bpf.MapKey) error
 }
 
+// VniMap is the native-vpc VNI-scoped ipcache BPF map (cilium_ipcache_vni).
+type VniMap Map
+
 // BPFListener implements the ipcache.IPIdentityMappingBPFListener
 // interface with an IPCache store that is backed by BPF maps.
 type BPFListener struct {
 	logger *slog.Logger
 	// bpfMap is the BPF map that this listener will update when events are
-	// received from the IPCache.
+	// received from the IPCache (plain cluster-wide ipcache).
 	bpfMap Map
+
+	// bpfVniMap is the native-vpc VNI-scoped ipcache map. Entries with a
+	// non-zero VNI are written here instead of bpfMap so that overlapping IPs
+	// from different VPCs can coexist.
+	bpfVniMap VniMap
 
 	// monitorNotify is used to notify the monitor about ipcache updates
 	monitorNotify monitorNotify
@@ -43,10 +51,11 @@ type BPFListener struct {
 }
 
 // NewListener returns a new listener to push IPCache entries into BPF maps.
-func NewListener(m Map, mn monitorNotify, tunnelConf tunnel.Config, logger *slog.Logger) *BPFListener {
+func NewListener(m Map, vniMap VniMap, mn monitorNotify, tunnelConf tunnel.Config, logger *slog.Logger) *BPFListener {
 	return &BPFListener{
 		logger:        logger,
 		bpfMap:        m,
+		bpfVniMap:     vniMap,
 		monitorNotify: mn,
 		tunnelConf:    tunnelConf,
 	}
@@ -79,11 +88,11 @@ func (l *BPFListener) notifyMonitor(modType ipcache.CacheModification,
 	switch modType {
 	case ipcache.Upsert:
 		msg := monitorAPI.IPCacheUpsertedMessage(cidr.String(), newIdentity, oldIdentityPtr,
-			newHostIP, oldHostIP, encryptKey, k8sNamespace, k8sPodName)
+			newHostIP, oldHostIP, encryptKey, k8sNamespace, k8sPodName, newID.Vni)
 		l.monitorNotify.SendEvent(monitorAPI.MessageTypeAgent, msg)
 	case ipcache.Delete:
 		msg := monitorAPI.IPCacheDeletedMessage(cidr.String(), newIdentity, oldIdentityPtr,
-			newHostIP, oldHostIP, encryptKey, k8sNamespace, k8sPodName)
+			newHostIP, oldHostIP, encryptKey, k8sNamespace, k8sPodName, newID.Vni)
 		l.monitorNotify.SendEvent(monitorAPI.MessageTypeAgent, msg)
 	}
 }
@@ -114,9 +123,20 @@ func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
 	// pkg/datapath instead of in the daemon directly so that the code is more
 	// logically located.
 
-	// Update BPF Maps.
-
-	key := ipcacheMap.NewKey(cidr.IP, cidr.Mask, uint16(cidrCluster.ClusterID()))
+	// Update BPF Maps. Entries with a non-zero VNI (native-vpc mode) go to the
+	// VNI-scoped map so that overlapping IPs from different VPCs can coexist.
+	// All other entries use the plain cluster-wide ipcache map.
+	targetMap := Map(l.bpfMap)
+	var (
+		key    ipcacheMap.Key
+		vniKey ipcacheMap.VniKey
+	)
+	if newID.Vni > 0 && l.bpfVniMap != nil {
+		targetMap = l.bpfVniMap
+		vniKey = ipcacheMap.NewVniKey(cidr.IP, cidr.Mask, newID.Vni)
+	} else {
+		key = ipcacheMap.NewKey(cidr.IP, cidr.Mask, uint16(cidrCluster.ClusterID()))
+	}
 
 	switch modType {
 	case ipcache.Upsert:
@@ -141,7 +161,12 @@ func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
 		}
 		value := ipcacheMap.NewValue(uint32(newID.ID), tunnelEndpoint, encryptKey,
 			ipcacheMap.RemoteEndpointInfoFlags(endpointFlags))
-		err := l.bpfMap.Update(&key, &value)
+		var err error
+		if newID.Vni > 0 && l.bpfVniMap != nil {
+			err = targetMap.Update(&vniKey, &value)
+		} else {
+			err = targetMap.Update(&key, &value)
+		}
 		if err != nil {
 			scopedLog.Warn(
 				"unable to update bpf map",
@@ -151,7 +176,12 @@ func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
 			)
 		}
 	case ipcache.Delete:
-		err := l.bpfMap.Delete(&key)
+		var err error
+		if newID.Vni > 0 && l.bpfVniMap != nil {
+			err = targetMap.Delete(&vniKey)
+		} else {
+			err = targetMap.Delete(&key)
+		}
 		if err != nil {
 			scopedLog.Warn(
 				"unable to delete from bpf map",

--- a/pkg/datapath/ipcache/listener_vni_test.go
+++ b/pkg/datapath/ipcache/listener_vni_test.go
@@ -54,7 +54,7 @@ func TestBPFListenerVNIRouting(t *testing.T) {
 		Vni:    0,
 	}, 0, nil, 0)
 	require.Len(t, v2.updates, 1)
-	require.Len(t, vni.updates, 0)
+	require.Empty(t, vni.updates)
 	_, ok := v2.updates[0].(*ipcacheMap.Key)
 	require.True(t, ok, "plain entry must use ipcacheMap.Key")
 

--- a/pkg/datapath/ipcache/listener_vni_test.go
+++ b/pkg/datapath/ipcache/listener_vni_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipcache
+
+import (
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/datapath/tunnel"
+	"github.com/cilium/cilium/pkg/ipcache"
+	ipcacheMap "github.com/cilium/cilium/pkg/maps/ipcache"
+	"github.com/cilium/cilium/pkg/source"
+)
+
+// fakeMap records the keys/values written to a BPF map.
+type fakeMap struct {
+	updates []bpf.MapKey
+	deletes []bpf.MapKey
+}
+
+func (f *fakeMap) Update(key bpf.MapKey, value bpf.MapValue) error {
+	f.updates = append(f.updates, key)
+	return nil
+}
+func (f *fakeMap) Delete(key bpf.MapKey) error {
+	f.deletes = append(f.deletes, key)
+	return nil
+}
+
+func newTestListener(t *testing.T) (*BPFListener, *fakeMap, *fakeMap) {
+	v2 := &fakeMap{}
+	vni := &fakeMap{}
+	l := NewListener(v2, vni, nil, tunnel.Config{}, hivetest.Logger(t))
+	return l, v2, vni
+}
+
+// TestBPFListenerVNIRouting verifies that ipcache entries with a non-zero VNI
+// are written to the VNI-scoped map (keyed by VNI+IP) and entries without a
+// VNI go to the plain ipcache map.
+func TestBPFListenerVNIRouting(t *testing.T) {
+	l, v2, vni := newTestListener(t)
+
+	// Plain entry (VNI 0) -> v2 map with plain Key.
+	prefix := cmtypes.MustParsePrefixCluster("192.168.1.2/32")
+	l.OnIPIdentityCacheChange(ipcache.Upsert, prefix, nil, nil, nil, ipcache.Identity{
+		ID:     21929,
+		Source: source.CustomResource,
+		Vni:    0,
+	}, 0, nil, 0)
+	require.Len(t, v2.updates, 1)
+	require.Len(t, vni.updates, 0)
+	_, ok := v2.updates[0].(*ipcacheMap.Key)
+	require.True(t, ok, "plain entry must use ipcacheMap.Key")
+
+	// Native-vpc entry (VNI 36) -> vni map with VniKey.
+	l.OnIPIdentityCacheChange(ipcache.Upsert, prefix, nil, nil, nil, ipcache.Identity{
+		ID:     21930,
+		Source: source.CustomResource,
+		Vni:    36,
+	}, 0, nil, 0)
+	require.Len(t, v2.updates, 1, "vni entry must not go to the v2 map")
+	require.Len(t, vni.updates, 1)
+	vk, ok := vni.updates[0].(*ipcacheMap.VniKey)
+	require.True(t, ok, "vni entry must use ipcacheMap.VniKey")
+	require.Equal(t, uint32(36), vk.Vni)
+
+	// Delete of the VNI entry must hit the vni map with the same VNI key.
+	l.OnIPIdentityCacheChange(ipcache.Delete, prefix, nil, nil, nil, ipcache.Identity{
+		ID:     21930,
+		Source: source.CustomResource,
+		Vni:    36,
+	}, 0, nil, 0)
+	require.Len(t, vni.deletes, 1)
+	vk, ok = vni.deletes[0].(*ipcacheMap.VniKey)
+	require.True(t, ok)
+	require.Equal(t, uint32(36), vk.Vni)
+}

--- a/pkg/datapath/ipcache/listener_vni_test.go
+++ b/pkg/datapath/ipcache/listener_vni_test.go
@@ -4,6 +4,7 @@
 package ipcache
 
 import (
+	"net/netip"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -79,4 +80,32 @@ func TestBPFListenerVNIRouting(t *testing.T) {
 	vk, ok = vni.deletes[0].(*ipcacheMap.VniKey)
 	require.True(t, ok)
 	require.Equal(t, uint32(36), vk.Vni)
+}
+
+// TestBPFListenerDeleteUsesDeletedEntryVNI pins the cache->forwarding seam for
+// deletions: the map is chosen by the VNI of the entry being removed, so
+// deleting a VPC entry never touches the plain map (and vice versa), and two
+// VPCs sharing an IP delete their own entry only.
+func TestBPFListenerDeleteUsesDeletedEntryVNI(t *testing.T) {
+	l, plain, vni := newTestListener(t)
+	prefix := cmtypes.NewLocalPrefixCluster(netip.MustParsePrefix("10.16.32.10/32"))
+
+	// Delete of a VPC entry -> VNI map only.
+	l.OnIPIdentityCacheChange(ipcache.Delete, prefix, nil, nil, nil,
+		ipcache.Identity{ID: 21929, Source: source.CustomResource, Vni: 36}, 0, nil, 0)
+	require.Empty(t, plain.deletes)
+	require.Len(t, vni.deletes, 1)
+	require.Equal(t, "10.16.32.10/32@vni:36", vni.deletes[0].String())
+
+	// Delete of the same IP in another VPC -> its own key.
+	l.OnIPIdentityCacheChange(ipcache.Delete, prefix, nil, nil, nil,
+		ipcache.Identity{ID: 21930, Source: source.CustomResource, Vni: 17}, 0, nil, 0)
+	require.Len(t, vni.deletes, 2)
+	require.Equal(t, "10.16.32.10/32@vni:17", vni.deletes[1].String())
+
+	// Delete of a non-VPC entry -> plain map only.
+	l.OnIPIdentityCacheChange(ipcache.Delete, prefix, nil, nil, nil,
+		ipcache.Identity{ID: 6, Source: source.KubeAPIServer}, 0, nil, 0)
+	require.Len(t, plain.deletes, 1)
+	require.Len(t, vni.deletes, 2)
 }

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -805,6 +805,10 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, devices []strin
 	// Local delivery metrics should always be set for endpoint programs.
 	fmt.Fprint(fw, "#define LOCAL_DELIVERY_METRICS 1\n")
 
+	// The native-vpc VNI is load-time per-endpoint data in .rodata.config
+	// (native_vpc_vni), not a compile-time define. Keeping it out of this
+	// header lets one compiled bpf_lxc template serve all VPCs.
+
 	h.writeNetdevConfig(fw, e.GetOptions())
 
 	return fw.Flush()

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -218,6 +218,15 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_IPV6"] = "1"
 	}
 
+	if option.Config.EnableNativeVPC {
+		// Node-level switch for the native-vpc datapath bits that cannot be
+		// expressed as per-endpoint load-time config, i.e. map key layouts.
+		// Currently only the VNI scope of the IPv4 fragment key; the
+		// per-endpoint VNI itself stays load-time data (native_vpc_vni) so
+		// that one bpf_lxc template serves every VPC.
+		cDefinesMap["ENABLE_NATIVE_VPC"] = "1"
+	}
+
 	if option.Config.EnableSRv6 {
 		cDefinesMap["ENABLE_SRV6"] = "1"
 		if option.Config.SRv6EncapMode != "reduced" {

--- a/pkg/datapath/loader/hash_test.go
+++ b/pkg/datapath/loader/hash_test.go
@@ -54,11 +54,19 @@ func TestHashEndpoint(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, base.String(), a)
 
-	// When we configure the endpoint differently, it's different
+	// When we configure the endpoint differently, it's different.
 	ep.Opts.SetBool("foo", true)
 	b, err := base.hashEndpoint(cfg, &localNodeConfig, &ep)
 	require.NoError(t, err)
 	require.NotEqual(t, a, b)
+
+	// Native-vpc VNI is load-time configuration: changing it must change the
+	// endpoint hash (so the object is reloaded with new constants), without
+	// changing the template hash (covered in TestHashTemplate below).
+	ep.VNIID = 36
+	c, err := base.hashEndpoint(cfg, &localNodeConfig, &ep)
+	require.NoError(t, err)
+	require.NotEqual(t, b, c)
 }
 
 func TestHashTemplate(t *testing.T) {
@@ -75,11 +83,11 @@ func TestHashTemplate(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, base.String(), a)
 
-	// Even with different endpoint IDs, we get the same hash
-	//
-	// This is the key to avoiding recompilation per endpoint; static
-	// data substitution is performed via pkg/elf instead.
+	// Even with different endpoint IDs or VNIs, we get the same hash.
+	// This is the key to avoiding recompilation per endpoint/VPC; load-time
+	// data substitution is performed via .rodata.config.
 	ep.Id++
+	ep.VNIID = 36
 	b, err := base.hashTemplate(cfg, &localNodeConfig, &ep)
 	require.NoError(t, err)
 	require.Equal(t, a, b)

--- a/pkg/datapath/loader/template.go
+++ b/pkg/datapath/loader/template.go
@@ -19,6 +19,9 @@ const (
 	templatePolicyVerdictFilter = uint32(0xffff)
 	templateIfIndex             = math.MaxUint32
 	templateEndpointNetNsCookie = math.MaxUint64
+	// Keep every 32-bit static-data segment non-zero in the template object;
+	// the loader replaces this with the real per-endpoint VNI (possibly 0).
+	templateNativeVPCVNI = uint64(1)
 )
 
 var (
@@ -76,6 +79,13 @@ func (t *templateCfg) GetIdentity() identity.NumericIdentity {
 // GetEndpointNetNsCookie returns a invalid (zero) network namespace cookie.
 func (t *templateCfg) GetEndpointNetNsCookie() uint64 {
 	return templateEndpointNetNsCookie
+}
+
+// GetVNIID returns a non-zero dummy VNI for the template object's load-time
+// configuration. It is not part of the template hash and is replaced with the
+// real endpoint value by endpointConfiguration when the object is loaded.
+func (t *templateCfg) GetVNIID() uint64 {
+	return templateNativeVPCVNI
 }
 
 // GetNodeMAC returns a well-known dummy MAC address which may be later

--- a/pkg/datapath/loader/template_test.go
+++ b/pkg/datapath/loader/template_test.go
@@ -5,7 +5,6 @@ package loader
 
 import (
 	"bytes"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -34,7 +33,7 @@ func TestWrap(t *testing.T) {
 	err = cfg.WriteTemplateConfig(&templateBuffer, &localNodeConfig, template)
 	require.NoError(t, err)
 	require.Equal(t, realEPBuffer.String(), templateBuffer.String())
-	require.False(t, strings.Contains(templateBuffer.String(), "NATIVE_VPC_VNI"),
+	require.NotContains(t, templateBuffer.String(), "NATIVE_VPC_VNI",
 		"VNI must be load-time .rodata.config data, not a template define")
 
 	// Runtime configuration must carry the real endpoint VNI, while the

--- a/pkg/datapath/loader/template_test.go
+++ b/pkg/datapath/loader/template_test.go
@@ -5,10 +5,12 @@ package loader
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	dpconfig "github.com/cilium/cilium/pkg/datapath/config"
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
@@ -19,13 +21,29 @@ func TestWrap(t *testing.T) {
 	)
 
 	realEP := testutils.NewTestEndpoint(t)
+	realEP.VNIID = 36
 	template := wrap(&realEP)
 	cfg := configWriterForTest(t)
 
-	// Write the configuration that should be the same, and verify it is.
+	// Compile-time header/template hash must be independent of VNI: one
+	// compiled bpf_lxc template serves all VPCs. The old implementation tried
+	// to emit NATIVE_VPC_VNI through a type assertion on templateCfg, which
+	// always failed because the wrapper only embedded CompileTimeConfiguration.
 	err := cfg.WriteTemplateConfig(&realEPBuffer, &localNodeConfig, &realEP)
 	require.NoError(t, err)
 	err = cfg.WriteTemplateConfig(&templateBuffer, &localNodeConfig, template)
 	require.NoError(t, err)
 	require.Equal(t, realEPBuffer.String(), templateBuffer.String())
+	require.False(t, strings.Contains(templateBuffer.String(), "NATIVE_VPC_VNI"),
+		"VNI must be load-time .rodata.config data, not a template define")
+
+	// Runtime configuration must carry the real endpoint VNI, while the
+	// template object uses a non-zero dummy value that the loader replaces.
+	realConfigs := endpointConfiguration(&realEP, &localNodeConfig)
+	require.Len(t, realConfigs, 1)
+	require.Equal(t, uint32(36), realConfigs[0].(*dpconfig.BPFLXC).NativeVpcVni)
+
+	templateConfigs := endpointConfiguration(template, &localNodeConfig)
+	require.Len(t, templateConfigs, 1)
+	require.Equal(t, uint32(templateNativeVPCVNI), templateConfigs[0].(*dpconfig.BPFLXC).NativeVpcVni)
 }

--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/callsmap"
 	"github.com/cilium/cilium/pkg/maps/cidrmap"
+	ipcachemap "github.com/cilium/cilium/pkg/maps/ipcache"
 	"github.com/cilium/cilium/pkg/maps/ipmasq"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/option"
@@ -202,6 +203,14 @@ func (ms *MapSweeper) RemoveDisabledMaps() {
 
 	if !ms.bwManager.Enabled() {
 		maps = append(maps, "cilium_throttle")
+	}
+
+	if !option.Config.EnableNativeVPC {
+		// The VNI-scoped ipcache only exists in native-vpc mode. Remove a stale
+		// pin left behind by a previous run with the mode enabled, so that a
+		// later re-enable starts from a clean map instead of inheriting entries
+		// of a previous VPC topology.
+		maps = append(maps, ipcachemap.VniName)
 	}
 
 	if !option.Config.EnableHealthDatapath {

--- a/pkg/datapath/types/config.go
+++ b/pkg/datapath/types/config.go
@@ -38,6 +38,12 @@ type LoadTimeConfiguration interface {
 	GetIfIndex() int
 	GetEndpointNetNsCookie() uint64
 
+	// GetVNIID returns the native-vpc VNI of the endpoint. A zero value means
+	// the endpoint uses the native (non-VPC) scheme. This is load-time data:
+	// templates are shared across VNIs and the loader rewrites the per-endpoint
+	// .rodata.config value when loading bpf_lxc.
+	GetVNIID() uint64
+
 	// GetPolicyVerdictLogFilter returns the PolicyVerdictLogFilter for the endpoint
 	GetPolicyVerdictLogFilter() uint32
 

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -88,7 +88,13 @@ func NewEndpointFromChangeModel(ctx context.Context, logger *slog.Logger, dnsRul
 	ep.K8sNamespace = model.K8sNamespace
 	ep.K8sUID = model.K8sUID
 	ep.disableLegacyIdentifiers = model.DisableLegacyIdentifiers
-	ep.VNIID = model.VniID
+	// Only honor the VNI carried in the API/CNI change request when native-vpc
+	// mode is enabled. Otherwise an external caller could set a VNI to opt into
+	// VNI-aware identifiers and conflict detection, bypassing the global IP
+	// uniqueness check.
+	if option.Config.EnableNativeVPC {
+		ep.VNIID = model.VniID
+	}
 
 	if model.Mac != "" {
 		m, err := mac.ParseMAC(model.Mac)

--- a/pkg/endpoint/api/endpoint_api_manager.go
+++ b/pkg/endpoint/api/endpoint_api_manager.go
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	"maps"
 	"net"
-	"strconv"
 	"sync"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,6 +35,7 @@ import (
 	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
+	"github.com/cilium/cilium/pkg/nativevpc"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/resiliency"
 	"github.com/cilium/cilium/pkg/time"
@@ -177,6 +177,15 @@ func (m *endpointAPIManager) CreateEndpoint(ctx context.Context, epTemplate *mod
 	m.endpointCreations.NewCreateRequest(ep, cancel)
 	defer m.endpointCreations.EndCreateRequest(ep)
 	nativeVPCEnabled := option.Config.EnableNativeVPC && option.Config.NativeVPCVNIAnnotation != ""
+	// The pod annotation is the single source of truth for the VNI. A value
+	// supplied through the API/CNI request is untrusted: it is only accepted if
+	// it matches what the annotation says (checked after the pod is fetched),
+	// so it can neither invent a VPC scope nor satisfy the mandatory-VNI gate
+	// when the annotation could not be read.
+	requestedVNI := ep.VNIID
+	if nativeVPCEnabled {
+		ep.VNIID = 0
+	}
 
 	identityLbls := maps.Clone(apiLabels)
 
@@ -227,8 +236,7 @@ func (m *endpointAPIManager) CreateEndpoint(ctx context.Context, epTemplate *mod
 
 			// For native-vpc mode, read VNI from Pod annotation before conflict detection.
 			if nativeVPCEnabled && pod != nil {
-				vniAnnotationKey := option.Config.NativeVPCVNIAnnotation
-				parsedVNI, err := parseVNIFromPod(pod, vniAnnotationKey, m.logger)
+				parsedVNI, err := parseVNIFromPod(pod, m.logger)
 				if err != nil {
 					return invalidDataError(ep, err)
 				}
@@ -278,6 +286,12 @@ func (m *endpointAPIManager) CreateEndpoint(ctx context.Context, epTemplate *mod
 
 	if err := requireVNI(nativeVPCEnabled, ep.VNIID, ep.IsHost(), ep.K8sNamespaceAndPodNameIsSet(), pod); err != nil {
 		return invalidDataError(ep, fmt.Errorf("native-vpc endpoint %s/%s: %w", ep.K8sNamespace, ep.K8sPodName, err))
+	}
+
+	if nativeVPCEnabled && requestedVNI != 0 && requestedVNI != ep.VNIID {
+		return invalidDataError(ep, fmt.Errorf(
+			"native-vpc endpoint %s/%s: requested VNI %d does not match the pod annotation %q (%d); the annotation is the single source of truth",
+			ep.K8sNamespace, ep.K8sPodName, requestedVNI, option.Config.NativeVPCVNIAnnotation, ep.VNIID))
 	}
 
 	// Build checkIDs for IP conflict detection
@@ -609,48 +623,33 @@ func requireVNI(nativeVPCEnabled bool, vni uint64, isHostEndpoint, isK8sPod bool
 	return fmt.Errorf("no VNI: the annotation %q was not applied", option.Config.NativeVPCVNIAnnotation)
 }
 
-// maxVNI mirrors endpoint.MaxVNI: the VNI space is 24 bits.
-const maxVNI = int64(endpoint.MaxVNI)
-
-// parseVNIFromPod extracts and validates the VNI from the Pod annotation.
-// parseVNIFromPod returns the VNI for the pod, or unsetVNI for hostNetwork
-// pods (they use the host network stack directly and are not part of any
-// overlay network, so VNI-based isolation does not apply).
+// parseVNIFromPod extracts and validates the VNI from the Pod annotation using
+// the single shared decision table (pkg/nativevpc), so that endpoint creation,
+// endpoint restore and the pod watcher can never disagree about a pod's scope.
 //
-// For any other pod a missing, empty, non-numeric or non-positive tunnel_key
-// annotation is an ERROR in native-vpc mode: the OVN subnet always carries a
-// non-zero tunnel key (kube-ovn waits for it before allocating pod IPs), so a
-// zero VNI means misconfiguration or an out-of-date kube-ovn. Returning an
-// error here rejects the endpoint instead of silently degrading to the plain
-// IP scheme, which would collide with overlapping VPC subnets and cause
-// non-deterministic policy verdicts ("部分可通").
-func parseVNIFromPod(pod *slim_corev1.Pod, vniAnnotationKey string, logger *slog.Logger) (int64, error) {
-	if pod.Spec.HostNetwork {
-		// Skip VNI for hostNetwork pods - they use host network stack directly,
-		// not overlay network, so VNI-based isolation is not applicable.
-		logger.Debug("Skipping VNI for hostNetwork pod",
+// It returns unsetVNI for hostNetwork pods (they use the host network stack
+// directly and are not part of any overlay network).
+//
+// For any other pod a missing, empty, non-numeric, zero or out-of-range
+// tunnel_key annotation is an ERROR in native-vpc mode: the OVN subnet always
+// carries a non-zero tunnel key (kube-ovn waits for it before allocating pod
+// IPs), so such a value means misconfiguration or an out-of-date kube-ovn.
+// Rejecting the endpoint here is deliberate: silently degrading to the plain
+// IP scheme would collide with overlapping VPC subnets and cause
+// non-deterministic policy verdicts.
+func parseVNIFromPod(pod *slim_corev1.Pod, logger *slog.Logger) (int64, error) {
+	vni, res, err := nativevpc.VNIFromPod(pod)
+	switch res {
+	case nativevpc.NotInVPC:
+		logger.Debug("Skipping VNI for pod that is not in any VPC",
 			logfields.K8sPodName, pod.Namespace+"/"+pod.Name,
 		)
 		return unsetVNI, nil
-	}
-
-	vniStr, ok := pod.Annotations[vniAnnotationKey]
-	if !ok || vniStr == "" {
+	case nativevpc.Absent:
 		return 0, fmt.Errorf("native-vpc pod %s/%s is missing tunnel_key annotation %q: a non-zero VNI is mandatory for every non-hostNetwork pod",
-			pod.Namespace, pod.Name, vniAnnotationKey)
+			pod.Namespace, pod.Name, option.Config.NativeVPCVNIAnnotation)
+	case nativevpc.Invalid:
+		return 0, fmt.Errorf("native-vpc pod %s/%s: %w", pod.Namespace, pod.Name, err)
 	}
-
-	// VNI annotation exists, parse it
-	parsedVNI, err := strconv.ParseInt(vniStr, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("invalid VNI annotation %q value %q: %w", vniAnnotationKey, vniStr, err)
-	}
-	if parsedVNI <= 0 {
-		return 0, fmt.Errorf("VNI annotation %q has invalid value %d", vniAnnotationKey, parsedVNI)
-	}
-	if parsedVNI > maxVNI {
-		return 0, fmt.Errorf("VNI annotation %q value %d exceeds maximum (%d)", vniAnnotationKey, parsedVNI, maxVNI)
-	}
-
-	return parsedVNI, nil
+	return int64(vni), nil
 }

--- a/pkg/endpoint/api/endpoint_api_manager.go
+++ b/pkg/endpoint/api/endpoint_api_manager.go
@@ -640,7 +640,7 @@ func requireVNI(nativeVPCEnabled bool, vni uint64, isHostEndpoint, isK8sPod bool
 func parseVNIFromPod(pod *slim_corev1.Pod, logger *slog.Logger) (int64, error) {
 	vni, res, err := nativevpc.VNIFromPod(pod)
 	switch res {
-	case nativevpc.NotInVPC:
+	case nativevpc.Disabled, nativevpc.HostNetwork:
 		logger.Debug("Skipping VNI for pod that is not in any VPC",
 			logfields.K8sPodName, pod.Namespace+"/"+pod.Name,
 		)

--- a/pkg/endpoint/api/endpoint_api_manager.go
+++ b/pkg/endpoint/api/endpoint_api_manager.go
@@ -276,6 +276,10 @@ func (m *endpointAPIManager) CreateEndpoint(ctx context.Context, epTemplate *mod
 		}
 	}
 
+	if err := requireVNI(nativeVPCEnabled, ep.VNIID, ep.IsHost(), ep.K8sNamespaceAndPodNameIsSet(), pod); err != nil {
+		return invalidDataError(ep, fmt.Errorf("native-vpc endpoint %s/%s: %w", ep.K8sNamespace, ep.K8sPodName, err))
+	}
+
 	// Build checkIDs for IP conflict detection
 	// For native-vpc mode with VNI, use VNI-aware identifier (vni-ipv4:<vni>:<ip>)
 	// Otherwise, use original IP-only identifier (ipv4:<ip>)
@@ -573,6 +577,37 @@ func (m *endpointAPIManager) ModifyEndpointIdentityLabelsFromAPI(id string, add,
 }
 
 const unsetVNI = int64(-1)
+
+// requireVNI enforces the native-vpc control-plane invariant: every endpoint
+// of a non-hostNetwork Kubernetes pod must have a VNI by the time it is
+// created.
+//
+// The VNI can only be read from the pod annotation. If the pod store and the
+// apiserver were both unavailable, the Kubernetes block of CreateEndpoint is
+// skipped with a warning, and the endpoint would otherwise be created on the
+// plain-IP scheme: registered under the bare "ipv4:" identifier (colliding
+// with the same IP in another VPC), without the VNI identity label, with
+// CONFIG(native_vpc_vni)=0 in bpf_lxc and without any VNI-scoped ipcache
+// entry. That is exactly the non-deterministic "partially reachable" state
+// this mode exists to prevent, so the endpoint is rejected instead and the CNI
+// ADD is retried by the kubelet.
+//
+// Endpoints that are not Kubernetes pods (host endpoint, ingress endpoint,
+// non-k8s workloads) are not in any VPC and keep VNI 0.
+func requireVNI(nativeVPCEnabled bool, vni uint64, isHostEndpoint, isK8sPod bool, pod *slim_corev1.Pod) error {
+	if !nativeVPCEnabled || vni > 0 || isHostEndpoint || !isK8sPod {
+		return nil
+	}
+	if pod != nil && pod.Spec.HostNetwork {
+		// hostNetwork pods use the host stack and are not in any VPC.
+		return nil
+	}
+	if pod == nil {
+		return fmt.Errorf("no VNI: pod metadata is unavailable, so the annotation %q could not be read",
+			option.Config.NativeVPCVNIAnnotation)
+	}
+	return fmt.Errorf("no VNI: the annotation %q was not applied", option.Config.NativeVPCVNIAnnotation)
+}
 
 // maxVNI mirrors endpoint.MaxVNI: the VNI space is 24 bits.
 const maxVNI = int64(endpoint.MaxVNI)

--- a/pkg/endpoint/api/endpoint_api_manager.go
+++ b/pkg/endpoint/api/endpoint_api_manager.go
@@ -240,6 +240,10 @@ func (m *endpointAPIManager) CreateEndpoint(ctx context.Context, epTemplate *mod
 						logfields.VNIID, ep.VNIID,
 					)
 				} else {
+					// Only reachable for hostNetwork pods (parseVNIFromPod returns
+					// unsetVNI for them); any other missing/invalid VNI is an error
+					// propagated by parseVNIFromPod above. VNIID=0 keeps hostNetwork
+					// endpoints on the plain-IP scheme (they are not in any VPC).
 					ep.VNIID = 0
 				}
 			}
@@ -569,11 +573,22 @@ func (m *endpointAPIManager) ModifyEndpointIdentityLabelsFromAPI(id string, add,
 }
 
 const unsetVNI = int64(-1)
-const maxVNI = (1 << 24) - 1
+
+// maxVNI mirrors endpoint.MaxVNI: the VNI space is 24 bits.
+const maxVNI = int64(endpoint.MaxVNI)
 
 // parseVNIFromPod extracts and validates the VNI from the Pod annotation.
-// Returns unsetVNI if no VNI annotation is present or if the Pod is using host networking.
-// Returns an error if the annotation value is invalid or not greater than 0.
+// parseVNIFromPod returns the VNI for the pod, or unsetVNI for hostNetwork
+// pods (they use the host network stack directly and are not part of any
+// overlay network, so VNI-based isolation does not apply).
+//
+// For any other pod a missing, empty, non-numeric or non-positive tunnel_key
+// annotation is an ERROR in native-vpc mode: the OVN subnet always carries a
+// non-zero tunnel key (kube-ovn waits for it before allocating pod IPs), so a
+// zero VNI means misconfiguration or an out-of-date kube-ovn. Returning an
+// error here rejects the endpoint instead of silently degrading to the plain
+// IP scheme, which would collide with overlapping VPC subnets and cause
+// non-deterministic policy verdicts ("部分可通").
 func parseVNIFromPod(pod *slim_corev1.Pod, vniAnnotationKey string, logger *slog.Logger) (int64, error) {
 	if pod.Spec.HostNetwork {
 		// Skip VNI for hostNetwork pods - they use host network stack directly,
@@ -585,8 +600,9 @@ func parseVNIFromPod(pod *slim_corev1.Pod, vniAnnotationKey string, logger *slog
 	}
 
 	vniStr, ok := pod.Annotations[vniAnnotationKey]
-	if !ok {
-		return unsetVNI, nil
+	if !ok || vniStr == "" {
+		return 0, fmt.Errorf("native-vpc pod %s/%s is missing tunnel_key annotation %q: a non-zero VNI is mandatory for every non-hostNetwork pod",
+			pod.Namespace, pod.Name, vniAnnotationKey)
 	}
 
 	// VNI annotation exists, parse it

--- a/pkg/endpoint/api/endpoint_api_manager_test.go
+++ b/pkg/endpoint/api/endpoint_api_manager_test.go
@@ -170,8 +170,20 @@ func TestParseVNIFromPod(t *testing.T) {
 					},
 				},
 			},
-			key:         vniKey,
-			expectedVNI: unsetVNI,
+			key:           vniKey,
+			expectedError: `native-vpc pod / is missing tunnel_key annotation "your-cni.io/vni": a non-zero VNI is mandatory for every non-hostNetwork pod`,
+		},
+		{
+			name: "Empty annotation value",
+			pod: &slim_corev1.Pod{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Annotations: map[string]string{
+						vniKey: "",
+					},
+				},
+			},
+			key:           vniKey,
+			expectedError: `native-vpc pod / is missing tunnel_key annotation "your-cni.io/vni": a non-zero VNI is mandatory for every non-hostNetwork pod`,
 		},
 		{
 			name: "Valid VNI",

--- a/pkg/endpoint/api/endpoint_api_manager_test.go
+++ b/pkg/endpoint/api/endpoint_api_manager_test.go
@@ -19,6 +19,7 @@ import (
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/labelsfilter"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 )
 
@@ -257,6 +258,52 @@ func TestParseVNIFromPod(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expectedVNI, vni)
 			}
+		})
+	}
+}
+
+// TestRequireVNI pins the native-vpc control-plane invariant: an endpoint of a
+// non-hostNetwork Kubernetes pod must never be created without a VNI, in
+// particular when the pod metadata could not be fetched (that path only logs a
+// warning and would otherwise fall back to the plain-IP scheme).
+func TestRequireVNI(t *testing.T) {
+	prev := option.Config.NativeVPCVNIAnnotation
+	option.Config.NativeVPCVNIAnnotation = "ovn.kubernetes.io/tunnel_key"
+	t.Cleanup(func() { option.Config.NativeVPCVNIAnnotation = prev })
+
+	hostNetworkPod := &slim_corev1.Pod{Spec: slim_corev1.PodSpec{HostNetwork: true}}
+	pod := &slim_corev1.Pod{}
+
+	for _, tc := range []struct {
+		name      string
+		nativeVPC bool
+		vni       uint64
+		isHost    bool
+		isK8sPod  bool
+		pod       *slim_corev1.Pod
+		wantErr   string
+	}{
+		{name: "native-vpc disabled", isK8sPod: true, pod: pod},
+		{name: "vni resolved", nativeVPC: true, vni: 36, isK8sPod: true, pod: pod},
+		{name: "host endpoint", nativeVPC: true, isHost: true},
+		{name: "not a k8s pod", nativeVPC: true},
+		{name: "hostNetwork pod", nativeVPC: true, isK8sPod: true, pod: hostNetworkPod},
+		{
+			name: "pod metadata unavailable", nativeVPC: true, isK8sPod: true, pod: nil,
+			wantErr: "pod metadata is unavailable",
+		},
+		{
+			name: "pod without annotation", nativeVPC: true, isK8sPod: true, pod: pod,
+			wantErr: "was not applied",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := requireVNI(tc.nativeVPC, tc.vni, tc.isHost, tc.isK8sPod, tc.pod)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tc.wantErr)
 		})
 	}
 }

--- a/pkg/endpoint/api/endpoint_api_manager_test.go
+++ b/pkg/endpoint/api/endpoint_api_manager_test.go
@@ -140,6 +140,14 @@ func TestParseVNIFromPod(t *testing.T) {
 	logger := hivetest.Logger(t)
 	vniKey := "your-cni.io/vni"
 
+	// The shared parser (pkg/nativevpc) is config driven.
+	prevEnabled, prevKey := option.Config.EnableNativeVPC, option.Config.NativeVPCVNIAnnotation
+	option.Config.EnableNativeVPC = true
+	t.Cleanup(func() {
+		option.Config.EnableNativeVPC = prevEnabled
+		option.Config.NativeVPCVNIAnnotation = prevKey
+	})
+
 	tests := []struct {
 		name          string
 		pod           *slim_corev1.Pod
@@ -208,7 +216,7 @@ func TestParseVNIFromPod(t *testing.T) {
 				},
 			},
 			key:           vniKey,
-			expectedError: `invalid VNI annotation "your-cni.io/vni" value "abc": strconv.ParseInt: parsing "abc": invalid syntax`,
+			expectedError: `native-vpc pod /: annotation "your-cni.io/vni" value "abc" is not a number: strconv.ParseUint: parsing "abc": invalid syntax`,
 		},
 		{
 			name: "Invalid VNI (zero)",
@@ -220,7 +228,7 @@ func TestParseVNIFromPod(t *testing.T) {
 				},
 			},
 			key:           vniKey,
-			expectedError: `VNI annotation "your-cni.io/vni" has invalid value 0`,
+			expectedError: `native-vpc pod /: annotation "your-cni.io/vni" is 0: kube-ovn only ever writes a non-zero tunnel_key`,
 		},
 		{
 			name: "Invalid VNI (negative)",
@@ -232,7 +240,7 @@ func TestParseVNIFromPod(t *testing.T) {
 				},
 			},
 			key:           vniKey,
-			expectedError: `VNI annotation "your-cni.io/vni" has invalid value -1`,
+			expectedError: `native-vpc pod /: annotation "your-cni.io/vni" value "-1" is not a number: strconv.ParseUint: parsing "-1": invalid syntax`,
 		},
 		{
 			name: "Invalid VNI (exceeds max)",
@@ -244,13 +252,14 @@ func TestParseVNIFromPod(t *testing.T) {
 				},
 			},
 			key:           vniKey,
-			expectedError: `VNI annotation "your-cni.io/vni" value 16777216 exceeds maximum (16777215)`,
+			expectedError: `native-vpc pod /: annotation "your-cni.io/vni" value 16777216 exceeds the maximum VNI (16777215)`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			vni, err := parseVNIFromPod(tt.pod, tt.key, logger)
+			option.Config.NativeVPCVNIAnnotation = tt.key
+			vni, err := parseVNIFromPod(tt.pod, logger)
 			if tt.expectedError != "" {
 				assert.Error(t, err)
 				assert.EqualError(t, err, tt.expectedError)

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -44,6 +44,7 @@ type epInfoCache struct {
 	ifIndex                int
 	parentIfIndex          int
 	netNsCookie            uint64
+	vniID                  uint64
 	properties             map[string]any
 
 	// endpoint is used to get the endpoint's logger.
@@ -68,6 +69,7 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 			ipv4:       e.IPv4Address(),
 			ipv6:       e.IPv6Address(),
 			atHostNS:   true,
+			vniID:      e.GetVNIID(),
 			properties: maps.Clone(e.properties),
 
 			endpoint: e,
@@ -93,6 +95,7 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 		ifIndex:                e.ifIndex,
 		parentIfIndex:          e.parentIfIndex,
 		netNsCookie:            e.NetNsCookie,
+		vniID:                  e.GetVNIID(),
 		properties:             maps.Clone(e.properties),
 
 		endpoint: e,
@@ -101,6 +104,10 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 
 func (ep *epInfoCache) GetIfIndex() int {
 	return ep.ifIndex
+}
+
+func (ep *epInfoCache) GetVNIID() uint64 {
+	return ep.vniID
 }
 
 func (ep *epInfoCache) GetParentIfIndex() int {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -869,18 +869,23 @@ const legacyVPCLabelSource = "vpc"
 // (option.Config.NativeVPCVNIAnnotation) and returns whether it changed.
 //
 // Decision table (the annotation is the single source of truth):
-//   - annotation absent   -> native scheme (VNIID = 0). This is the normal
-//     case for hostNetwork pods and non-OVN (e.g. vlan) subnets, which are
-//     never part of an overlay VPC. kube-ovn guarantees that every
-//     non-hostNetwork OVN pod carries a non-zero tunnel_key before CNI ADD,
-//     so an absent annotation on an OVN pod only occurs for legacy pods that
-//     predate the kube-ovn backfill.
+//   - annotation absent   -> native scheme (VNIID = 0) **only for an endpoint
+//     that has no VNI yet**. This is the normal case for hostNetwork pods and
+//     non-OVN (e.g. vlan) subnets, which are never part of an overlay VPC.
+//     kube-ovn guarantees that every non-hostNetwork OVN pod carries a
+//     non-zero tunnel_key before CNI ADD, so an absent annotation on an OVN
+//     pod only occurs for legacy pods that predate the kube-ovn backfill, for
+//     a stale pod object, or for an operator/kube-ovn error.
 //   - annotation present, valid (> 0, <= MaxVNI) -> VNIID = the value.
-//   - annotation present, 0 or unparsable/out-of-range -> ERROR. A zero
-//     tunnel_key violates the kube-ovn guarantee (kube-ovn never writes 0;
-//     its allocation gate and backfill only ever persist a non-zero key). The
-//     endpoint falls back to the native scheme (VNIID = 0) and the operator
-//     must investigate the kube-ovn side.
+//   - annotation present, 0 or unparsable/out-of-range -> ERROR.
+//
+// A non-zero VNI is never downgraded to 0 by a missing or broken annotation:
+// dropping the VNI would move the endpoint into the shared plain-IP scope,
+// where it collides with the same IP in another VPC and gets a foreign
+// identity - the exact failure this mode prevents. Keeping the last known VNI
+// is the fail-closed direction (at worst the endpoint stays isolated), and the
+// condition is reported as an error. A pod that legitimately leaves a VPC is
+// recreated by kube-ovn, which creates a new endpoint.
 //
 // Fallback strategy: if a running pod is ever missing its tunnel_key
 // annotation, restart kube-ovn-controller first (its init flow backfills the
@@ -906,7 +911,13 @@ func (e *Endpoint) SyncVNIFromPodAnnotation(pod *slim_corev1.Pod) bool {
 		parsed uint64
 		valid  bool
 		broken bool // annotation present but 0 / unparsable / out of range
+		// hostNetwork is an immutable, structural "not in any VPC" signal, as
+		// opposed to an annotation that can transiently disappear.
+		hostNetwork bool
 	)
+	if pod != nil && pod.Spec.HostNetwork {
+		hostNetwork = true
+	}
 	if pod != nil && !pod.Spec.HostNetwork {
 		if vniStr, ok := pod.Annotations[option.Config.NativeVPCVNIAnnotation]; ok {
 			if v, err := strconv.ParseUint(strings.TrimSpace(vniStr), 10, 64); err == nil && v > 0 && v <= MaxVNI {
@@ -919,7 +930,7 @@ func (e *Endpoint) SyncVNIFromPodAnnotation(pod *slim_corev1.Pod) bool {
 
 	if broken {
 		e.getLogger().Error(
-			"Invalid tunnel_key annotation on native-vpc pod (violates the kube-ovn guarantee: only a non-zero key is ever written); falling back to the native (non-VPC) scheme",
+			"Invalid tunnel_key annotation on native-vpc pod (violates the kube-ovn guarantee: only a non-zero key is ever written)",
 			logfields.K8sPodName, pod.Namespace+"/"+pod.Name,
 			logfields.Annotation, pod.Annotations[option.Config.NativeVPCVNIAnnotation],
 		)
@@ -929,10 +940,23 @@ func (e *Endpoint) SyncVNIFromPodAnnotation(pod *slim_corev1.Pod) bool {
 	defer e.unlock()
 
 	// Decision table: absent -> native (0); present+valid -> parsed;
-	// present+broken -> native (0) with the error logged above.
+	// present+broken -> keep the current scope with the error logged above.
 	newVNI := uint64(0)
 	if valid {
 		newVNI = parsed
+	}
+
+	// Never downgrade a VPC endpoint into the shared plain-IP scope because the
+	// annotation is missing or broken: that would merge it with the same IP in
+	// another VPC. Keep the last known VNI and report. A hostNetwork pod is the
+	// one authoritative "no VPC" signal and may reset the scope.
+	if newVNI == 0 && e.VNIID != 0 && !hostNetwork {
+		e.getLogger().Error(
+			"Native-vpc pod has no usable tunnel_key annotation; keeping the last known VNI to preserve VPC isolation",
+			logfields.VNIID, e.VNIID,
+			logfields.K8sPodName, e.GetK8sNamespaceAndPodName(),
+		)
+		return false
 	}
 
 	// VNI is an identity/datapath dimension. Once an endpoint is ready, changing

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -54,6 +54,7 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	monitoragent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/monitor/notifications"
+	"github.com/cilium/cilium/pkg/nativevpc"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
@@ -855,7 +856,10 @@ func (e *Endpoint) GetVNIID() uint64 {
 
 // MaxVNI is the upper bound for native-vpc VNI (Virtual Network Identifier)
 // values: the VNI space is 24 bits (VXLAN/Geneve VNI).
-const MaxVNI = uint64(1<<24) - 1
+// MaxVNI is the upper bound for native-vpc VNI (Virtual Network Identifier)
+// values. It is an alias of nativevpc.MaxVNI, which is the single definition
+// of the native-vpc annotation semantics.
+const MaxVNI = nativevpc.MaxVNI
 
 // legacyVPCLabelSource was used by the initial native-vpc implementation to
 // encode a subnet VNI as "vpc:vpc=<vni>". This was semantically wrong: VPC is
@@ -914,23 +918,22 @@ func (e *Endpoint) SyncVNIFromPodAnnotation(pod *slim_corev1.Pod) bool {
 		// hostNetwork is an immutable, structural "not in any VPC" signal, as
 		// opposed to an annotation that can transiently disappear.
 		hostNetwork bool
+		parseErr    error
 	)
-	if pod != nil && pod.Spec.HostNetwork {
-		hostNetwork = true
-	}
-	if pod != nil && !pod.Spec.HostNetwork {
-		if vniStr, ok := pod.Annotations[option.Config.NativeVPCVNIAnnotation]; ok {
-			if v, err := strconv.ParseUint(strings.TrimSpace(vniStr), 10, 64); err == nil && v > 0 && v <= MaxVNI {
-				parsed, valid = v, true
-			} else {
-				broken = true
-			}
-		}
+	vni, res, err := nativevpc.VNIFromPod(pod)
+	switch res {
+	case nativevpc.Valid:
+		parsed, valid = vni, true
+	case nativevpc.Invalid:
+		broken, parseErr = true, err
+	case nativevpc.NotInVPC:
+		hostNetwork = pod != nil && pod.Spec.HostNetwork
 	}
 
 	if broken {
 		e.getLogger().Error(
 			"Invalid tunnel_key annotation on native-vpc pod (violates the kube-ovn guarantee: only a non-zero key is ever written)",
+			logfields.Error, parseErr,
 			logfields.K8sPodName, pod.Namespace+"/"+pod.Name,
 			logfields.Annotation, pod.Annotations[option.Config.NativeVPCVNIAnnotation],
 		)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -853,6 +853,109 @@ func (e *Endpoint) GetVNIID() uint64 {
 	return e.VNIID
 }
 
+// MaxVNI is the upper bound for native-vpc VNI (Virtual Network Identifier)
+// values: the VNI space is 24 bits (VXLAN/Geneve VNI).
+const MaxVNI = uint64(1<<24) - 1
+
+// legacyVPCLabelSource was used by the initial native-vpc implementation to
+// encode a subnet VNI as "vpc:vpc=<vni>". This was semantically wrong: VPC is
+// an aggregate object and its subnets can carry different VNIs. Remove labels
+// from this source during metadata reconciliation so restored endpoints
+// converge to the VNI-scoped label.
+const legacyVPCLabelSource = "vpc"
+
+// SyncVNIFromPodAnnotation refreshes the endpoint's native-vpc VNI (VNIID)
+// from the pod's tunnel_key annotation
+// (option.Config.NativeVPCVNIAnnotation) and returns whether it changed.
+//
+// Decision table (the annotation is the single source of truth):
+//   - annotation absent   -> native scheme (VNIID = 0). This is the normal
+//     case for hostNetwork pods and non-OVN (e.g. vlan) subnets, which are
+//     never part of an overlay VPC. kube-ovn guarantees that every
+//     non-hostNetwork OVN pod carries a non-zero tunnel_key before CNI ADD,
+//     so an absent annotation on an OVN pod only occurs for legacy pods that
+//     predate the kube-ovn backfill.
+//   - annotation present, valid (> 0, <= MaxVNI) -> VNIID = the value.
+//   - annotation present, 0 or unparsable/out-of-range -> ERROR. A zero
+//     tunnel_key violates the kube-ovn guarantee (kube-ovn never writes 0;
+//     its allocation gate and backfill only ever persist a non-zero key). The
+//     endpoint falls back to the native scheme (VNIID = 0) and the operator
+//     must investigate the kube-ovn side.
+//
+// Fallback strategy: if a running pod is ever missing its tunnel_key
+// annotation, restart kube-ovn-controller first (its init flow backfills the
+// tunnel_key annotations, see InitIPAM/enqueuePodTunnelKeyRepair in
+// kube-ovn), then restart cilium. The restart re-runs this sync and
+// re-flushes the resources tied to the tunnel_key+IP pair on all three
+// planes:
+//   - control plane: the VNI identity label (metadataResolver re-injects
+//     it) and the endpoint identifier index (validateEndpoint syncs VNIID
+//     before expose);
+//   - cache plane: the local ipcache registration via the identity sync
+//     (runIPIdentitySync reads VNIID fresh on every run) and the pod watcher's
+//     VNI-scoped entries (podVNI re-reads the annotation on pod updates);
+//   - forwarding plane: endpoint reload rewrites the per-endpoint
+//     CONFIG(native_vpc_vni) value in bpf_lxc and the ipcache listener writes
+//     cilium_ipcache_vni entries.
+func (e *Endpoint) SyncVNIFromPodAnnotation(pod *slim_corev1.Pod) bool {
+	if !option.Config.EnableNativeVPC || option.Config.NativeVPCVNIAnnotation == "" {
+		return false
+	}
+
+	var (
+		parsed uint64
+		valid  bool
+		broken bool // annotation present but 0 / unparsable / out of range
+	)
+	if pod != nil && !pod.Spec.HostNetwork {
+		if vniStr, ok := pod.Annotations[option.Config.NativeVPCVNIAnnotation]; ok {
+			if v, err := strconv.ParseUint(strings.TrimSpace(vniStr), 10, 64); err == nil && v > 0 && v <= MaxVNI {
+				parsed, valid = v, true
+			} else {
+				broken = true
+			}
+		}
+	}
+
+	if broken {
+		e.getLogger().Error(
+			"Invalid tunnel_key annotation on native-vpc pod (violates the kube-ovn guarantee: only a non-zero key is ever written); falling back to the native (non-VPC) scheme",
+			logfields.K8sPodName, pod.Namespace+"/"+pod.Name,
+			logfields.Annotation, pod.Annotations[option.Config.NativeVPCVNIAnnotation],
+		)
+	}
+
+	e.unconditionalLock()
+	defer e.unlock()
+
+	// Decision table: absent -> native (0); present+valid -> parsed;
+	// present+broken -> native (0) with the error logged above.
+	newVNI := uint64(0)
+	if valid {
+		newVNI = parsed
+	}
+
+	// VNI is an identity/datapath dimension. Once an endpoint is ready, changing
+	// it without coordinating endpointmanager references, ipcache/kvstore,
+	// policy regeneration, and the loaded BPF configuration would leave a
+	// split-brain identity chain. Runtime annotation changes therefore do not
+	// hot-update an exposed endpoint; restore/recreation is the convergence
+	// mechanism documented by native-vpc.rst.
+	if e.getState() == StateReady {
+		if e.VNIID != newVNI {
+			e.getLogger().Warn("Ignoring native-vpc VNI drift on ready endpoint; recreate or restore the endpoint to converge",
+				logfields.VNIID, e.VNIID,
+				logfields.K8sPodName, e.GetK8sNamespaceAndPodName())
+		}
+		return false
+	}
+	if e.VNIID != newVNI {
+		e.VNIID = newVNI
+		return true
+	}
+	return false
+}
+
 // StringID returns the endpoint's ID in a string.
 func (e *Endpoint) StringID() string {
 	return strconv.Itoa(int(e.ID))
@@ -1913,6 +2016,22 @@ func (e *Endpoint) metadataResolver(ctx context.Context,
 
 	e.SetPod(pod)
 	e.SetK8sMetadata(k8sMetadata.ContainerPorts)
+
+	// Native-vpc: keep the endpoint's VNI converged with the pod's tunnel_key
+	// annotation (decision table in SyncVNIFromPodAnnotation: absent -> native
+	// scheme; valid non-zero -> VNIID; zero/invalid -> error + native
+	// fallback). If it changed, the updated VNIID flows into the VNI identity
+	// label below (control plane), the local ipcache registration via the
+	// identity sync (cache plane), and the CONFIG(native_vpc_vni) load-time
+	// datapath value on endpoint reload (forwarding plane). This is the
+	// control-plane half of the
+	// fallback sequence (restart kube-ovn-controller, then restart cilium)
+	// documented in the native-vpc design page.
+	if e.SyncVNIFromPodAnnotation(pod) {
+		e.Logger(resolveLabels).Info("Native-vpc VNI updated from pod annotation",
+			logfields.VNIID, e.GetVNIID())
+	}
+
 	e.UpdateNoTrackRules(func() string {
 		value, _ := annotation.Get(pod, annotation.NoTrack, annotation.NoTrackAlias)
 		return value
@@ -1939,7 +2058,39 @@ func (e *Endpoint) metadataResolver(ctx context.Context,
 	if len(baseLabels) != 0 {
 		source = labels.LabelSourceAny
 	}
-	regenTriggered = e.UpdateLabels(ctx, source, controllerBaseLabels, k8sMetadata.InfoLabels, blocking)
+
+	// Inject/refresh the VNI identity label so the identity/policy plane
+	// carries the same subnet/logical-switch VNI scope as the (VNI, IP)
+	// ipcache/datapath key. VNI is deliberately not called VPC here: one
+	// kube-ovn VPC can aggregate several subnets with different VNIs.
+	labelsRemoved := false
+	if option.Config.EnableNativeVPC {
+		// Remove the semantically-wrong legacy "vpc:vpc=<vni>" label on
+		// upgrade. Also remove the current VNI label when VNI resets to 0.
+		// These are real removals (not ModifyIdentityLabels, whose delete moves
+		// labels to Disabled and would block a later 0->N recovery).
+		e.unconditionalLock()
+		if e.replaceIdentityLabels(legacyVPCLabelSource, labels.Labels{}) != 0 {
+			labelsRemoved = true
+		}
+		if e.GetVNIID() == 0 && e.replaceIdentityLabels(labels.LabelSourceVNI, labels.Labels{}) != 0 {
+			labelsRemoved = true
+		}
+		e.unlock()
+
+		if vni := e.GetVNIID(); vni > 0 {
+			controllerBaseLabels.MergeLabels(labels.Labels{
+				labels.VNIKey: labels.NewLabel(labels.VNIKey, strconv.FormatUint(vni, 10), labels.LabelSourceVNI),
+			})
+		}
+	}
+
+	updateTriggered := e.UpdateLabels(ctx, source, controllerBaseLabels, k8sMetadata.InfoLabels, blocking)
+	if labelsRemoved && !updateTriggered {
+		e.Logger(resolveLabels).Info("Removed stale VPC/VNI identity label during VNI reconciliation")
+		regenTriggered = e.runIdentityResolver(ctx, blocking, 0)
+	}
+	regenTriggered = updateTriggered || regenTriggered
 
 	// If SIP setting changed but UpdateLabels did not trigger regeneration (e.g., during
 	// endpoint restore or when identity labels are unchanged), we must explicitly trigger

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -976,6 +976,25 @@ func (e *Endpoint) SyncVNIFromPodAnnotation(pod *slim_corev1.Pod) bool {
 		}
 		return false
 	}
+
+	// The same reasoning applies before the endpoint is exposed, with one
+	// exception. Taking a scope for the first time (0 -> N) is the kube-ovn
+	// backfill this re-read exists for: nothing derives from a scope that does
+	// not exist yet. Moving between two scopes is different - the identity
+	// label, the numeric identity, the CiliumEndpoint annotation other nodes
+	// read and the loaded datapath configuration all derive from the VNI, and
+	// none of them is re-derived here. Adopting the new scope would publish the
+	// address in a VPC while the endpoint's identity still says another one, so
+	// the endpoint keeps the scope it was admitted with and a recreation is
+	// what moves a pod between VPCs. A hostNetwork pod is exempt for the same
+	// reason it may reset the scope at all: it is a structural signal, not an
+	// annotation that drifted.
+	if !hostNetwork && e.VNIID != 0 && newVNI != e.VNIID {
+		e.getLogger().Warn("Ignoring native-vpc VNI change on an existing endpoint; recreate the pod to move it between VPCs",
+			logfields.VNIID, e.VNIID,
+			logfields.K8sPodName, e.GetK8sNamespaceAndPodName())
+		return false
+	}
 	if e.VNIID != newVNI {
 		e.VNIID = newVNI
 		return true

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -907,27 +907,27 @@ const legacyVPCLabelSource = "vpc"
 //     CONFIG(native_vpc_vni) value in bpf_lxc and the ipcache listener writes
 //     cilium_ipcache_vni entries.
 func (e *Endpoint) SyncVNIFromPodAnnotation(pod *slim_corev1.Pod) bool {
-	if !option.Config.EnableNativeVPC || option.Config.NativeVPCVNIAnnotation == "" {
-		return false
-	}
-
 	var (
 		parsed uint64
 		valid  bool
 		broken bool // annotation present but 0 / unparsable / out of range
 		// hostNetwork is an immutable, structural "not in any VPC" signal, as
-		// opposed to an annotation that can transiently disappear.
+		// opposed to an annotation that can transiently disappear. It comes
+		// from the shared decision table, never from a second reading of the
+		// pod here.
 		hostNetwork bool
 		parseErr    error
 	)
 	vni, res, err := nativevpc.VNIFromPod(pod)
 	switch res {
+	case nativevpc.Disabled:
+		return false
 	case nativevpc.Valid:
 		parsed, valid = vni, true
 	case nativevpc.Invalid:
 		broken, parseErr = true, err
-	case nativevpc.NotInVPC:
-		hostNetwork = pod != nil && pod.Spec.HostNetwork
+	case nativevpc.HostNetwork:
+		hostNetwork = true
 	}
 
 	if broken {

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -516,13 +516,15 @@ func TestSyncVNIFromPodAnnotation(t *testing.T) {
 		require.Equal(t, uint64(36), ep.GetVNIID())
 	})
 
-	t.Run("missing annotation resolves to native scheme", func(t *testing.T) {
+	t.Run("missing annotation keeps the last known VNI", func(t *testing.T) {
 		ep := newEndpoint()
+		ep.logger.Store(hivetest.Logger(t))
 		ep.VNIID = 36
-		require.True(t, ep.SyncVNIFromPodAnnotation(&corev1.Pod{
+		require.False(t, ep.SyncVNIFromPodAnnotation(&corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", Annotations: map[string]string{}},
 		}))
-		require.Zero(t, ep.GetVNIID(), "absent annotation follows cilium native logic (plain IP scheme)")
+		require.Equal(t, uint64(36), ep.GetVNIID(),
+			"downgrading to the plain scheme would merge the endpoint with the same IP in another VPC")
 	})
 
 	t.Run("missing annotation with VNI 0 is a no-op", func(t *testing.T) {
@@ -533,34 +535,30 @@ func TestSyncVNIFromPodAnnotation(t *testing.T) {
 		require.Zero(t, ep.GetVNIID())
 	})
 
-	t.Run("zero annotation is an error and falls back to native", func(t *testing.T) {
-		ep := newEndpoint()
-		ep.logger.Store(hivetest.Logger(t))
-		ep.VNIID = 36
-		require.True(t, ep.SyncVNIFromPodAnnotation(podWith("0", false)))
-		require.Zero(t, ep.GetVNIID(), "a zero tunnel_key violates the kube-ovn guarantee; fall back to native")
-	})
+	for _, broken := range []string{"0", "abc", "16777216"} {
+		t.Run("broken annotation "+broken+" keeps the last known VNI", func(t *testing.T) {
+			ep := newEndpoint()
+			ep.logger.Store(hivetest.Logger(t))
+			ep.VNIID = 36
+			require.False(t, ep.SyncVNIFromPodAnnotation(podWith(broken, false)))
+			require.Equal(t, uint64(36), ep.GetVNIID(),
+				"a broken tunnel_key is reported, but must not merge the endpoint into the plain scope")
+		})
 
-	t.Run("invalid annotation is an error and falls back to native", func(t *testing.T) {
-		ep := newEndpoint()
-		ep.logger.Store(hivetest.Logger(t))
-		ep.VNIID = 36
-		require.True(t, ep.SyncVNIFromPodAnnotation(podWith("abc", false)))
-		require.Zero(t, ep.GetVNIID())
-	})
-
-	t.Run("out-of-range annotation is an error and falls back to native", func(t *testing.T) {
-		ep := newEndpoint()
-		ep.logger.Store(hivetest.Logger(t))
-		ep.VNIID = 36
-		require.True(t, ep.SyncVNIFromPodAnnotation(podWith("16777216", false)))
-		require.Zero(t, ep.GetVNIID())
-	})
+		t.Run("broken annotation "+broken+" on a fresh endpoint stays native", func(t *testing.T) {
+			ep := newEndpoint()
+			ep.logger.Store(hivetest.Logger(t))
+			require.False(t, ep.SyncVNIFromPodAnnotation(podWith(broken, false)))
+			require.Zero(t, ep.GetVNIID())
+		})
+	}
 
 	t.Run("hostNetwork pod resolves to native scheme without error", func(t *testing.T) {
 		ep := newEndpoint()
+		ep.logger.Store(hivetest.Logger(t))
 		ep.VNIID = 36
-		require.True(t, ep.SyncVNIFromPodAnnotation(podWith("36", true)))
+		require.True(t, ep.SyncVNIFromPodAnnotation(podWith("36", true)),
+			"hostNetwork is an authoritative not-in-any-VPC signal and may reset the scope")
 		require.Zero(t, ep.GetVNIID())
 	})
 

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -477,6 +477,143 @@ func TestApplySourceIPVerificationResetsToGlobalDefault(t *testing.T) {
 		"Invalid annotation should reset to global default (Enabled)")
 }
 
+func TestSyncVNIFromPodAnnotation(t *testing.T) {
+	// Save original config and restore after test.
+	oldEnable := option.Config.EnableNativeVPC
+	oldAnnot := option.Config.NativeVPCVNIAnnotation
+	t.Cleanup(func() {
+		option.Config.EnableNativeVPC = oldEnable
+		option.Config.NativeVPCVNIAnnotation = oldAnnot
+	})
+	option.Config.EnableNativeVPC = true
+	option.Config.NativeVPCVNIAnnotation = "ovn.kubernetes.io/tunnel_key"
+
+	// A zero-value Endpoint is enough: SyncVNIFromPodAnnotation only touches
+	// option.Config and e.VNIID under the (zero-value usable) mutex.
+	newEndpoint := func() *Endpoint { return &Endpoint{} }
+
+	podWith := func(vni string, hostNetwork bool) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-pod",
+				Namespace:   "default",
+				Annotations: map[string]string{"ovn.kubernetes.io/tunnel_key": vni},
+			},
+			Spec: corev1.PodSpec{HostNetwork: hostNetwork},
+		}
+	}
+
+	t.Run("annotation present updates VNI", func(t *testing.T) {
+		ep := newEndpoint()
+		require.True(t, ep.SyncVNIFromPodAnnotation(podWith("36", false)))
+		require.Equal(t, uint64(36), ep.GetVNIID())
+	})
+
+	t.Run("same value is a no-op", func(t *testing.T) {
+		ep := newEndpoint()
+		ep.VNIID = 36
+		require.False(t, ep.SyncVNIFromPodAnnotation(podWith("36", false)))
+		require.Equal(t, uint64(36), ep.GetVNIID())
+	})
+
+	t.Run("missing annotation resolves to native scheme", func(t *testing.T) {
+		ep := newEndpoint()
+		ep.VNIID = 36
+		require.True(t, ep.SyncVNIFromPodAnnotation(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", Annotations: map[string]string{}},
+		}))
+		require.Zero(t, ep.GetVNIID(), "absent annotation follows cilium native logic (plain IP scheme)")
+	})
+
+	t.Run("missing annotation with VNI 0 is a no-op", func(t *testing.T) {
+		ep := newEndpoint()
+		require.False(t, ep.SyncVNIFromPodAnnotation(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default", Annotations: map[string]string{}},
+		}))
+		require.Zero(t, ep.GetVNIID())
+	})
+
+	t.Run("zero annotation is an error and falls back to native", func(t *testing.T) {
+		ep := newEndpoint()
+		ep.logger.Store(hivetest.Logger(t))
+		ep.VNIID = 36
+		require.True(t, ep.SyncVNIFromPodAnnotation(podWith("0", false)))
+		require.Zero(t, ep.GetVNIID(), "a zero tunnel_key violates the kube-ovn guarantee; fall back to native")
+	})
+
+	t.Run("invalid annotation is an error and falls back to native", func(t *testing.T) {
+		ep := newEndpoint()
+		ep.logger.Store(hivetest.Logger(t))
+		ep.VNIID = 36
+		require.True(t, ep.SyncVNIFromPodAnnotation(podWith("abc", false)))
+		require.Zero(t, ep.GetVNIID())
+	})
+
+	t.Run("out-of-range annotation is an error and falls back to native", func(t *testing.T) {
+		ep := newEndpoint()
+		ep.logger.Store(hivetest.Logger(t))
+		ep.VNIID = 36
+		require.True(t, ep.SyncVNIFromPodAnnotation(podWith("16777216", false)))
+		require.Zero(t, ep.GetVNIID())
+	})
+
+	t.Run("hostNetwork pod resolves to native scheme without error", func(t *testing.T) {
+		ep := newEndpoint()
+		ep.VNIID = 36
+		require.True(t, ep.SyncVNIFromPodAnnotation(podWith("36", true)))
+		require.Zero(t, ep.GetVNIID())
+	})
+
+	t.Run("native-vpc disabled is a no-op", func(t *testing.T) {
+		option.Config.EnableNativeVPC = false
+		defer func() { option.Config.EnableNativeVPC = true }()
+		ep := newEndpoint()
+		ep.VNIID = 36
+		require.False(t, ep.SyncVNIFromPodAnnotation(podWith("17", false)))
+		require.Equal(t, uint64(36), ep.GetVNIID())
+	})
+}
+
+// TestVNILabelRemovalOnVNIReset simulates the metadataResolver branch taken
+// when the native-vpc VNI drops to 0 (annotation removed, or zero/invalid per
+// the SyncVNIFromPodAnnotation decision table): the stale VNI identity label
+// must be fully removed from the identity labels - not moved to Disabled
+// (ModifyIdentityLabels semantics, which would block a later VNI 0->36
+// recovery via UpdateLabels) - and the identity revision must advance so the
+// endpoint is re-resolved without the VNI label.
+func TestVNILabelRemovalOnVNIReset(t *testing.T) {
+	ep := &Endpoint{
+		labels: labels.NewOpLabels(),
+	}
+	ep.logger.Store(hivetest.Logger(t))
+	ep.labels.OrchestrationIdentity[labels.VNIKey] = labels.NewLabel(labels.VNIKey, "36", labels.LabelSourceVNI)
+
+	ep.unconditionalLock()
+	rev := ep.replaceIdentityLabels(labels.LabelSourceVNI, labels.Labels{})
+	ep.unlock()
+
+	require.NotZero(t, rev, "removing the VNI label must bump the identity revision")
+	_, ok := ep.labels.OrchestrationIdentity[labels.VNIKey]
+	require.False(t, ok, "VNI label must be removed from the identity labels")
+	require.NotContains(t, ep.labels.Disabled, labels.VNIKey,
+		"removal must not disable the label; a later VNI 0->36 recovery must be able to re-inject it")
+}
+
+func TestLegacyVPCLabelRemoval(t *testing.T) {
+	ep := &Endpoint{labels: labels.NewOpLabels()}
+	ep.logger.Store(hivetest.Logger(t))
+	ep.labels.OrchestrationIdentity["vpc"] = labels.NewLabel("vpc", "36", legacyVPCLabelSource)
+
+	ep.unconditionalLock()
+	rev := ep.replaceIdentityLabels(legacyVPCLabelSource, labels.Labels{})
+	ep.unlock()
+
+	require.NotZero(t, rev)
+	_, ok := ep.labels.OrchestrationIdentity["vpc"]
+	require.False(t, ok, "legacy vpc:vpc=<vni> label must be removed during upgrade")
+	require.NotContains(t, ep.labels.Disabled, "vpc")
+}
+
 func TestEndpointUpdateLabels(t *testing.T) {
 	s := setupEndpointSuite(t)
 	logger := hivetest.Logger(t)
@@ -1076,7 +1213,7 @@ func TestMetadataResolver(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(fmt.Sprintf("%s (restored=%t)", tt.name, restored), func(t *testing.T) {
 				model := newTestEndpointModel(100, StateWaitingForIdentity)
-				kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
+				kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName), testipcache.NewMockIPCache())
 				ep, err := NewEndpointFromChangeModel(t.Context(), logger, nil, &MockEndpointBuildQueue{}, nil, s.orchestrator, nil, &fakeTypes.BandwidthManager{}, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil)
 				require.NoError(t, err)
 

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -1233,3 +1233,26 @@ func newTestEndpointModel(id int, state State) *models.EndpointChangeRequest {
 		},
 	}
 }
+
+// TestRestoreVNIRespectsMode pins the lifecycle contract for a mode
+// downgrade: a serialized VNI is only restored while native-vpc is enabled.
+// Restoring it with the mode off would leave the endpoint half configured -
+// VNI-scoped identifiers and ipcache keys and a non-zero
+// CONFIG(native_vpc_vni), but no VNI-scoped ipcache map to write to - so peers
+// would resolve it as world.
+func TestRestoreVNIRespectsMode(t *testing.T) {
+	prev := option.Config.EnableNativeVPC
+	t.Cleanup(func() { option.Config.EnableNativeVPC = prev })
+
+	serialized := &serializableEndpoint{VNIID: 36}
+
+	option.Config.EnableNativeVPC = true
+	ep := &Endpoint{}
+	ep.fromSerializedEndpoint(serialized)
+	require.Equal(t, uint64(36), ep.VNIID, "the VNI must survive a restart in native-vpc mode")
+
+	option.Config.EnableNativeVPC = false
+	ep = &Endpoint{}
+	ep.fromSerializedEndpoint(serialized)
+	require.Zero(t, ep.VNIID, "a mode downgrade must return the endpoint to the plain scheme")
+}

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -1256,3 +1256,62 @@ func TestRestoreVNIRespectsMode(t *testing.T) {
 	ep.fromSerializedEndpoint(serialized)
 	require.Zero(t, ep.VNIID, "a mode downgrade must return the endpoint to the plain scheme")
 }
+
+// TestSyncVNIFromPodAnnotationScopeChange pins that an endpoint keeps the VPC
+// it was admitted with.
+//
+// The re-read on restore exists so that an endpoint which never had a scope can
+// take one once kube-ovn has written the annotation. Moving an endpoint from
+// one VPC to another is a different operation: the identity label, the numeric
+// identity, the CiliumEndpoint annotation other nodes read and the loaded
+// datapath configuration all derive from the VNI and none of them is re-derived
+// here, so adopting the new scope would publish the address in a VPC while the
+// endpoint's identity still claims another one - the address then exists in
+// both.
+func TestSyncVNIFromPodAnnotationScopeChange(t *testing.T) {
+	prev := option.Config.EnableNativeVPC
+	prevAnn := option.Config.NativeVPCVNIAnnotation
+	option.Config.EnableNativeVPC = true
+	option.Config.NativeVPCVNIAnnotation = "ovn.kubernetes.io/tunnel_key"
+	t.Cleanup(func() {
+		option.Config.EnableNativeVPC = prev
+		option.Config.NativeVPCVNIAnnotation = prevAnn
+	})
+
+	pod := func(vni string, hostNetwork bool) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "p",
+				Namespace:   "ns",
+				Annotations: map[string]string{"ovn.kubernetes.io/tunnel_key": vni},
+			},
+			Spec: corev1.PodSpec{HostNetwork: hostNetwork},
+		}
+	}
+
+	newEP := func() *Endpoint { return &Endpoint{} }
+
+	t.Run("first scope is taken", func(t *testing.T) {
+		ep := newEP()
+		ep.logger.Store(hivetest.Logger(t))
+		require.True(t, ep.SyncVNIFromPodAnnotation(pod("9", false)))
+		require.Equal(t, uint64(9), ep.GetVNIID())
+	})
+
+	t.Run("a different scope is refused", func(t *testing.T) {
+		ep := newEP()
+		ep.logger.Store(hivetest.Logger(t))
+		ep.VNIID = 9
+		require.False(t, ep.SyncVNIFromPodAnnotation(pod("99", false)),
+			"the endpoint must not be moved between VPCs by an annotation alone")
+		require.Equal(t, uint64(9), ep.GetVNIID())
+	})
+
+	t.Run("the same scope is not a change", func(t *testing.T) {
+		ep := newEP()
+		ep.logger.Store(hivetest.Logger(t))
+		ep.VNIID = 9
+		require.False(t, ep.SyncVNIFromPodAnnotation(pod("9", false)))
+		require.Equal(t, uint64(9), ep.GetVNIID())
+	})
+}

--- a/pkg/endpoint/id/id.go
+++ b/pkg/endpoint/id/id.go
@@ -193,3 +193,22 @@ func NewVNIIPPrefixID(ip netip.Addr, vniID uint64) string {
 func FormatVNIIP(vniID uint64, ip netip.Addr) string {
 	return strconv.FormatUint(vniID, 10) + ":" + ip.String()
 }
+
+// SplitVNIIP splits a "<vni>:<ip>" identifier value (see FormatVNIIP) back
+// into its bare IP string, reporting whether the value was well-formed. Note
+// that IPv6 addresses contain colons, so the split is on the *first* colon
+// (the VNI is a plain decimal number and never contains one).
+func SplitVNIIP(vniIP string) (ip string, ok bool) {
+	i := strings.Index(vniIP, ":")
+	if i <= 0 || i == len(vniIP)-1 {
+		return "", false
+	}
+	if _, err := strconv.ParseUint(vniIP[:i], 10, 64); err != nil {
+		return "", false
+	}
+	ip = vniIP[i+1:]
+	if parsed, err := netip.ParseAddr(ip); err != nil || !parsed.IsValid() {
+		return "", false
+	}
+	return ip, true
+}

--- a/pkg/endpoint/id/vni_test.go
+++ b/pkg/endpoint/id/vni_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package id
+
+import "testing"
+
+func TestSplitVNIIP(t *testing.T) {
+	for _, tc := range []struct {
+		name, input, want string
+		ok                bool
+	}{
+		{"v4", "36:192.0.2.1", "192.0.2.1", true},
+		{"v6", "17:2001:db8::1", "2001:db8::1", true},
+		{"missing vni", ":192.0.2.1", "", false},
+		{"invalid vni", "x:192.0.2.1", "", false},
+		{"missing ip", "36:", "", false},
+		{"invalid ip", "36:not-an-ip", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := SplitVNIIP(tc.input)
+			if got != tc.want || ok != tc.ok {
+				t.Fatalf("SplitVNIIP(%q) = (%q, %v), want (%q, %v)", tc.input, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -1084,6 +1084,7 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 					K8sServiceAccount: k8sServiceAccount,
 					NPM:               e.GetK8sPorts(),
 					Vni:               vni,
+					EndpointID:        e.ID,
 				}
 
 				if err := e.kvstoreSyncher.Upsert(ctx, params); err != nil {
@@ -1097,7 +1098,7 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 				// pod can be given it, and that pod's endpoint registers the
 				// same (VNI, IP). Name the pod this entry belongs to so the
 				// removal cannot take the new owner's entry with it.
-				if err := e.kvstoreSyncher.Delete(ctx, ip, vni, e.K8sNamespace, e.K8sPodName); err != nil {
+				if err := e.kvstoreSyncher.Delete(ctx, ip, vni, e.K8sNamespace, e.K8sPodName, e.ID); err != nil {
 					return fmt.Errorf("unable to delete endpoint IP '%s' from ipcache: %w", ip, err)
 				}
 				return nil

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -1010,9 +1010,12 @@ func (e *Endpoint) FormatGlobalEndpointID() string {
 }
 
 // This synchronizes the key-value store with a mapping of the endpoint's IP
-// with the numerical ID representing its security identity.
+// with the numerical ID representing its security identity. When no kvstore is
+// configured, the mapping is registered directly in the local ipcache instead
+// (see IPIdentitySynchronizer.Upsert), so local endpoints are always
+// resolvable by the datapath.
 func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
-	if !e.kvstoreSyncher.IsEnabled() || !endpointIP.IsValid() {
+	if !endpointIP.IsValid() {
 		return
 	}
 
@@ -1028,6 +1031,12 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 	if endpointIP.Is6() {
 		addressFamily = "IPv6"
 	}
+
+	// Capture the VNI used by this controller instance. UpdateController
+	// replaces the old controller when VNI/identity changes; the old StopFunc
+	// must delete the exact key its DoFunc wrote (e.g. <ip>@vni:N), rather than
+	// re-reading a newer e.VNIID and leaking the old kvstore/tracker entry.
+	vni := e.VNIID
 
 	e.controllers.UpdateController(
 		fmt.Sprintf("sync-%s-identity-mapping (%d)", addressFamily, e.ID),
@@ -1074,6 +1083,7 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 					K8sPodName:        k8sPodName,
 					K8sServiceAccount: k8sServiceAccount,
 					NPM:               e.GetK8sPorts(),
+					Vni:               vni,
 				}
 
 				if err := e.kvstoreSyncher.Upsert(ctx, params); err != nil {
@@ -1083,7 +1093,7 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 			},
 			StopFunc: func(ctx context.Context) error {
 				ip := endpointIP.String()
-				if err := e.kvstoreSyncher.Delete(ctx, ip); err != nil {
+				if err := e.kvstoreSyncher.Delete(ctx, ip, vni); err != nil {
 					return fmt.Errorf("unable to delete endpoint IP '%s' from ipcache: %w", ip, err)
 				}
 				return nil

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -1093,7 +1093,11 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 			},
 			StopFunc: func(ctx context.Context) error {
 				ip := endpointIP.String()
-				if err := e.kvstoreSyncher.Delete(ctx, ip, vni); err != nil {
+				// The address outlives this endpoint: once it is free another
+				// pod can be given it, and that pod's endpoint registers the
+				// same (VNI, IP). Name the pod this entry belongs to so the
+				// removal cannot take the new owner's entry with it.
+				if err := e.kvstoreSyncher.Delete(ctx, ip, vni, e.K8sNamespace, e.K8sPodName); err != nil {
 					return fmt.Errorf("unable to delete endpoint IP '%s' from ipcache: %w", ip, err)
 				}
 				return nil

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -164,7 +164,7 @@ const (
 func (s *RedirectSuite) NewTestEndpoint(t *testing.T) *Endpoint {
 	logger := hivetest.Logger(t)
 	model := newTestEndpointModel(12345, StateRegenerating)
-	kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
+	kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName), testipcache.NewMockIPCache())
 	ep, err := NewEndpointFromChangeModel(t.Context(), logger, nil, &MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, s.do.idmgr, nil, nil, s.do.repo, testipcache.NewMockIPCache(), s.rsp, s.mgr, ctmap.NewFakeGCRunner(), kvstoreSync, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil)
 	require.NoError(t, err)
 

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -635,7 +635,16 @@ func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.IPv6IPAMPool = r.IPv6IPAMPool
 	ep.IPv4 = r.IPv4
 	ep.IPv4IPAMPool = r.IPv4IPAMPool
-	ep.VNIID = r.VNIID
+	// Native-vpc: only restore the VNI scope while the mode is enabled. If the
+	// mode was turned off, a restored non-zero VNI would leave the endpoint
+	// half configured - VNI-scoped endpoint identifiers and ipcache keys, a
+	// non-zero CONFIG(native_vpc_vni) in bpf_lxc, but no VNI-scoped ipcache map
+	// for the agent to write to - so peers would resolve it as world. Dropping
+	// it makes the downgrade deterministic: the endpoint returns to the plain
+	// scheme on every plane.
+	if option.Config.EnableNativeVPC {
+		ep.VNIID = r.VNIID
+	}
 	ep.nodeMAC = r.NodeMAC
 	ep.SecurityIdentity = r.SecurityIdentity
 	ep.DNSRules = r.DNSRules

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -54,6 +54,23 @@ var Cell = cell.Module(
 type EndpointsLookupVNI interface {
 	LookupIPWithVNI(ip netip.Addr, vni uint64) *endpoint.Endpoint
 	LookupIPUnambiguous(ip netip.Addr) *endpoint.Endpoint
+	// LookupIPAnyVNI returns any endpoint using the given IP, regardless of
+	// its VNI scope. It must only be used by "is this IP in use" safety
+	// checks, never for identity/metadata resolution.
+	LookupIPAnyVNI(ip netip.Addr) *endpoint.Endpoint
+}
+
+// LookupIPAnyVNI reports any endpoint using the given IP in any VNI scope.
+// Unlike LookupIPUnambiguous it deliberately fails *open* on overlapping IPs
+// (it returns one of them), because its only purpose is to answer "is this IP
+// still in use on this node" (e.g. before releasing an IPAM address).
+func LookupIPAnyVNI(lookup interface {
+	LookupIP(netip.Addr) *endpoint.Endpoint
+}, ip netip.Addr) *endpoint.Endpoint {
+	if vniLookup, ok := lookup.(EndpointsLookupVNI); ok {
+		return vniLookup.LookupIPAnyVNI(ip)
+	}
+	return lookup.LookupIP(ip)
 }
 
 // LookupIPUnambiguous uses the explicit best-effort VNI-aware API when the

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -51,6 +51,10 @@ var Cell = cell.Module(
 // EndpointsLookupVNI is the optional VNI-aware extension for endpoint
 // readers. It is intentionally separate from EndpointsLookup so existing
 // lightweight consumers and test doubles keep the legacy interface.
+//
+// Consumers reach it through a type assertion and silently fall back to
+// bare-IP behavior when it is absent, so the production implementation is
+// asserted at compile time (see manager.go).
 type EndpointsLookupVNI interface {
 	LookupIPWithVNI(ip netip.Addr, vni uint64) *endpoint.Endpoint
 	LookupIPUnambiguous(ip netip.Addr) *endpoint.Endpoint

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -48,6 +48,32 @@ var Cell = cell.Module(
 	),
 )
 
+// EndpointsLookupVNI is the optional VNI-aware extension for endpoint
+// readers. It is intentionally separate from EndpointsLookup so existing
+// lightweight consumers and test doubles keep the legacy interface.
+type EndpointsLookupVNI interface {
+	LookupIPWithVNI(ip netip.Addr, vni uint64) *endpoint.Endpoint
+	LookupIPUnambiguous(ip netip.Addr) *endpoint.Endpoint
+}
+
+// LookupIPUnambiguous uses the explicit best-effort VNI-aware API when the
+// implementation provides it. Legacy implementations retain their exact
+// LookupIP behavior.
+func LookupIPUnambiguous(lookup interface {
+	LookupIP(netip.Addr) *endpoint.Endpoint
+}, ip netip.Addr) *endpoint.Endpoint {
+	if vniLookup, ok := lookup.(EndpointsLookupVNI); ok {
+		return vniLookup.LookupIPUnambiguous(ip)
+	}
+	// A legacy implementation has no VNI-aware capability. Keep it usable
+	// for non-native-vpc callers, but fail closed in native-vpc mode rather
+	// than silently reintroducing a bare-IP identity lookup.
+	if option.Config.EnableNativeVPC {
+		return nil
+	}
+	return lookup.LookupIP(ip)
+}
+
 type EndpointsLookup interface {
 	// Lookup looks up endpoint by prefix ID
 	Lookup(id string) (*endpoint.Endpoint, error)

--- a/pkg/endpointmanager/endpointsynchronizer.go
+++ b/pkg/endpointmanager/endpointsynchronizer.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 
 	"github.com/blang/semver/v4"
 	"github.com/cilium/hive/cell"
@@ -16,6 +17,7 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
+	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -33,6 +35,11 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
 )
+
+// ciliumEndpointVNIAnnotation is the annotation written on CiliumEndpoints to
+// carry the native-vpc VNI of the endpoint, so that CiliumEndpoint watchers on
+// other nodes can register the endpoint IP in the VNI-scoped ipcache.
+const ciliumEndpointVNIAnnotation = annotation.NativeVPCVNIPrefix + "/vni"
 
 const (
 	// subsysEndpointSync is the value for logfields.LogSubsys
@@ -273,6 +280,9 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 								// Mirror the labels of parent pod in CiliumEndpoint object to enable
 								// label based selection for CiliumEndpoints.
 								Labels: cepOwner.GetLabels(),
+								// Carry the native-vpc VNI so that CiliumEndpoint watchers on
+								// other nodes can register the IP in the VNI-scoped ipcache.
+								Annotations: ciliumEndpointVNIAnnotations(e),
 							},
 							Status: *mdl,
 						}
@@ -372,6 +382,16 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 						Value: mdl,
 					},
 				}
+				// Backfill the native-vpc VNI annotation on pre-existing CEPs.
+				if vniAnnots := ciliumEndpointVNIAnnotations(e); len(vniAnnots) > 0 {
+					if localCEP == nil || localCEP.Annotations[ciliumEndpointVNIAnnotation] != vniAnnots[ciliumEndpointVNIAnnotation] {
+						replaceCEPStatus = append(replaceCEPStatus, k8s.JSONPatch{
+							OP:    "add",
+							Path:  "/metadata/annotations/" + ciliumEndpointVNIAnnotation,
+							Value: vniAnnots[ciliumEndpointVNIAnnotation],
+						})
+					}
+				}
 				var createStatusPatch []byte
 				createStatusPatch, err = json.Marshal(replaceCEPStatus)
 				if err != nil {
@@ -417,6 +437,16 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 				return deleteCEP(ctx, scopedLog, ciliumClient, e)
 			},
 		})
+}
+
+// ciliumEndpointVNIAnnotations returns the annotations to write on the CEP of
+// the given endpoint to carry its native-vpc VNI. Returns an empty map when the
+// endpoint is not a native-vpc endpoint (VNI == 0).
+func ciliumEndpointVNIAnnotations(e *endpoint.Endpoint) map[string]string {
+	if vni := e.GetVNIID(); vni > 0 {
+		return map[string]string{ciliumEndpointVNIAnnotation: strconv.FormatUint(vni, 10)}
+	}
+	return nil
 }
 
 // updateCEPUID attempts to update the endpoints UID to be that of localCEP.

--- a/pkg/endpointmanager/endpointsynchronizer.go
+++ b/pkg/endpointmanager/endpointsynchronizer.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"strings"
 
 	"github.com/blang/semver/v4"
 	"github.com/cilium/hive/cell"
@@ -39,7 +40,15 @@ import (
 // ciliumEndpointVNIAnnotation is the annotation written on CiliumEndpoints to
 // carry the native-vpc VNI of the endpoint, so that CiliumEndpoint watchers on
 // other nodes can register the endpoint IP in the VNI-scoped ipcache.
-const ciliumEndpointVNIAnnotation = annotation.NativeVPCVNIPrefix + "/vni"
+const ciliumEndpointVNIAnnotation = annotation.CiliumEndpointNativeVPCVNI
+
+// jsonPointerEscape escapes a JSON Patch path token per RFC 6901. The VNI
+// annotation key contains a '/' ("native-vpc.cilium.io/vni"), which would
+// otherwise be interpreted as a path separator and make the whole patch
+// (including the status replace) fail.
+func jsonPointerEscape(token string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(token, "~", "~0"), "/", "~1")
+}
 
 const (
 	// subsysEndpointSync is the value for logfields.LogSubsys
@@ -384,11 +393,22 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 				}
 				// Backfill the native-vpc VNI annotation on pre-existing CEPs.
 				if vniAnnots := ciliumEndpointVNIAnnotations(e); len(vniAnnots) > 0 {
-					if localCEP == nil || localCEP.Annotations[ciliumEndpointVNIAnnotation] != vniAnnots[ciliumEndpointVNIAnnotation] {
+					vniValue := vniAnnots[ciliumEndpointVNIAnnotation]
+					switch {
+					case localCEP == nil || localCEP.Annotations == nil:
+						// The annotations object does not exist (or is unknown):
+						// "add" on a missing parent member fails, so create the
+						// whole map. Nothing can be clobbered as it is empty.
 						replaceCEPStatus = append(replaceCEPStatus, k8s.JSONPatch{
 							OP:    "add",
-							Path:  "/metadata/annotations/" + ciliumEndpointVNIAnnotation,
-							Value: vniAnnots[ciliumEndpointVNIAnnotation],
+							Path:  "/metadata/annotations",
+							Value: vniAnnots,
+						})
+					case localCEP.Annotations[ciliumEndpointVNIAnnotation] != vniValue:
+						replaceCEPStatus = append(replaceCEPStatus, k8s.JSONPatch{
+							OP:    "add",
+							Path:  "/metadata/annotations/" + jsonPointerEscape(ciliumEndpointVNIAnnotation),
+							Value: vniValue,
 						})
 					}
 				}

--- a/pkg/endpointmanager/endpointsynchronizer_vni_test.go
+++ b/pkg/endpointmanager/endpointsynchronizer_vni_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpointmanager
+
+import (
+	"encoding/json"
+	"testing"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/annotation"
+	"github.com/cilium/cilium/pkg/k8s"
+)
+
+// TestJSONPointerEscape pins the RFC 6901 escaping of the CiliumEndpoint VNI
+// annotation key. The key contains a '/', which unescaped would be parsed as a
+// JSON Pointer path separator and would make the whole CEP patch (including
+// the status replace) fail.
+func TestJSONPointerEscape(t *testing.T) {
+	require.Equal(t, "native-vpc.cilium.io~1vni", jsonPointerEscape(annotation.CiliumEndpointNativeVPCVNI))
+	require.Equal(t, "a~0b~1c", jsonPointerEscape("a~b/c"))
+	require.Equal(t, "plain", jsonPointerEscape("plain"))
+}
+
+// TestVNIAnnotationPatchApplies verifies that the patch the endpoint
+// synchronizer builds actually applies, both when the CEP already has
+// annotations and when the annotations object does not exist yet (an "add" on
+// a missing parent member is an error in JSON Patch, so the whole map has to
+// be created in that case).
+func TestVNIAnnotationPatchApplies(t *testing.T) {
+	apply := func(t *testing.T, doc string, patch []k8s.JSONPatch) map[string]any {
+		t.Helper()
+		raw, err := json.Marshal(patch)
+		require.NoError(t, err)
+		p, err := jsonpatch.DecodePatch(raw)
+		require.NoError(t, err)
+		out, err := p.Apply([]byte(doc))
+		require.NoError(t, err)
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(out, &got))
+		return got
+	}
+
+	// Existing annotations: add a single escaped member, keeping the others.
+	got := apply(t, `{"metadata":{"annotations":{"keep":"me"}}}`, []k8s.JSONPatch{{
+		OP:    "add",
+		Path:  "/metadata/annotations/" + jsonPointerEscape(annotation.CiliumEndpointNativeVPCVNI),
+		Value: "36",
+	}})
+	annotations := got["metadata"].(map[string]any)["annotations"].(map[string]any)
+	require.Equal(t, "36", annotations[annotation.CiliumEndpointNativeVPCVNI])
+	require.Equal(t, "me", annotations["keep"])
+
+	// No annotations object: create it wholesale.
+	got = apply(t, `{"metadata":{}}`, []k8s.JSONPatch{{
+		OP:    "add",
+		Path:  "/metadata/annotations",
+		Value: map[string]string{annotation.CiliumEndpointNativeVPCVNI: "36"},
+	}})
+	annotations = got["metadata"].(map[string]any)["annotations"].(map[string]any)
+	require.Equal(t, "36", annotations[annotation.CiliumEndpointNativeVPCVNI])
+}

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -717,9 +717,7 @@ func (mgr *endpointManager) updateIDReferenceLocked(ep *endpoint.Endpoint) {
 
 func cloneIdentifiers(in endpointid.Identifiers) endpointid.Identifiers {
 	out := make(endpointid.Identifiers, len(in))
-	for k, v := range in {
-		out[k] = v
-	}
+	maps.Copy(out, in)
 	return out
 }
 

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -125,6 +125,11 @@ type endpointManager struct {
 // functionality from endpoint management for testing purposes.
 type endpointDeleteFunc func(*endpoint.Endpoint, endpoint.DeleteConfig) []error
 
+// The VNI-aware lookups are reached through an optional interface (Hubble,
+// DNS proxy, L7 accesslog, ipam). A missing method would silently degrade
+// every consumer to bare-IP lookups, so assert it here.
+var _ EndpointsLookupVNI = (*endpointManager)(nil)
+
 // New creates a new endpointManager.
 func New(logger *slog.Logger, registry *metrics.Registry, epSynchronizer EndpointResourceSynchronizer, lns *node.LocalNodeStore, health cell.Health, monitorAgent monitoragent.Agent, config EndpointManagerConfig) *endpointManager {
 	mgr := endpointManager{

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -63,6 +63,12 @@ type endpointManager struct {
 	endpoints    map[uint16]*endpoint.Endpoint
 	endpointsAux map[string]*endpoint.Endpoint
 
+	// registeredIdentifiers is the exact identifier snapshot installed for
+	// each exposed endpoint. Endpoint identifiers (notably VNI/IP) can change
+	// while an endpoint object is alive, so cleanup must use the snapshot that
+	// was actually registered rather than recomputing identifiers at delete.
+	registeredIdentifiers map[uint16]endpointid.Identifiers
+
 	// mcastManager handles IPv6 multicast group join/leave for pods. This is required for the
 	// node to receive ICMPv6 NDP messages, especially NS (Neighbor Solicitation) message, so
 	// pod's IPv6 address is discoverable.
@@ -118,6 +124,7 @@ func New(logger *slog.Logger, registry *metrics.Registry, epSynchronizer Endpoin
 		health:                       health,
 		endpoints:                    make(map[uint16]*endpoint.Endpoint),
 		endpointsAux:                 make(map[string]*endpoint.Endpoint),
+		registeredIdentifiers:        make(map[uint16]endpointid.Identifiers),
 		mcastManager:                 mcastmanager.New(logger, option.Config.IPv6MCastDevice),
 		EndpointResourceSynchronizer: epSynchronizer,
 		subscribers:                  make(map[Subscriber]struct{}),
@@ -457,7 +464,6 @@ func (mgr *endpointManager) GetEndpointsByServiceAccount(namespace string, servi
 // lookups will no longer find the endpoint.
 func (mgr *endpointManager) unexpose(ep *endpoint.Endpoint) {
 	defer ep.Close()
-	identifiers := ep.Identifiers()
 
 	previousState := ep.GetState()
 
@@ -476,13 +482,19 @@ func (mgr *endpointManager) unexpose(ep *endpoint.Endpoint) {
 				"Unable to release endpoint ID",
 				logfields.Error, err,
 				logfields.State, previousState,
-				logfields.CNIAttachmentID, identifiers[endpointid.CNIAttachmentIdPrefix],
-				logfields.CEPName, identifiers[endpointid.CEPNamePrefix],
+				logfields.CNIAttachmentID, ep.GetCNIAttachmentID(),
+				logfields.CEPName, ep.GetK8sNamespaceAndCEPName(),
 			)
 		}
 	}
 
-	mgr.removeReferencesLocked(identifiers)
+	if registered := mgr.registeredIdentifiers[ep.ID]; registered != nil {
+		mgr.removeReferencesLocked(registered)
+		delete(mgr.registeredIdentifiers, ep.ID)
+	} else {
+		// Restoring endpoints may not have a registration snapshot yet.
+		mgr.removeReferencesLocked(ep.Identifiers())
+	}
 }
 
 // removeEndpoint stops the active handling of events by the specified endpoint,
@@ -560,6 +572,45 @@ func (mgr *endpointManager) lookupIPv6(ipv6 string) *endpoint.Endpoint {
 	return nil
 }
 
+// LookupIPWithVNI performs an exact (VNI, IP) endpoint lookup. A zero VNI
+// deliberately uses the plain IP namespace and does not consult VNI entries.
+func (mgr *endpointManager) LookupIPWithVNI(ip netip.Addr, vni uint64) *endpoint.Endpoint {
+	if !ip.IsValid() {
+		return nil
+	}
+	mgr.mutex.RLock()
+	defer mgr.mutex.RUnlock()
+	if vni == 0 {
+		if ip.Is4() {
+			return mgr.lookupIPv4(ip.Unmap().String())
+		}
+		return mgr.lookupIPv6(ip.Unmap().String())
+	}
+	key := endpointid.NewVNIIPPrefixID(ip.Unmap(), vni)
+	if key == "" {
+		return nil
+	}
+	if ep, ok := mgr.endpointsAux[key]; ok && mgr.endpoints[ep.ID] == ep {
+		return ep
+	}
+	return nil
+}
+
+// LookupIPUnambiguous is the explicit bare-IP fallback for non-VPC entities.
+// It never returns a VNI-scoped endpoint. Callers without VNI context must
+// fail closed for VPC endpoints; use LookupIPWithVNI for VPC endpoints.
+func (mgr *endpointManager) LookupIPUnambiguous(ip netip.Addr) *endpoint.Endpoint {
+	if !ip.IsValid() {
+		return nil
+	}
+	mgr.mutex.RLock()
+	defer mgr.mutex.RUnlock()
+	if ip.Is4() {
+		return mgr.lookupIPv4(ip.Unmap().String())
+	}
+	return mgr.lookupIPv6(ip.Unmap().String())
+}
+
 // lookupVNIIPv4 looks up an endpoint by VNI-aware IPv4 identifier.
 // The vniIPv4 parameter should be in format "<vni>:<ipv4>".
 func (mgr *endpointManager) lookupVNIIPv4(vniIPv4 string) *endpoint.Endpoint {
@@ -601,10 +652,19 @@ func (mgr *endpointManager) updateIDReferenceLocked(ep *endpoint.Endpoint) {
 	mgr.endpoints[ep.ID] = ep
 }
 
+func cloneIdentifiers(in endpointid.Identifiers) endpointid.Identifiers {
+	out := make(endpointid.Identifiers, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
 func (mgr *endpointManager) updateReferencesLocked(ep *endpoint.Endpoint, identifiers endpointid.Identifiers) {
 	for k := range identifiers {
 		id := endpointid.NewID(k, identifiers[k])
 		mgr.endpointsAux[id] = ep
+
 	}
 }
 
@@ -613,9 +673,19 @@ func (mgr *endpointManager) UpdateReferences(ep *endpoint.Endpoint) error {
 	mgr.mutex.Lock()
 	defer mgr.mutex.Unlock()
 
-	identifiers := ep.Identifiers()
-	mgr.updateReferencesLocked(ep, identifiers)
+	// Only exposed endpoints own endpointmanager references. Preserve the old
+	// behavior for callers racing endpoint teardown: do not create aux keys for
+	// an endpoint that is no longer present in the primary ID map.
+	if current, exposed := mgr.endpoints[ep.ID]; !exposed || current != ep {
+		return nil
+	}
 
+	identifiers := ep.Identifiers()
+	if old := mgr.registeredIdentifiers[ep.ID]; old != nil {
+		mgr.removeReferencesLocked(old)
+	}
+	mgr.updateReferencesLocked(ep, identifiers)
+	mgr.registeredIdentifiers[ep.ID] = cloneIdentifiers(identifiers)
 	return nil
 }
 
@@ -696,6 +766,7 @@ func (mgr *endpointManager) expose(ep *endpoint.Endpoint) error {
 	mgr.mcastManager.AddAddress(ep.IPv6)
 	mgr.updateIDReferenceLocked(ep)
 	mgr.updateReferencesLocked(ep, identifiers)
+	mgr.registeredIdentifiers[ep.ID] = cloneIdentifiers(identifiers)
 	mgr.mutex.Unlock()
 
 	ep.InitEndpointHealth(mgr.health)

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -11,6 +11,7 @@ import (
 	"maps"
 	"net/netip"
 	"runtime"
+	"slices"
 	"sync"
 
 	"github.com/cilium/hive/cell"
@@ -857,12 +858,58 @@ func (mgr *endpointManager) expose(ep *endpoint.Endpoint) error {
 	mgr.updateIDReferenceLocked(ep)
 	mgr.updateReferencesLocked(ep, identifiers)
 	mgr.registeredIdentifiers[ep.ID] = cloneIdentifiers(identifiers)
+	overlapping := mgr.overlappingVNIEndpointsLocked(ep)
 	mgr.mutex.Unlock()
+
+	for ip, ids := range overlapping {
+		// The conntrack and NAT maps are keyed by the bare 5-tuple, so two
+		// endpoints of different VPCs that share an IP on this node can share
+		// a CT entry when they also pick the same peer and ports. Surface the
+		// condition: it is the one plane where the (VNI, IP) pair cannot be
+		// expressed today (see Documentation/network/native-vpc.rst).
+		mgr.logger.Warn(
+			"local endpoints of different VPCs share an IP: conntrack entries are keyed by the bare 5-tuple and may be shared between them",
+			logfields.IPAddr, ip,
+			logfields.EndpointID, ids,
+		)
+	}
 
 	ep.InitEndpointHealth(mgr.health)
 	mgr.RunK8sCiliumEndpointSync(ep, ep.GetReporter("cep-k8s-sync"))
 
 	return nil
+}
+
+// overlappingVNIEndpointsLocked reports, per IP of the given endpoint, the ids
+// of all local endpoints that use the same IP in a different VNI scope.
+// Returns nil (the normal case) when the endpoint's IPs are unique on the node.
+func (mgr *endpointManager) overlappingVNIEndpointsLocked(ep *endpoint.Endpoint) map[string][]uint16 {
+	if !option.Config.EnableNativeVPC {
+		return nil
+	}
+	var out map[string][]uint16
+	for _, addr := range []netip.Addr{ep.IPv4, ep.IPv6} {
+		if !addr.IsValid() {
+			continue
+		}
+		ipStr := addr.Unmap().String()
+		keys := mgr.ipToVNIAuxKeys[ipStr]
+		if len(keys) < 2 {
+			continue
+		}
+		ids := make([]uint16, 0, len(keys))
+		for key := range keys {
+			if other, ok := mgr.endpointsAux[key]; ok {
+				ids = append(ids, other.ID)
+			}
+		}
+		slices.Sort(ids)
+		if out == nil {
+			out = map[string][]uint16{}
+		}
+		out[ipStr] = ids
+	}
+	return out
 }
 
 func (mgr *endpointManager) GetEndpointList(params endpointapi.GetEndpointParams) []*models.Endpoint {

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -505,11 +505,11 @@ func (mgr *endpointManager) unexpose(ep *endpoint.Endpoint) {
 	}
 
 	if registered := mgr.registeredIdentifiers[ep.ID]; registered != nil {
-		mgr.removeReferencesLocked(registered)
+		mgr.removeReferencesLocked(ep, registered)
 		delete(mgr.registeredIdentifiers, ep.ID)
 	} else {
 		// Restoring endpoints may not have a registration snapshot yet.
-		mgr.removeReferencesLocked(ep.Identifiers())
+		mgr.removeReferencesLocked(ep, ep.Identifiers())
 	}
 }
 
@@ -763,7 +763,7 @@ func (mgr *endpointManager) UpdateReferences(ep *endpoint.Endpoint) error {
 
 	identifiers := ep.Identifiers()
 	if old := mgr.registeredIdentifiers[ep.ID]; old != nil {
-		mgr.removeReferencesLocked(old)
+		mgr.removeReferencesLocked(ep, old)
 	}
 	mgr.updateReferencesLocked(ep, identifiers)
 	mgr.registeredIdentifiers[ep.ID] = cloneIdentifiers(identifiers)
@@ -791,9 +791,22 @@ func (mgr *endpointManager) updateOverlappingIPsMetric() {
 }
 
 // removeReferencesLocked removes the mappings from the endpointmanager.
-func (mgr *endpointManager) removeReferencesLocked(identifiers endpointid.Identifiers) {
+// removeReferencesLocked drops the aux identifiers of an endpoint that is being
+// removed.
+//
+// An identifier may already belong to a different endpoint by the time this
+// runs: a pod that is deleted and recreated on the same address in the same VPC
+// produces a new endpoint that registers the same (VNI, IP) identifier before
+// the previous one has finished being torn down. Removing it then would leave
+// the running pod with no identifier at all - endpoints in a VPC deliberately
+// register no bare-address one - so only references that still point at this
+// endpoint are removed.
+func (mgr *endpointManager) removeReferencesLocked(ep *endpoint.Endpoint, identifiers endpointid.Identifiers) {
 	for prefix := range identifiers {
 		id := endpointid.NewID(prefix, identifiers[prefix])
+		if current, exists := mgr.endpointsAux[id]; exists && current != ep {
+			continue
+		}
 		delete(mgr.endpointsAux, id)
 
 		if ip, ok := bareIPOfVNIIdentifier(prefix, identifiers[prefix]); ok {

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -517,6 +517,7 @@ func (mgr *endpointManager) unexpose(ep *endpoint.Endpoint) {
 // and prevents the endpoint from being globally accessible via other packages.
 func (mgr *endpointManager) removeEndpoint(ep *endpoint.Endpoint, conf endpoint.DeleteConfig) []error {
 	mgr.unexpose(ep)
+	mgr.updateOverlappingIPsMetric()
 	result := ep.Delete(conf)
 
 	if !option.Config.DryMode {
@@ -771,6 +772,26 @@ func (mgr *endpointManager) UpdateReferences(ep *endpoint.Endpoint) error {
 	return nil
 }
 
+// updateOverlappingIPsMetric publishes the number of IPs that are used by more
+// than one local endpoint in different VNIs. This is the precondition for
+// conntrack entry sharing between VPCs (the CT key is the bare 5-tuple), so it
+// must be observable rather than only logged. Zero on this node means no CT
+// ambiguity on this node.
+func (mgr *endpointManager) updateOverlappingIPsMetric() {
+	if !option.Config.EnableNativeVPC {
+		return
+	}
+	mgr.mutex.RLock()
+	var overlapping int
+	for _, keys := range mgr.ipToVNIAuxKeys {
+		if len(keys) > 1 {
+			overlapping++
+		}
+	}
+	mgr.mutex.RUnlock()
+	metrics.NativeVPCOverlappingIPs.Set(float64(overlapping))
+}
+
 // removeReferencesLocked removes the mappings from the endpointmanager.
 func (mgr *endpointManager) removeReferencesLocked(identifiers endpointid.Identifiers) {
 	for prefix := range identifiers {
@@ -873,6 +894,7 @@ func (mgr *endpointManager) expose(ep *endpoint.Endpoint) error {
 			logfields.EndpointID, ids,
 		)
 	}
+	mgr.updateOverlappingIPsMetric()
 
 	ep.InitEndpointHealth(mgr.health)
 	mgr.RunK8sCiliumEndpointSync(ep, ep.GetReporter("cep-k8s-sync"))

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -63,6 +63,15 @@ type endpointManager struct {
 	endpoints    map[uint16]*endpoint.Endpoint
 	endpointsAux map[string]*endpoint.Endpoint
 
+	// ipToVNIAuxKeys maps a bare IP string to the set of native-vpc
+	// VNI-scoped aux keys ("vni-ipv4:<vni>:<ip>") currently registered for
+	// it. Native-vpc endpoints are deliberately not registered under the bare
+	// "ipv4:/ipv6:" keys (overlapping IPs would overwrite each other), so this
+	// index is what allows the explicit bare-IP fallback
+	// (LookupIPUnambiguous) to resolve an endpoint when exactly one VNI uses
+	// the IP on this node. It is never used to guess between overlapping IPs.
+	ipToVNIAuxKeys map[string]map[string]struct{}
+
 	// registeredIdentifiers is the exact identifier snapshot installed for
 	// each exposed endpoint. Endpoint identifiers (notably VNI/IP) can change
 	// while an endpoint object is alive, so cleanup must use the snapshot that
@@ -124,6 +133,7 @@ func New(logger *slog.Logger, registry *metrics.Registry, epSynchronizer Endpoin
 		health:                       health,
 		endpoints:                    make(map[uint16]*endpoint.Endpoint),
 		endpointsAux:                 make(map[string]*endpoint.Endpoint),
+		ipToVNIAuxKeys:               make(map[string]map[string]struct{}),
 		registeredIdentifiers:        make(map[uint16]endpointid.Identifiers),
 		mcastManager:                 mcastmanager.New(logger, option.Config.IPv6MCastDevice),
 		EndpointResourceSynchronizer: epSynchronizer,
@@ -596,19 +606,65 @@ func (mgr *endpointManager) LookupIPWithVNI(ip netip.Addr, vni uint64) *endpoint
 	return nil
 }
 
-// LookupIPUnambiguous is the explicit bare-IP fallback for non-VPC entities.
-// It never returns a VNI-scoped endpoint. Callers without VNI context must
-// fail closed for VPC endpoints; use LookupIPWithVNI for VPC endpoints.
+// LookupIPUnambiguous is the explicit bare-IP fallback for consumers that only
+// have an IP (DNS proxy source endpoint, Hubble local endpoint, L7 accesslog,
+// ipam API). It first resolves the plain (non-VPC) key, then - only if exactly
+// one native-vpc endpoint on this node uses the IP - the corresponding
+// VNI-scoped endpoint. When several VPCs overlap on the IP it deliberately
+// reports a miss (fail closed) instead of guessing a VPC; those callers must
+// use LookupIPWithVNI with a real (VNI, IP) context.
 func (mgr *endpointManager) LookupIPUnambiguous(ip netip.Addr) *endpoint.Endpoint {
 	if !ip.IsValid() {
 		return nil
 	}
+	ipStr := ip.Unmap().String()
 	mgr.mutex.RLock()
 	defer mgr.mutex.RUnlock()
+	var ep *endpoint.Endpoint
 	if ip.Is4() {
-		return mgr.lookupIPv4(ip.Unmap().String())
+		ep = mgr.lookupIPv4(ipStr)
+	} else {
+		ep = mgr.lookupIPv6(ipStr)
 	}
-	return mgr.lookupIPv6(ip.Unmap().String())
+	if ep != nil {
+		return ep
+	}
+	keys := mgr.ipToVNIAuxKeys[ipStr]
+	if len(keys) != 1 {
+		return nil
+	}
+	for key := range keys {
+		if ep, ok := mgr.endpointsAux[key]; ok && mgr.endpoints[ep.ID] == ep {
+			return ep
+		}
+	}
+	return nil
+}
+
+// LookupIPAnyVNI returns any endpoint using the given IP, regardless of its
+// VNI scope (see the interface documentation in cell.go).
+func (mgr *endpointManager) LookupIPAnyVNI(ip netip.Addr) *endpoint.Endpoint {
+	if !ip.IsValid() {
+		return nil
+	}
+	ipStr := ip.Unmap().String()
+	mgr.mutex.RLock()
+	defer mgr.mutex.RUnlock()
+	var ep *endpoint.Endpoint
+	if ip.Is4() {
+		ep = mgr.lookupIPv4(ipStr)
+	} else {
+		ep = mgr.lookupIPv6(ipStr)
+	}
+	if ep != nil {
+		return ep
+	}
+	for key := range mgr.ipToVNIAuxKeys[ipStr] {
+		if ep, ok := mgr.endpointsAux[key]; ok && mgr.endpoints[ep.ID] == ep {
+			return ep
+		}
+	}
+	return nil
 }
 
 // lookupVNIIPv4 looks up an endpoint by VNI-aware IPv4 identifier.
@@ -665,7 +721,27 @@ func (mgr *endpointManager) updateReferencesLocked(ep *endpoint.Endpoint, identi
 		id := endpointid.NewID(k, identifiers[k])
 		mgr.endpointsAux[id] = ep
 
+		// Keep the per-IP index of VNI-scoped keys in sync so that the
+		// explicit bare-IP fallback can resolve unambiguous IPs.
+		if ip, ok := bareIPOfVNIIdentifier(k, identifiers[k]); ok {
+			keys, exists := mgr.ipToVNIAuxKeys[ip]
+			if !exists {
+				keys = map[string]struct{}{}
+				mgr.ipToVNIAuxKeys[ip] = keys
+			}
+			keys[id] = struct{}{}
+		}
 	}
+}
+
+// bareIPOfVNIIdentifier returns the bare IP of a native-vpc VNI-scoped
+// endpoint identifier ("vni-ipv4"/"vni-ipv6" prefix, value "<vni>:<ip>").
+func bareIPOfVNIIdentifier(prefix endpointid.PrefixType, value string) (string, bool) {
+	switch prefix {
+	case endpointid.VNIIPv4Prefix, endpointid.VNIIPv6Prefix:
+		return endpointid.SplitVNIIP(value)
+	}
+	return "", false
 }
 
 // UpdateReferences updates maps the contents of mappings to the specified endpoint.
@@ -694,6 +770,15 @@ func (mgr *endpointManager) removeReferencesLocked(identifiers endpointid.Identi
 	for prefix := range identifiers {
 		id := endpointid.NewID(prefix, identifiers[prefix])
 		delete(mgr.endpointsAux, id)
+
+		if ip, ok := bareIPOfVNIIdentifier(prefix, identifiers[prefix]); ok {
+			if keys, exists := mgr.ipToVNIAuxKeys[ip]; exists {
+				delete(keys, id)
+				if len(keys) == 0 {
+					delete(mgr.ipToVNIAuxKeys, ip)
+				}
+			}
+		}
 	}
 }
 

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -825,7 +825,7 @@ func TestMissingNodeLabelsUpdate(t *testing.T) {
 
 	// Create host endpoint and expose it in the endpoint manager.
 	model := newTestEndpointModel(1, endpoint.StateReady)
-	kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
+	kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName), testipcache.NewMockIPCache())
 	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil)
 	require.NoError(t, err)
 
@@ -855,7 +855,7 @@ func TestMissingNodeLabelsUpdate(t *testing.T) {
 
 func TestUpdateHostEndpointLabels(t *testing.T) {
 	logger := hivetest.Logger(t)
-	kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
+	kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName), testipcache.NewMockIPCache())
 	// Initialize label filter config.
 	labelsfilter.ParseLabelPrefixCfg(logger, []string{"k8s:!ignore1", "k8s:!ignore2"}, nil, "")
 	s := setupEndpointManagerSuite(t)
@@ -941,7 +941,7 @@ func TestUpdateHostEndpointLabels(t *testing.T) {
 			preTestRun: func() {
 				model := newTestEndpointModel(1, endpoint.StateReady)
 				model.Labels = apiv1.Labels([]string{"k8s:k1=v1"})
-				kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName))
+				kvstoreSync := ipcache.NewIPIdentitySynchronizer(logger, kvstore.SetupDummy(t, kvstore.DisabledBackendName), testipcache.NewMockIPCache())
 				ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), kvstoreSync, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil)
 				ep.SetIsHost(true)
 				require.NoError(t, err)

--- a/pkg/endpointmanager/vni_lookup_test.go
+++ b/pkg/endpointmanager/vni_lookup_test.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpointmanager
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/identity/identitymanager"
+	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/testutils/identity"
+	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
+)
+
+// TestLookupIPVNIEndpoints verifies the endpointmanager side of the native-vpc
+// identity resolution chain: endpoints with a VNI register only VNI-scoped aux
+// identifiers (vni-ipv4:<vni>:<ip>), and the bare-IP lookups used by the DNS
+// proxy / Hubble / L7 accesslog resolve them when exactly one VNI uses the IP
+// on this node, while overlapping IPs (several VNIs) stay a deliberate miss.
+func TestLookupIPVNIEndpoints(t *testing.T) {
+	s := setupEndpointManagerSuite(t)
+	logger := hivetest.Logger(t)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
+
+	newEP := func(id int64, ip string, vni uint64) *endpoint.Endpoint {
+		model := newTestEndpointModel(int(id), endpoint.StateReady)
+		ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil)
+		require.NoError(t, err)
+		ep.Start(uint16(model.ID))
+		t.Cleanup(ep.Stop)
+		ep.IPv4 = netip.MustParseAddr(ip)
+		ep.VNIID = vni
+		return ep
+	}
+
+	ip := "192.168.1.2"
+	addr := netip.MustParseAddr(ip)
+
+	// Generic and bare-IP fallback lookups remain key-exact for VPC endpoints.
+	// Only an explicit VNI context can resolve the endpoint.
+	epA := newEP(10, ip, 36)
+	require.NoError(t, mgr.expose(epA))
+	require.Nil(t, mgr.LookupIPv4(ip), "generic bare-IP lookup must remain key-exact")
+	require.Nil(t, mgr.LookupIPUnambiguous(addr))
+	require.Same(t, epA, mgr.LookupIPWithVNI(addr, 36))
+
+	// Second endpoint, same IP, different VNI: the bare-IP lookup is now
+	// ambiguous and must miss (never guess a VNI).
+	epB := newEP(11, ip, 17)
+	require.NoError(t, mgr.expose(epB))
+	require.Nil(t, mgr.LookupIPv4(ip), "overlapping IP across VNIs must not resolve")
+
+	// The VNI-scoped identifier lookups stay exact.
+	gotA, err := mgr.Lookup("vni-ipv4:36:" + ip)
+	require.NoError(t, err)
+	require.Equal(t, epA, gotA)
+	gotB, err := mgr.Lookup("vni-ipv4:17:" + ip)
+	require.NoError(t, err)
+	require.Equal(t, epB, gotB)
+
+	// Removing one endpoint does not make a VPC endpoint resolvable without VNI.
+	mgr.WaitEndpointRemoved(epA)
+	require.Nil(t, mgr.LookupIPUnambiguous(addr))
+	require.Same(t, epB, mgr.LookupIPWithVNI(addr, 17))
+
+	// Removing the last one cleans the index entirely.
+	mgr.WaitEndpointRemoved(epB)
+	require.Nil(t, mgr.LookupIPv4(ip))
+	require.Nil(t, mgr.LookupIPWithVNI(addr, 17))
+}
+
+// TestLookupIPVNIAndPlainMixed pins the plain/VNI mixed case: generic plain
+// readers see only the plain namespace, while VNI readers must provide VNI.
+func TestLookupIPVNIAndPlainMixed(t *testing.T) {
+	s := setupEndpointManagerSuite(t)
+	logger := hivetest.Logger(t)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
+
+	newEP := func(id int64, ip string, vni uint64) *endpoint.Endpoint {
+		model := newTestEndpointModel(int(id), endpoint.StateReady)
+		ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil)
+		require.NoError(t, err)
+		ep.Start(uint16(model.ID))
+		t.Cleanup(ep.Stop)
+		ep.IPv4 = netip.MustParseAddr(ip)
+		ep.VNIID = vni
+		return ep
+	}
+
+	ip := "192.168.1.3"
+	addr := netip.MustParseAddr(ip)
+	plain := newEP(20, ip, 0)
+	vpc := newEP(21, ip, 36)
+	require.NoError(t, mgr.expose(plain))
+	require.NoError(t, mgr.expose(vpc))
+
+	require.Equal(t, plain, mgr.LookupIPUnambiguous(addr), "plain fallback is valid for the non-VPC endpoint")
+	require.Same(t, vpc, mgr.LookupIPWithVNI(addr, 36), "the VNI endpoint requires explicit VNI context")
+
+	mgr.WaitEndpointRemoved(plain)
+	require.Nil(t, mgr.LookupIPUnambiguous(addr), "bare-IP readers must not resolve VNI endpoints")
+	require.Same(t, vpc, mgr.LookupIPWithVNI(addr, 36))
+	mgr.WaitEndpointRemoved(vpc)
+}
+
+func TestUpdateReferencesVNIReplacement(t *testing.T) {
+	s := setupEndpointManagerSuite(t)
+	logger := hivetest.Logger(t)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
+	model := newTestEndpointModel(30, endpoint.StateReady)
+	ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil)
+	require.NoError(t, err)
+	ep.Start(uint16(model.ID))
+	t.Cleanup(ep.Stop)
+	ep.IPv4 = netip.MustParseAddr("192.0.2.30")
+	ep.VNIID = 36
+	require.NoError(t, mgr.expose(ep))
+	ep.VNIID = 17
+	require.NoError(t, mgr.UpdateReferences(ep))
+	old, err := mgr.Lookup("vni-ipv4:36:192.0.2.30")
+	require.NoError(t, err)
+	require.Nil(t, old)
+	newEP, err := mgr.Lookup("vni-ipv4:17:192.0.2.30")
+	require.NoError(t, err)
+	require.Same(t, ep, newEP)
+	mgr.WaitEndpointRemoved(ep)
+}

--- a/pkg/endpointmanager/vni_lookup_test.go
+++ b/pkg/endpointmanager/vni_lookup_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils/identity"
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 )
@@ -134,4 +135,59 @@ func TestUpdateReferencesVNIReplacement(t *testing.T) {
 	require.NoError(t, err)
 	require.Same(t, ep, newEP)
 	mgr.WaitEndpointRemoved(ep)
+}
+
+// TestOverlappingIPsMetric pins the conntrack-plane guard: the number of IPs
+// used by more than one local endpoint in different VNIs must be observable,
+// because that is exactly the precondition for two VPCs sharing a conntrack
+// entry (the CT key is the bare 5-tuple, with no VNI).
+func TestOverlappingIPsMetric(t *testing.T) {
+	prev := option.Config.EnableNativeVPC
+	option.Config.EnableNativeVPC = true
+	t.Cleanup(func() { option.Config.EnableNativeVPC = prev })
+
+	s := setupEndpointManagerSuite(t)
+	logger := hivetest.Logger(t)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
+
+	newEP := func(id int64, ip string, vni uint64) *endpoint.Endpoint {
+		model := newTestEndpointModel(int(id), endpoint.StateReady)
+		ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil)
+		require.NoError(t, err)
+		ep.Start(uint16(model.ID))
+		t.Cleanup(ep.Stop)
+		ep.IPv4 = netip.MustParseAddr(ip)
+		ep.VNIID = vni
+		return ep
+	}
+
+	count := func() int {
+		mgr.mutex.RLock()
+		defer mgr.mutex.RUnlock()
+		var n int
+		for _, keys := range mgr.ipToVNIAuxKeys {
+			if len(keys) > 1 {
+				n++
+			}
+		}
+		return n
+	}
+
+	a := newEP(40, "192.0.2.40", 36)
+	require.NoError(t, mgr.expose(a))
+	require.Zero(t, count(), "a single VNI per IP is not an overlap")
+
+	b := newEP(41, "192.0.2.40", 17)
+	require.NoError(t, mgr.expose(b))
+	require.Equal(t, 1, count(), "the same IP in two VPCs is a CT-collision precondition")
+
+	// A third VPC on the same IP is still one overlapping IP.
+	c := newEP(42, "192.0.2.40", 99)
+	require.NoError(t, mgr.expose(c))
+	require.Equal(t, 1, count())
+
+	mgr.WaitEndpointRemoved(b)
+	mgr.WaitEndpointRemoved(c)
+	require.Zero(t, count(), "the condition clears when the overlap is gone")
+	mgr.WaitEndpointRemoved(a)
 }

--- a/pkg/endpointmanager/vni_lookup_test.go
+++ b/pkg/endpointmanager/vni_lookup_test.go
@@ -20,8 +20,8 @@ import (
 
 // TestLookupIPVNIEndpoints verifies the endpointmanager side of the native-vpc
 // identity resolution chain: endpoints with a VNI register only VNI-scoped aux
-// identifiers (vni-ipv4:<vni>:<ip>), and the bare-IP lookups used by the DNS
-// proxy / Hubble / L7 accesslog resolve them when exactly one VNI uses the IP
+// identifiers (vni-ipv4:<vni>:<ip>), and the bare-IP fallback used by the DNS
+// proxy / Hubble / L7 accesslog resolves them when exactly one VNI uses the IP
 // on this node, while overlapping IPs (several VNIs) stay a deliberate miss.
 func TestLookupIPVNIEndpoints(t *testing.T) {
 	s := setupEndpointManagerSuite(t)
@@ -42,12 +42,12 @@ func TestLookupIPVNIEndpoints(t *testing.T) {
 	ip := "192.168.1.2"
 	addr := netip.MustParseAddr(ip)
 
-	// Generic and bare-IP fallback lookups remain key-exact for VPC endpoints.
-	// Only an explicit VNI context can resolve the endpoint.
+	// Generic (key-exact) lookups never resolve a VPC endpoint from a bare IP.
+	// The explicit fallback does, as long as the IP is used by a single VNI.
 	epA := newEP(10, ip, 36)
 	require.NoError(t, mgr.expose(epA))
 	require.Nil(t, mgr.LookupIPv4(ip), "generic bare-IP lookup must remain key-exact")
-	require.Nil(t, mgr.LookupIPUnambiguous(addr))
+	require.Same(t, epA, mgr.LookupIPUnambiguous(addr), "single-VNI IP must resolve for bare-IP consumers")
 	require.Same(t, epA, mgr.LookupIPWithVNI(addr, 36))
 
 	// Second endpoint, same IP, different VNI: the bare-IP lookup is now
@@ -55,6 +55,8 @@ func TestLookupIPVNIEndpoints(t *testing.T) {
 	epB := newEP(11, ip, 17)
 	require.NoError(t, mgr.expose(epB))
 	require.Nil(t, mgr.LookupIPv4(ip), "overlapping IP across VNIs must not resolve")
+	require.Nil(t, mgr.LookupIPUnambiguous(addr), "overlapping IP must fail closed")
+	require.NotNil(t, mgr.LookupIPAnyVNI(addr), "in-use checks must still see the IP")
 
 	// The VNI-scoped identifier lookups stay exact.
 	gotA, err := mgr.Lookup("vni-ipv4:36:" + ip)
@@ -64,14 +66,16 @@ func TestLookupIPVNIEndpoints(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, epB, gotB)
 
-	// Removing one endpoint does not make a VPC endpoint resolvable without VNI.
+	// Removing one endpoint makes the IP unambiguous again.
 	mgr.WaitEndpointRemoved(epA)
-	require.Nil(t, mgr.LookupIPUnambiguous(addr))
+	require.Same(t, epB, mgr.LookupIPUnambiguous(addr))
 	require.Same(t, epB, mgr.LookupIPWithVNI(addr, 17))
 
 	// Removing the last one cleans the index entirely.
 	mgr.WaitEndpointRemoved(epB)
 	require.Nil(t, mgr.LookupIPv4(ip))
+	require.Nil(t, mgr.LookupIPUnambiguous(addr))
+	require.Nil(t, mgr.LookupIPAnyVNI(addr))
 	require.Nil(t, mgr.LookupIPWithVNI(addr, 17))
 }
 
@@ -100,11 +104,11 @@ func TestLookupIPVNIAndPlainMixed(t *testing.T) {
 	require.NoError(t, mgr.expose(plain))
 	require.NoError(t, mgr.expose(vpc))
 
-	require.Equal(t, plain, mgr.LookupIPUnambiguous(addr), "plain fallback is valid for the non-VPC endpoint")
+	require.Equal(t, plain, mgr.LookupIPUnambiguous(addr), "the plain entry wins over the VNI fallback")
 	require.Same(t, vpc, mgr.LookupIPWithVNI(addr, 36), "the VNI endpoint requires explicit VNI context")
 
 	mgr.WaitEndpointRemoved(plain)
-	require.Nil(t, mgr.LookupIPUnambiguous(addr), "bare-IP readers must not resolve VNI endpoints")
+	require.Same(t, vpc, mgr.LookupIPUnambiguous(addr), "single remaining VNI endpoint resolves")
 	require.Same(t, vpc, mgr.LookupIPWithVNI(addr, 36))
 	mgr.WaitEndpointRemoved(vpc)
 }

--- a/pkg/endpointmanager/vni_lookup_test.go
+++ b/pkg/endpointmanager/vni_lookup_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/option"
-	"github.com/cilium/cilium/pkg/testutils/identity"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 )
 

--- a/pkg/endpointmanager/vni_lookup_test.go
+++ b/pkg/endpointmanager/vni_lookup_test.go
@@ -191,3 +191,50 @@ func TestOverlappingIPsMetric(t *testing.T) {
 	require.Zero(t, count(), "the condition clears when the overlap is gone")
 	mgr.WaitEndpointRemoved(a)
 }
+
+// TestUnexposeRemovesOnlyItsOwnReferences covers what happens when an address
+// is handed to a new endpoint before the old one has finished being torn down.
+//
+// A pod that is deleted and recreated on the same address in the same VPC
+// produces exactly that: the new endpoint registers the (VNI, IP) identifier,
+// which is the only way this address can be resolved - endpoints in a VPC
+// deliberately register no bare-address identifier - and the old endpoint's
+// teardown runs afterwards. Removing the identifier because the old endpoint
+// once registered it would leave the running pod unresolvable, so the removal
+// only applies to references that still point at the endpoint being removed.
+func TestUnexposeRemovesOnlyItsOwnReferences(t *testing.T) {
+	s := setupEndpointManagerSuite(t)
+	logger := hivetest.Logger(t)
+	mgr := New(logger, nil, &dummyEpSyncher{}, nil, nil, nil, defaultEndpointManagerConfig)
+
+	newEP := func(id int64, ip string, vni uint64) *endpoint.Endpoint {
+		model := newTestEndpointModel(int(id), endpoint.StateReady)
+		ep, err := endpoint.NewEndpointFromChangeModel(t.Context(), logger, nil, &endpoint.MockEndpointBuildQueue{}, nil, nil, nil, nil, nil, identitymanager.NewIDManager(logger), nil, nil, s.repo, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), ctmap.NewFakeGCRunner(), nil, model, fakeTypes.WireguardConfig{}, fakeTypes.IPsecConfig{}, nil, nil)
+		require.NoError(t, err)
+		ep.Start(uint16(model.ID))
+		t.Cleanup(ep.Stop)
+		ep.IPv4 = netip.MustParseAddr(ip)
+		ep.VNIID = vni
+		return ep
+	}
+
+	const ip = "10.99.0.11"
+	addr := netip.MustParseAddr(ip)
+
+	old := newEP(20, ip, 5)
+	require.NoError(t, mgr.expose(old))
+	require.Same(t, old, mgr.LookupIPWithVNI(addr, 5))
+
+	// The replacement takes the same address in the same VPC and is exposed
+	// while the previous endpoint is still being removed.
+	fresh := newEP(21, ip, 5)
+	require.NoError(t, mgr.expose(fresh))
+	require.Same(t, fresh, mgr.LookupIPWithVNI(addr, 5), "the newest endpoint owns the identifier")
+
+	mgr.unexpose(old)
+
+	require.Same(t, fresh, mgr.LookupIPWithVNI(addr, 5),
+		"the running endpoint must keep its identifier when its predecessor is removed")
+	require.Same(t, fresh, mgr.LookupIPUnambiguous(addr))
+	require.NotNil(t, mgr.LookupIPAnyVNI(addr), "the per-IP index must still know the address is in use")
+}

--- a/pkg/envoy/test/updater_mock.go
+++ b/pkg/envoy/test/updater_mock.go
@@ -13,6 +13,9 @@ type ProxyUpdaterMock struct {
 	Id   uint64
 	Ipv4 string
 	Ipv6 string
+	// VNIID is the native-vpc scope; zero means the endpoint is not in a VPC,
+	// which is what the existing tests exercise.
+	VNIID uint64
 }
 
 func (m *ProxyUpdaterMock) GetPolicyNames() []string {
@@ -27,7 +30,8 @@ func (m *ProxyUpdaterMock) GetPolicyNames() []string {
 	return res
 }
 
-func (m *ProxyUpdaterMock) GetID() uint64 { return m.Id }
+func (m *ProxyUpdaterMock) GetID() uint64    { return m.Id }
+func (m *ProxyUpdaterMock) GetVNIID() uint64 { return m.VNIID }
 
 func (m *ProxyUpdaterMock) GetIPv4Address() string { return m.Ipv4 }
 

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1798,6 +1798,25 @@ func getNodeIDs(ep endpoint.EndpointUpdater, policy *policy.L4Policy) []string {
 // implemented by Cilium.
 var ErrNilPolicy = errors.New("nil EndpointPolicy")
 
+// vpcEndpointPolicy decides what the proxy may be told about an endpoint that
+// lives in a VPC.
+//
+// A policy pushed to Envoy is found again by the endpoint's address, which is
+// not unique once VPC subnets overlap: the endpoints sharing an address in
+// different VPCs would push over each other, and the last one to regenerate
+// would decide what the proxy enforces for all of them. Nothing is therefore
+// pushed for such an endpoint. A policy that only the proxy can enforce cannot
+// be honoured either, and is refused instead of being applied to whichever
+// endpoint happens to share the address.
+func vpcEndpointPolicy(vni, epID uint64, needsEnvoy bool) (error, func() error) {
+	if needsEnvoy {
+		return fmt.Errorf("native-vpc: refusing L7 policy for endpoint %d in VPC %d: "+
+			"the proxy identifies endpoints by address, which overlapping VPC subnets make ambiguous",
+			epID, vni), nil
+	}
+	return nil, func() error { return nil }
+}
+
 func (s *xdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, epp *policy.EndpointPolicy, wg *completion.WaitGroup,
 ) (error, func() error) {
 	s.mutex.Lock()
@@ -1815,6 +1834,10 @@ func (s *xdsServer) UpdateNetworkPolicy(ep endpoint.EndpointUpdater, epp *policy
 	// Error out if the selectors are no longer valid
 	if !selectors.IsValid() {
 		return policy.ErrStaleSelectors, nil
+	}
+
+	if vni := ep.GetVNIID(); vni != 0 {
+		return vpcEndpointPolicy(vni, ep.GetID(), epp.SelectorPolicy.L4Policy.HasEnvoyRedirect())
 	}
 
 	ips := ep.GetPolicyNames()

--- a/pkg/envoy/xds_server_vni_test.go
+++ b/pkg/envoy/xds_server_vni_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package envoy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestVPCEndpointPolicy covers what the proxy may be told about an endpoint
+// that lives in a VPC.
+//
+// Envoy finds the policy of a connection by the endpoint's address. With
+// overlapping VPC subnets that address is shared, so a policy pushed for one
+// endpoint would be found for an endpoint in another VPC, and the last endpoint
+// to regenerate would decide what the proxy enforces for all of them. Nothing
+// is pushed for such an endpoint, and a policy that only the proxy could
+// enforce is refused rather than applied to whoever shares the address.
+func TestVPCEndpointPolicy(t *testing.T) {
+	t.Run("no proxy policy is pushed", func(t *testing.T) {
+		err, revert := vpcEndpointPolicy(5, 42, false)
+		require.NoError(t, err)
+		require.NotNil(t, revert, "the caller pushes this onto its revert stack")
+		require.NoError(t, revert())
+	})
+
+	t.Run("a policy that needs the proxy is refused", func(t *testing.T) {
+		err, _ := vpcEndpointPolicy(5, 42, true)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "native-vpc")
+		require.Contains(t, err.Error(), "VPC 5")
+	})
+}

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -187,7 +187,25 @@ type restoredIPRule struct {
 }
 
 // map from EP IPs to *Endpoint
-type restoredEPs map[netip.Addr]*endpoint.Endpoint
+// restoredEPs maps a bare endpoint IP to the restored endpoints using it.
+// Native-vpc: several endpoints on this node may share the same IP with
+// different VNIs, so the value is a small slice rather than a single pointer;
+// the bare-IP lookup only resolves when exactly one restored endpoint uses
+// the IP (never guessing a VNI under overlap).
+type restoredEPs map[netip.Addr][]*endpoint.Endpoint
+
+// appendRestoredEP adds ep to the per-IP restored endpoint list, replacing a
+// previous entry with the same endpoint ID (RestoreRules may be re-invoked
+// for the same endpoint) instead of duplicating it.
+func appendRestoredEP(eps []*endpoint.Endpoint, ep *endpoint.Endpoint) []*endpoint.Endpoint {
+	for i, old := range eps {
+		if old.ID == ep.ID {
+			eps[i] = ep
+			return eps
+		}
+	}
+	return append(eps, ep)
+}
 
 // asIPRule returns a new restore.IPRule representing the rules, including the provided IP map.
 func asIPRule(r *regexp.Regexp, IPs map[restore.RuleIPOrCIDR]struct{}) restore.IPRule {
@@ -361,10 +379,10 @@ func (p *DNSProxy) RestoreRules(ep *endpoint.Endpoint) {
 	p.Lock()
 	defer p.Unlock()
 	if ep.IPv4.IsValid() {
-		p.restoredEPs[ep.IPv4] = ep
+		p.restoredEPs[ep.IPv4] = appendRestoredEP(p.restoredEPs[ep.IPv4], ep)
 	}
 	if ep.IPv6.IsValid() {
-		p.restoredEPs[ep.IPv6] = ep
+		p.restoredEPs[ep.IPv6] = appendRestoredEP(p.restoredEPs[ep.IPv6], ep)
 	}
 	if ep.IsHost() {
 		p.restoredHost = ep
@@ -412,9 +430,17 @@ func (p *DNSProxy) RestoreRules(ep *endpoint.Endpoint) {
 func (p *DNSProxy) removeRestoredRulesLocked(endpointID uint64) {
 	if _, exists := p.restored[endpointID]; exists {
 		// Remove IP->ID mappings for the restored EP
-		for ip, ep := range p.restoredEPs {
-			if ep.ID == uint16(endpointID) {
+		for ip, eps := range p.restoredEPs {
+			kept := eps[:0]
+			for _, ep := range eps {
+				if ep.ID != uint16(endpointID) {
+					kept = append(kept, ep)
+				}
+			}
+			if len(kept) == 0 {
 				delete(p.restoredEPs, ip)
+			} else {
+				p.restoredEPs[ip] = kept
 			}
 		}
 		for _, rule := range p.restored[endpointID] {
@@ -737,10 +763,12 @@ func shutdownServers(logger *slog.Logger, dnsServers []*dns.Server) {
 // LookupEndpointByIP wraps LookupRegisteredEndpoint by falling back to an restored EP, if available
 func (p *DNSProxy) LookupEndpointByIP(ip netip.Addr) (endpoint *endpoint.Endpoint, isHost bool, err error) {
 	if endpoint, isHost, err = p.proxyLookupHandler.LookupRegisteredEndpoint(ip); err != nil {
-		// Check restored endpoints
-		var found bool
-		if endpoint, found = p.restoredEPs[ip]; found {
-			return endpoint, endpoint.IsHost(), nil
+		// Check restored endpoints. Only resolve when the bare IP maps to
+		// exactly one restored endpoint: with native-vpc IP overlap the DNS
+		// proxy cannot tell which VNI the connection belongs to, so it fails
+		// closed rather than applying another VPC's restored rules.
+		if eps := p.restoredEPs[ip]; len(eps) == 1 {
+			return eps[0], eps[0].IsHost(), nil
 		}
 		if isHost && p.restoredHost != nil {
 			return p.restoredHost, true, nil
@@ -997,7 +1025,11 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 
 	// Ignore invalid IP - getter will handle invalid value.
 	targetServerID := identity.GetWorldIdentityFromIP(targetServer.Addr())
-	if serverSecID, exists := p.proxyLookupHandler.LookupSecIDByIP(targetServer.Addr()); !exists {
+	// The DNS proxy only has the target's bare IP. Use the explicit
+	// unambiguous lookup so a single native-vpc entry can be resolved without
+	// weakening the generic key-exact ipcache semantics; overlapping IPs stay
+	// ambiguous and correctly fall back to WORLD instead of guessing a VPC.
+	if serverSecID, exists := p.proxyLookupHandler.LookupSecIDByIPUnambiguous(targetServer.Addr()); !exists {
 		scopedLog.Debug(
 			"cannot find server ip in ipcache, defaulting to WORLD",
 			logfields.Server, targetServer.Addr(),

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -153,6 +153,10 @@ func (s *DNSProxyTestSuite) LookupSecIDByIP(ip netip.Addr) (secID ipcache.Identi
 	}
 }
 
+func (s *DNSProxyTestSuite) LookupSecIDByIPUnambiguous(ip netip.Addr) (secID ipcache.Identity, exists bool) {
+	return s.LookupSecIDByIP(ip)
+}
+
 func (s *DNSProxyTestSuite) LookupByIdentity(nid identity.NumericIdentity) []string {
 	DNSServerListenerAddr := (s.dnsServer.Listener.Addr()).(*net.TCPAddr)
 	switch nid {

--- a/pkg/fqdn/dnsproxy/restored_eps_vni_test.go
+++ b/pkg/fqdn/dnsproxy/restored_eps_vni_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package dnsproxy
+
+import (
+	"errors"
+	"log/slog"
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+)
+
+type restoredLookupStub struct{}
+
+func (restoredLookupStub) LookupRegisteredEndpoint(netip.Addr) (*endpoint.Endpoint, bool, error) {
+	return nil, false, errors.New("endpoint manager unavailable during restore")
+}
+func (restoredLookupStub) LookupSecIDByIP(netip.Addr) (ipcache.Identity, bool) {
+	return ipcache.Identity{}, false
+}
+func (restoredLookupStub) LookupSecIDByIPUnambiguous(netip.Addr) (ipcache.Identity, bool) {
+	return ipcache.Identity{}, false
+}
+func (restoredLookupStub) LookupByIdentity(identity.NumericIdentity) []string { return nil }
+
+// TestLookupEndpointByIPRestoredVNIOverlap exercises the actual DNS proxy
+// fallback, rather than only testing the restoredEPs slice helper.
+func TestLookupEndpointByIPRestoredVNIOverlap(t *testing.T) {
+	ip := netip.MustParseAddr("192.168.1.2")
+	p := &DNSProxy{
+		proxyLookupHandler: restoredLookupStub{},
+		restoredEPs:        restoredEPs{},
+		restored:           perEPRestored{},
+		logger:             slog.Default(),
+	}
+	epA := &endpoint.Endpoint{ID: 10, IPv4: ip, VNIID: 36}
+	epB := &endpoint.Endpoint{ID: 11, IPv4: ip, VNIID: 17}
+
+	p.RestoreRules(epA)
+	got, _, err := p.LookupEndpointByIP(ip)
+	require.NoError(t, err)
+	require.Same(t, epA, got)
+
+	p.RestoreRules(epB)
+	got, _, err = p.LookupEndpointByIP(ip)
+	require.Error(t, err, "same bare IP across VNIs must fail closed")
+	require.Nil(t, got)
+
+	// RestoreRules installs an empty ruleset in p.restored; removing epA must
+	// retain epB's restored IP mapping.
+	p.RemoveRestoredRules(epA.ID)
+	got, _, err = p.LookupEndpointByIP(ip)
+	require.NoError(t, err)
+	require.Same(t, epB, got)
+
+	p.RemoveRestoredRules(epB.ID)
+	got, _, err = p.LookupEndpointByIP(ip)
+	require.Error(t, err)
+	require.Nil(t, got)
+}

--- a/pkg/fqdn/lookup/endpoint.go
+++ b/pkg/fqdn/lookup/endpoint.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 type ProxyLookupHandler interface {
@@ -61,7 +62,26 @@ func (p *proxyLookupHandler) LookupRegisteredEndpoint(endpointAddr netip.Addr) (
 		}
 	}
 
-	return nil, false, fmt.Errorf("cannot find endpoint with IP %s", endpointAddr.String())
+	return nil, false, endpointLookupError(p.endpointManager, endpointAddr)
+}
+
+// endpointLookupError explains why an address could not be attributed to an
+// endpoint.
+//
+// The proxy is reached from the host namespace and has only the address of the
+// connection to work with. That is enough while an address belongs to one
+// endpoint, and it stops being enough the moment several VPCs use it: the
+// lookup then refuses to answer rather than picking one of them, and the query
+// is dropped. Saying which of the two situations it is turns a stream of
+// "cannot find endpoint" failures into something an operator can act on -
+// either the address really is unknown, or DNS policy cannot be applied to this
+// address at all.
+func endpointLookupError(mgr endpointmanager.EndpointManager, addr netip.Addr) error {
+	if option.Config.EnableNativeVPC && endpointmanager.LookupIPAnyVNI(mgr, addr) != nil {
+		return fmt.Errorf("cannot attribute IP %s to an endpoint: it is used by endpoints in more than one VPC, "+
+			"and the proxy sees only the address", addr)
+	}
+	return fmt.Errorf("cannot find endpoint with IP %s", addr)
 }
 
 func (p *proxyLookupHandler) LookupSecIDByIP(ip netip.Addr) (secID ipcache.Identity, exists bool) {

--- a/pkg/fqdn/lookup/endpoint.go
+++ b/pkg/fqdn/lookup/endpoint.go
@@ -17,16 +17,21 @@ import (
 )
 
 type ProxyLookupHandler interface {
-	// LookupSecIDByIP looks up the security ID for a given IP address
-	// from the ipcache.
+	// LookupSecIDByIP looks up the security ID for a given IP address from the
+	// key-exact (bare-IP) ipcache entry.
 	LookupSecIDByIP(ip netip.Addr) (secID ipcache.Identity, exists bool)
+
+	// LookupSecIDByIPUnambiguous is the explicit best-effort exception used by
+	// the DNS proxy: if the bare-IP entry is absent it resolves a native-vpc
+	// VNI-scoped entry only when exactly one VPC uses the IP, and reports a
+	// miss under overlap rather than guessing a VPC.
+	LookupSecIDByIPUnambiguous(ip netip.Addr) (secID ipcache.Identity, exists bool)
 
 	// LookupByIdentity is a provided callback that returns the IPs of a given security ID.
 	LookupByIdentity(nid identity.NumericIdentity) []string
 
-	// LookupRegisteredEndpoint looks up the endpoint corresponding
-	// to a given IP address. It correctly handles *all* IPs belonging to the node, not just that
-	// of the node endpoint.
+	// LookupRegisteredEndpoint looks up non-VPC endpoints by bare IP. Native-VPC
+	// endpoints require VNI context and are intentionally unresolved here.
 	LookupRegisteredEndpoint(endpointAddr netip.Addr) (endpoint *endpoint.Endpoint, isHost bool, err error)
 }
 
@@ -39,7 +44,7 @@ type proxyLookupHandler struct {
 var _ ProxyLookupHandler = &proxyLookupHandler{}
 
 func (p *proxyLookupHandler) LookupRegisteredEndpoint(endpointAddr netip.Addr) (endpoint *endpoint.Endpoint, isHost bool, err error) {
-	if e := p.endpointManager.LookupIP(endpointAddr); e != nil {
+	if e := endpointmanager.LookupIPUnambiguous(p.endpointManager, endpointAddr); e != nil {
 		return e, e.IsHost(), nil
 	}
 
@@ -61,6 +66,10 @@ func (p *proxyLookupHandler) LookupRegisteredEndpoint(endpointAddr netip.Addr) (
 
 func (p *proxyLookupHandler) LookupSecIDByIP(ip netip.Addr) (secID ipcache.Identity, exists bool) {
 	return p.ipCache.LookupSecIDByIP(ip)
+}
+
+func (p *proxyLookupHandler) LookupSecIDByIPUnambiguous(ip netip.Addr) (secID ipcache.Identity, exists bool) {
+	return p.ipCache.LookupSecIDByIPUnambiguous(ip)
 }
 
 func (p *proxyLookupHandler) LookupByIdentity(nid identity.NumericIdentity) []string {

--- a/pkg/fqdn/lookup/endpoint_vni_test.go
+++ b/pkg/fqdn/lookup/endpoint_vni_test.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package lookup
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// vniEndpointManager answers the two questions the lookup asks: which endpoint
+// owns this address unambiguously, and is the address in use at all.
+type vniEndpointManager struct {
+	endpointmanager.EndpointManager
+	unambiguous *endpoint.Endpoint
+	any         *endpoint.Endpoint
+}
+
+func (m vniEndpointManager) LookupIPUnambiguous(netip.Addr) *endpoint.Endpoint { return m.unambiguous }
+func (m vniEndpointManager) LookupIPAnyVNI(netip.Addr) *endpoint.Endpoint      { return m.any }
+func (m vniEndpointManager) LookupIP(netip.Addr) *endpoint.Endpoint            { return m.any }
+
+// TestEndpointLookupError covers what the proxy is told when it cannot
+// attribute an address.
+//
+// The proxy is reached from the host namespace with only the address of the
+// connection, so an address several VPCs use cannot be attributed to one of
+// them and the query is refused. That refusal is correct, but it looks exactly
+// like an unknown address unless it says so - and the two call for opposite
+// reactions from whoever is reading the log.
+func TestEndpointLookupError(t *testing.T) {
+	addr := netip.MustParseAddr("10.99.0.11")
+	prev := option.Config.EnableNativeVPC
+	t.Cleanup(func() { option.Config.EnableNativeVPC = prev })
+
+	t.Run("an address no endpoint uses", func(t *testing.T) {
+		option.Config.EnableNativeVPC = true
+		err := endpointLookupError(vniEndpointManager{}, addr)
+		require.ErrorContains(t, err, "cannot find endpoint")
+		require.NotContains(t, err.Error(), "more than one VPC")
+	})
+
+	t.Run("an address several VPCs use", func(t *testing.T) {
+		option.Config.EnableNativeVPC = true
+		err := endpointLookupError(vniEndpointManager{any: &endpoint.Endpoint{}}, addr)
+		require.ErrorContains(t, err, "more than one VPC")
+		require.ErrorContains(t, err, addr.String())
+	})
+
+	t.Run("outside native-vpc the message is unchanged", func(t *testing.T) {
+		option.Config.EnableNativeVPC = false
+		err := endpointLookupError(vniEndpointManager{any: &endpoint.Endpoint{}}, addr)
+		require.ErrorContains(t, err, "cannot find endpoint")
+	})
+}

--- a/pkg/fqdn/service/service.go
+++ b/pkg/fqdn/service/service.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"iter"
 	"log/slog"
+	"maps"
 	"net"
 	"net/netip"
 	"strings"
@@ -23,6 +24,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/counter"
+	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/fqdn/dnsproxy"
 	"github.com/cilium/cilium/pkg/fqdn/messagehandler"
@@ -36,6 +38,22 @@ import (
 
 	pb "github.com/cilium/cilium/api/v1/standalone-dns-proxy"
 )
+
+func endpointVNI(lookup endpointmanager.EndpointsLookup, id uint64) uint64 {
+	for _, ep := range lookup.GetEndpoints() {
+		if uint64(ep.GetID()) == id {
+			return ep.GetVNIID()
+		}
+	}
+	return 0
+}
+
+func lookupEndpointWithVNI(lookup endpointmanager.EndpointsLookup, ip netip.Addr, vni uint32) *endpoint.Endpoint {
+	if vniLookup, ok := lookup.(endpointmanager.EndpointsLookupVNI); ok {
+		return vniLookup.LookupIPWithVNI(ip, uint64(vni))
+	}
+	return nil
+}
 
 // FQDNDataServer is the server for the standalone DNS proxy grpc server
 // It is responsible for handling the FQDN mapping requests from the SDP
@@ -125,6 +143,9 @@ var _ statedb.TableWritable = PolicyRules{}
 type identityToIPs struct {
 	Identity identity.NumericIdentity
 	IPs      part.Set[netip.Prefix]
+	// VNIs preserves the VNI alongside each prefix. A zero value denotes the
+	// non-VPC/plain namespace; non-zero values are required for exact lookup.
+	VNIs map[string]uint32
 }
 
 // TableHeader implements statedb.TableWritable.
@@ -276,6 +297,7 @@ func (s *FQDNDataServer) sendAndRecvAckForDNSPolicies(stream pb.FQDNData_StreamP
 	var identityToPrefixMapping []*pb.IdentityToPrefixMapping
 	// Process identity to IPs mappings - build both for quick lookup map and endpoint mappings
 	identityIPMap := make(map[identity.NumericIdentity][]netip.Prefix)
+	identityIPMapVNI := make(map[identity.NumericIdentity]map[string]uint32)
 
 	for identityIP := range identityToIPs {
 		var prefixes []netip.Prefix
@@ -285,7 +307,13 @@ func (s *FQDNDataServer) sendAndRecvAckForDNSPolicies(stream pb.FQDNData_StreamP
 			prefixes = append(prefixes, prefix)
 
 			ip := prefix.Addr()
-			ep := s.endpointsLookup.LookupIP(ip)
+			vni := identityIP.VNIs[prefix.String()]
+			var ep *endpoint.Endpoint
+			if vni > 0 {
+				ep = lookupEndpointWithVNI(s.endpointsLookup, ip, vni)
+			} else {
+				ep = endpointmanager.LookupIPUnambiguous(s.endpointsLookup, ip)
+			}
 			if ep != nil {
 				epID := uint64(ep.GetID())
 				endpointToIPsBytes[epID] = append(endpointToIPsBytes[epID], ip.AsSlice())
@@ -294,13 +322,15 @@ func (s *FQDNDataServer) sendAndRecvAckForDNSPolicies(stream pb.FQDNData_StreamP
 
 		// Store prefixes for DNS policy processing
 		identityIPMap[identityIP.Identity] = prefixes
+		identityIPMapVNI[identityIP.Identity] = identityIP.VNIs
 
 		// Create EndpointInfo structures to be sent to the client
 		var endpointInfos []*pb.EndpointInfo
 		for epID, ipBytes := range endpointToIPsBytes {
 			endpointInfo := &pb.EndpointInfo{
-				Id: epID,
-				Ip: ipBytes,
+				Id:  epID,
+				Ip:  ipBytes,
+				Vni: uint32(endpointVNI(s.endpointsLookup, epID)),
 			}
 			endpointInfos = append(endpointInfos, endpointInfo)
 		}
@@ -341,7 +371,13 @@ func (s *FQDNDataServer) sendAndRecvAckForDNSPolicies(stream pb.FQDNData_StreamP
 			// For each IP, find the corresponding endpoint and create DNS policy
 			for _, prefix := range epIPs {
 				ip := prefix.Addr()
-				ep := s.endpointsLookup.LookupIP(ip)
+				vni := identityIPMapVNI[rule.Identity][prefix.String()]
+				var ep *endpoint.Endpoint
+				if vni > 0 {
+					ep = lookupEndpointWithVNI(s.endpointsLookup, ip, vni)
+				} else {
+					ep = endpointmanager.LookupIPUnambiguous(s.endpointsLookup, ip)
+				}
 				if ep == nil {
 					// If the endpoint is not found, log a warning
 					s.log.Debug("Endpoint not found for IP", logfields.IPAddr, ip)
@@ -452,14 +488,17 @@ func (s *FQDNDataServer) OnIPIdentityCacheChange(modType ipcache.CacheModificati
 			newObj := identityToIPs{
 				Identity: newID.ID,
 				IPs:      part.NewSet(prefix),
+				VNIs:     map[string]uint32{prefix.String(): newID.Vni},
 			}
 			_, _, err := s.identityToIPsTable.Modify(txn, newObj, func(oldObj identityToIPs, newObj identityToIPs) identityToIPs {
 				// Update the existing record with the new IPs
 				newIPs := oldObj.IPs.Union(part.NewSet(prefix))
-				return identityToIPs{
-					Identity: oldObj.Identity,
-					IPs:      newIPs,
+				vnis := maps.Clone(oldObj.VNIs)
+				if vnis == nil {
+					vnis = map[string]uint32{}
 				}
+				vnis[prefix.String()] = newID.Vni
+				return identityToIPs{Identity: oldObj.Identity, IPs: newIPs, VNIs: vnis}
 			})
 			if err != nil {
 				s.log.Error("Failed to update identity to IP mapping", logfields.Error, err)
@@ -495,6 +534,8 @@ func (s *FQDNDataServer) deleteFromIdentityToIPLocked(txn statedb.WriteTxn, iden
 	}
 
 	newIPs := existing.IPs.Delete(prefix)
+	vnis := maps.Clone(existing.VNIs)
+	delete(vnis, prefix.String())
 	if existing.IPs.Has(prefix) {
 		// If the prefix was found, we need to remove it from the prefixLength
 		s.prefixLengths.Delete([]netip.Prefix{prefix})
@@ -511,6 +552,7 @@ func (s *FQDNDataServer) deleteFromIdentityToIPLocked(txn statedb.WriteTxn, iden
 		_, _, err := s.identityToIPsTable.Insert(txn, identityToIPs{
 			Identity: identity.ID,
 			IPs:      newIPs,
+			VNIs:     vnis,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to insert identity to IP mapping: %w", err)
@@ -686,7 +728,12 @@ func (s *FQDNDataServer) UpdateMappingRequest(ctx context.Context, mappings *pb.
 	}
 
 	endpointAddr := netip.MustParseAddr(string(sourceIP))
-	ep := s.endpointsLookup.LookupIP(endpointAddr)
+	var ep *endpoint.Endpoint
+	if mappings.GetVni() > 0 {
+		ep = lookupEndpointWithVNI(s.endpointsLookup, endpointAddr, mappings.GetVni())
+	} else {
+		ep = endpointmanager.LookupIPUnambiguous(s.endpointsLookup, endpointAddr)
+	}
 	if ep == nil {
 		s.log.Error("Endpoint not found for IP", logfields.IPAddr, endpointAddr)
 		return &pb.UpdateMappingResponse{

--- a/pkg/hubble/metrics/api/context.go
+++ b/pkg/hubble/metrics/api/context.go
@@ -6,6 +6,7 @@ package api
 import (
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -44,6 +45,11 @@ const (
 	ContextWorkloadName
 	// ContextApp uses the pod's app label for identification.
 	ContextApp
+	// ContextVNI uses the native-vpc VNI (kube-ovn tunnel_key) of the endpoint
+	// for identification purposes. With overlapping VPC subnets the pod/IP
+	// contexts alone are ambiguous, so the VNI is what separates two flows
+	// that share an IP.
+	ContextVNI
 )
 
 // ContextOptionsHelp is the help text for context options
@@ -55,8 +61,8 @@ const ContextOptionsHelp = `
  destinationEgressContext  ::= identifier , { "|", identifier }
  destinationIngressContext ::= identifier , { "|", identifier }
  labels                    ::= label , { ",", label }
- identifier                ::= identity | namespace | pod | pod-name | dns | ip | reserved-identity | workload | workload-name | app
- label                     ::= source_ip | source_pod | source_namespace | source_workload | source_workload_kind | source_app | destination_ip | destination_pod | destination_namespace | destination_workload | destination_workload_kind | destination_app | traffic_direction
+ identifier                ::= identity | namespace | pod | pod-name | dns | ip | reserved-identity | workload | workload-name | app | vni
+ label                     ::= source_ip | source_pod | source_namespace | source_workload | source_workload_kind | source_app | source_vni | destination_ip | destination_pod | destination_namespace | destination_workload | destination_workload_kind | destination_app | destination_vni | traffic_direction
 `
 
 var (
@@ -70,12 +76,14 @@ var (
 		"source_workload",
 		"source_workload_kind",
 		"source_app",
+		"source_vni",
 		"destination_ip",
 		"destination_pod",
 		"destination_namespace",
 		"destination_workload",
 		"destination_workload_kind",
 		"destination_app",
+		"destination_vni",
 		"traffic_direction",
 	}
 	allowedContextLabels = newLabelsSet(contextLabelsList)
@@ -114,6 +122,8 @@ func (c ContextIdentifier) String() string {
 		return "workload-name"
 	case ContextApp:
 		return "app"
+	case ContextVNI:
+		return "vni"
 	}
 	return fmt.Sprintf("%d", c)
 }
@@ -176,6 +186,8 @@ func parseContextIdentifier(s string) (ContextIdentifier, error) {
 		return ContextWorkloadName, nil
 	case "app":
 		return ContextApp, nil
+	case "vni":
+		return ContextVNI, nil
 	default:
 		return ContextDisabled, fmt.Errorf("unknown context '%s'", s)
 	}
@@ -318,6 +330,8 @@ func labelsContext(invertSourceDestination bool, wantedLabels labelsSet, flow *p
 				}
 			case "source_app":
 				labelValue = getK8sAppFromLabels(source.GetLabels())
+			case "source_vni":
+				labelValue = vniLabelValue(source)
 			case "destination_ip":
 				labelValue = destinationIp
 			case "destination_pod":
@@ -334,6 +348,8 @@ func labelsContext(invertSourceDestination bool, wantedLabels labelsSet, flow *p
 				}
 			case "destination_app":
 				labelValue = getK8sAppFromLabels(destination.GetLabels())
+			case "destination_vni":
+				labelValue = vniLabelValue(destination)
 			case "traffic_direction":
 				direction := flow.GetTrafficDirection()
 				if direction == pb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN {
@@ -498,8 +514,20 @@ func getContextIDLabelValue(contextID ContextIdentifier, flow *pb.Flow, source b
 		}
 	case ContextApp:
 		labelValue = getK8sAppFromLabels(ep.GetLabels())
+	case ContextVNI:
+		labelValue = vniLabelValue(ep)
 	}
 	return labelValue
+}
+
+// vniLabelValue returns the native-vpc VNI of the endpoint as a metric label
+// value, or "" for non-VPC endpoints (nodes, host, world, non-OVN pods) so
+// that the next context identifier in a "a|b" list is used instead.
+func vniLabelValue(ep *pb.Endpoint) string {
+	if vni := ep.GetVniId(); vni != 0 {
+		return strconv.FormatUint(vni, 10)
+	}
+	return ""
 }
 
 // GetLabelNames returns a slice of label names required to fulfil the

--- a/pkg/hubble/metrics/api/context_test.go
+++ b/pkg/hubble/metrics/api/context_test.go
@@ -166,7 +166,7 @@ func TestParseContextOptions(t *testing.T) {
 		},
 	)
 	assert.NoError(t, err)
-	assert.Equal(t, "labels=source_ip,source_pod,source_namespace,source_workload,source_workload_kind,source_app,destination_ip,destination_pod,destination_namespace,destination_workload,destination_workload_kind,destination_app,traffic_direction", opts.Status())
+	assert.Equal(t, "labels=source_ip,source_pod,source_namespace,source_workload,source_workload_kind,source_app,source_vni,destination_ip,destination_pod,destination_namespace,destination_workload,destination_workload_kind,destination_app,destination_vni,traffic_direction", opts.Status())
 	assert.Equal(t, contextLabelsList, opts.GetLabelNames())
 
 	opts, err = ParseContextOptions(
@@ -515,10 +515,10 @@ func TestParseGetLabelValues(t *testing.T) {
 	}
 	assert.Equal(t,
 		[]string{
-			// source_ip, source_pod, source_namespace, source_workload, source_workload_kind , source_app
-			"1.2.3.4", "foo-deploy-pod", "foo-ns", "foo-deploy", "Deployment", "fooapp",
-			// destination_ip, destination_pod, destination_namespace, destination_workload, destination_workload_kind, destination_app
-			"5.6.7.8", "bar-deploy-pod", "bar-ns", "bar-deploy", "StatefulSet", "barapp",
+			// source_ip, source_pod, source_namespace, source_workload, source_workload_kind , source_app, source_vni
+			"1.2.3.4", "foo-deploy-pod", "foo-ns", "foo-deploy", "Deployment", "fooapp", "",
+			// destination_ip, destination_pod, destination_namespace, destination_workload, destination_workload_kind, destination_app, destination_vni
+			"5.6.7.8", "bar-deploy-pod", "bar-ns", "bar-deploy", "StatefulSet", "barapp", "",
 			// traffic_direction
 			"ingress",
 		}, mustGetLabelValues(opts, flow),
@@ -528,8 +528,8 @@ func TestParseGetLabelValues(t *testing.T) {
 	// and set traffic_direction to "unknown"
 	assert.Equal(t,
 		[]string{
-			"", "", "", "", "", "",
-			"", "", "", "", "", "",
+			"", "", "", "", "", "", "",
+			"", "", "", "", "", "", "",
 			"unknown",
 		}, mustGetLabelValues(opts, &pb.Flow{}),
 	)

--- a/pkg/hubble/metrics/api/context_vni_test.go
+++ b/pkg/hubble/metrics/api/context_vni_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/cilium/cilium/api/v1/flow"
+)
+
+// TestVNIContext verifies the native-vpc metrics context: flows of two VPCs
+// that share an IP/pod name must be distinguishable by the VNI label, and
+// non-VPC endpoints must yield an empty value so that a "vni|pod" context
+// falls through to the next identifier.
+func TestVNIContext(t *testing.T) {
+	opts, err := ParseContextOptions([]*ContextOptionConfig{
+		{Name: "sourceContext", Values: []string{"vni"}},
+		{Name: "destinationContext", Values: []string{"vni", "ip"}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"source", "destination"}, opts.GetLabelNames())
+
+	flow := &pb.Flow{
+		IP:          &pb.IP{Source: "10.16.32.10", Destination: "10.16.32.20"},
+		Source:      &pb.Endpoint{PodName: "client", Namespace: "vpc-a", VniId: 36},
+		Destination: &pb.Endpoint{PodName: "server", Namespace: "vpc-a", VniId: 36},
+	}
+	values, err := opts.GetLabelValues(flow)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"36", "36"}, values)
+
+	// Same IPs, other VPC: the metric series must not be shared.
+	flow.Source.VniId, flow.Destination.VniId = 17, 17
+	values, err = opts.GetLabelValues(flow)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"17", "17"}, values)
+
+	// Non-VPC destination (node/world): empty VNI falls through to "ip".
+	flow.Destination = &pb.Endpoint{}
+	values, err = opts.GetLabelValues(flow)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"17", "10.16.32.20"}, values)
+}
+
+// TestVNILabelsContext verifies the source_vni/destination_vni labelsContext.
+func TestVNILabelsContext(t *testing.T) {
+	opts, err := ParseContextOptions([]*ContextOptionConfig{
+		{Name: "labelsContext", Values: []string{"source_vni", "destination_vni", "source_pod"}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"source_pod", "source_vni", "destination_vni"}, opts.GetLabelNames())
+
+	values, err := opts.GetLabelValues(&pb.Flow{
+		Source:      &pb.Endpoint{PodName: "client", VniId: 36},
+		Destination: &pb.Endpoint{PodName: "server"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"client", "36", ""}, values)
+}

--- a/pkg/hubble/metrics/http/plugin_test.go
+++ b/pkg/hubble/metrics/http/plugin_test.go
@@ -27,8 +27,8 @@ Options:
  destinationEgressContext  ::= identifier , { "|", identifier }
  destinationIngressContext ::= identifier , { "|", identifier }
  labels                    ::= label , { ",", label }
- identifier                ::= identity | namespace | pod | pod-name | dns | ip | reserved-identity | workload | workload-name | app
- label                     ::= source_ip | source_pod | source_namespace | source_workload | source_workload_kind | source_app | destination_ip | destination_pod | destination_namespace | destination_workload | destination_workload_kind | destination_app | traffic_direction
+ identifier                ::= identity | namespace | pod | pod-name | dns | ip | reserved-identity | workload | workload-name | app | vni
+ label                     ::= source_ip | source_pod | source_namespace | source_workload | source_workload_kind | source_app | source_vni | destination_ip | destination_pod | destination_namespace | destination_workload | destination_workload_kind | destination_app | destination_vni | traffic_direction
 `
 	assert.Equal(t, expected, plugin.HelpText())
 }

--- a/pkg/hubble/metrics/kafka/plugin_test.go
+++ b/pkg/hubble/metrics/kafka/plugin_test.go
@@ -26,8 +26,8 @@ Options:
  destinationEgressContext  ::= identifier , { "|", identifier }
  destinationIngressContext ::= identifier , { "|", identifier }
  labels                    ::= label , { ",", label }
- identifier                ::= identity | namespace | pod | pod-name | dns | ip | reserved-identity | workload | workload-name | app
- label                     ::= source_ip | source_pod | source_namespace | source_workload | source_workload_kind | source_app | destination_ip | destination_pod | destination_namespace | destination_workload | destination_workload_kind | destination_app | traffic_direction
+ identifier                ::= identity | namespace | pod | pod-name | dns | ip | reserved-identity | workload | workload-name | app | vni
+ label                     ::= source_ip | source_pod | source_namespace | source_workload | source_workload_kind | source_app | source_vni | destination_ip | destination_pod | destination_namespace | destination_workload | destination_workload_kind | destination_app | destination_vni | traffic_direction
 `
 	assert.Equal(t, expected, plugin.HelpText())
 }

--- a/pkg/hubble/observer/local_observer_test.go
+++ b/pkg/hubble/observer/local_observer_test.go
@@ -368,7 +368,7 @@ func TestLocalObserverServer_GetAgentEvents(t *testing.T) {
 		if i == 0 {
 			msg = monitorAPI.StartMessage(time.Unix(42, 1))
 		} else {
-			msg = monitorAPI.IPCacheUpsertedMessage(cidr, uint32(i), nil, net.ParseIP("10.1.5.4"), nil, 0xff, "default", "foobar")
+			msg = monitorAPI.IPCacheUpsertedMessage(cidr, uint32(i), nil, net.ParseIP("10.1.5.4"), nil, 0xff, "default", "foobar", 0)
 		}
 		m <- &observerTypes.MonitorEvent{
 			Timestamp: ts,

--- a/pkg/hubble/parser/agent/parser.go
+++ b/pkg/hubble/parser/agent/parser.go
@@ -97,6 +97,7 @@ func notifyIPCacheNotificationToProto(typ flowpb.AgentEventType, n monitorAPI.IP
 				EncryptKey:  uint32(n.EncryptKey),
 				Namespace:   n.Namespace,
 				PodName:     n.PodName,
+				Vni:         n.Vni,
 			},
 		},
 	}

--- a/pkg/hubble/parser/agent/parser_test.go
+++ b/pkg/hubble/parser/agent/parser_test.go
@@ -209,7 +209,7 @@ func TestDecodeAgentEvent(t *testing.T) {
 		},
 		{
 			name: "IPCacheUpsertedMessage (insert)",
-			msg:  monitorAPI.IPCacheUpsertedMessage("10.0.1.42/32", 1023, nil, net.ParseIP("10.1.5.4"), nil, 0xff, "default", "foobar"),
+			msg:  monitorAPI.IPCacheUpsertedMessage("10.0.1.42/32", 1023, nil, net.ParseIP("10.1.5.4"), nil, 0xff, "default", "foobar", 36),
 			ev: &flowpb.AgentEvent{
 				Type: flowpb.AgentEventType_IPCACHE_UPSERTED,
 				Notification: &flowpb.AgentEvent_IpcacheUpdate{
@@ -222,13 +222,14 @@ func TestDecodeAgentEvent(t *testing.T) {
 						EncryptKey:  0xff,
 						Namespace:   "default",
 						PodName:     "foobar",
+						Vni:         36,
 					},
 				},
 			},
 		},
 		{
 			name: "IPCacheUpsertedMessage (update)",
-			msg:  monitorAPI.IPCacheUpsertedMessage("192.168.10.11/32", 1023, &oldID, net.ParseIP("10.1.5.4"), net.ParseIP("10.2.6.11"), 5, "hubble", "podmcpodface"),
+			msg:  monitorAPI.IPCacheUpsertedMessage("192.168.10.11/32", 1023, &oldID, net.ParseIP("10.1.5.4"), net.ParseIP("10.2.6.11"), 5, "hubble", "podmcpodface", 17),
 			ev: &flowpb.AgentEvent{
 				Type: flowpb.AgentEventType_IPCACHE_UPSERTED,
 				Notification: &flowpb.AgentEvent_IpcacheUpdate{
@@ -243,13 +244,14 @@ func TestDecodeAgentEvent(t *testing.T) {
 						EncryptKey: 5,
 						Namespace:  "hubble",
 						PodName:    "podmcpodface",
+						Vni:        17,
 					},
 				},
 			},
 		},
 		{
 			name: "IPCacheDeletedMessage",
-			msg:  monitorAPI.IPCacheDeletedMessage("192.168.10.0/24", 6048, nil, net.ParseIP("10.1.5.4"), nil, 0, "", ""),
+			msg:  monitorAPI.IPCacheDeletedMessage("192.168.10.0/24", 6048, nil, net.ParseIP("10.1.5.4"), nil, 0, "", "", 0),
 			ev: &flowpb.AgentEvent{
 				Type: flowpb.AgentEventType_IPCACHE_DELETED,
 				Notification: &flowpb.AgentEvent_IpcacheUpdate{

--- a/pkg/hubble/parser/cell/cell.go
+++ b/pkg/hubble/parser/cell/cell.go
@@ -124,7 +124,23 @@ func (h *payloadGetters) GetEndpointInfo(ip netip.Addr) (endpoint hubbleGetters.
 	if !ip.IsValid() {
 		return nil, false
 	}
-	ep := h.endpointManager.LookupIP(ip)
+	ep := endpointmanager.LookupIPUnambiguous(h.endpointManager, ip)
+	if ep == nil {
+		return nil, false
+	}
+	return ep, true
+}
+
+// GetEndpointInfoForVNI implements the exact native-vpc endpoint lookup.
+func (h *payloadGetters) GetEndpointInfoForVNI(ip netip.Addr, vni uint32) (endpoint hubbleGetters.EndpointInfo, ok bool) {
+	if !ip.IsValid() || vni == 0 {
+		return nil, false
+	}
+	vniLookup, supported := h.endpointManager.(endpointmanager.EndpointsLookupVNI)
+	if !supported {
+		return nil, false
+	}
+	ep := vniLookup.LookupIPWithVNI(ip, uint64(vni))
 	if ep == nil {
 		return nil, false
 	}

--- a/pkg/hubble/parser/cell/cell.go
+++ b/pkg/hubble/parser/cell/cell.go
@@ -106,6 +106,18 @@ type payloadGetters struct {
 	frontends         statedb.Table[*loadbalancer.Frontend]
 }
 
+// The native-vpc (VNI, IP) resolution of the Hubble parsers is reached through
+// optional interfaces: a parser that does not find them silently degrades to
+// bare-IP lookups, which is exactly what native-vpc must never do. Assert the
+// production getters implement them so that a rename cannot disable the whole
+// observability chain unnoticed.
+var (
+	_ hubbleGetters.EndpointGetter      = (*payloadGetters)(nil)
+	_ hubbleGetters.EndpointGetterVNI   = (*payloadGetters)(nil)
+	_ hubbleGetters.EndpointGetterByPod = (*payloadGetters)(nil)
+	_ hubbleGetters.IPGetter            = (*ipcache.IPCache)(nil)
+)
+
 // GetIdentity implements IdentityGetter. It looks up identity by ID from
 // Cilium's identity cache. Hubble uses the identity info to populate flow
 // source and destination labels.

--- a/pkg/hubble/parser/cell/cell.go
+++ b/pkg/hubble/parser/cell/cell.go
@@ -131,9 +131,11 @@ func (h *payloadGetters) GetEndpointInfo(ip netip.Addr) (endpoint hubbleGetters.
 	return ep, true
 }
 
-// GetEndpointInfoForVNI implements the exact native-vpc endpoint lookup.
+// GetEndpointInfoForVNI implements the exact native-vpc endpoint lookup. A zero
+// VNI is the plain (non-VPC) scope and resolves only endpoints that are not in
+// any VPC; both forms are key-exact and never guess a VNI from a bare IP.
 func (h *payloadGetters) GetEndpointInfoForVNI(ip netip.Addr, vni uint32) (endpoint hubbleGetters.EndpointInfo, ok bool) {
-	if !ip.IsValid() || vni == 0 {
+	if !ip.IsValid() {
 		return nil, false
 	}
 	vniLookup, supported := h.endpointManager.(endpointmanager.EndpointsLookupVNI)

--- a/pkg/hubble/parser/cell/cell.go
+++ b/pkg/hubble/parser/cell/cell.go
@@ -159,6 +159,22 @@ func (h *payloadGetters) GetEndpointInfoByID(id uint16) (endpoint hubbleGetters.
 	return ep, true
 }
 
+// GetEndpointInfoByPod implements EndpointGetterByPod. It resolves the local
+// endpoint of a pod (an exact context, e.g. derived from a cgroup id), which
+// is what gives socket-level events their native-vpc VNI without any bare-IP
+// lookup. A pod with several endpoints (which does not happen for the local
+// pod of a socket event) is reported as unresolved rather than guessed.
+func (h *payloadGetters) GetEndpointInfoByPod(namespace, name string) (endpoint hubbleGetters.EndpointInfo, ok bool) {
+	if namespace == "" || name == "" {
+		return nil, false
+	}
+	eps := h.endpointManager.GetEndpointsByPodName(namespace + "/" + name)
+	if len(eps) != 1 {
+		return nil, false
+	}
+	return eps[0], true
+}
+
 // GetNamesOf implements DNSGetter.GetNamesOf. It looks up DNS names of a given
 // IP from the FQDN cache of an endpoint specified by sourceEpID.
 func (h *payloadGetters) GetNamesOf(sourceEpID uint32, ip netip.Addr) []string {

--- a/pkg/hubble/parser/common/endpoint.go
+++ b/pkg/hubble/parser/common/endpoint.go
@@ -152,6 +152,15 @@ func (r *EndpointResolver) ResolveEndpoint(ip netip.Addr, datapathSecurityIdenti
 		if vni > 0 {
 			if vniGetter, supported := r.endpointGetter.(getters.EndpointGetterVNI); supported {
 				epInfo, ok = vniGetter.GetEndpointInfoForVNI(ip, vni)
+				if !ok {
+					// The peer of a VPC endpoint is either in the same VPC
+					// (resolved above, mirroring what bpf_lxc does with the
+					// endpoint's own CONFIG(native_vpc_vni)) or a non-VPC
+					// entity (host, node, non-OVN pod). Only the latter,
+					// key-exact plain scope is an acceptable fallback: a
+					// bare-IP guess could pick an endpoint of another VPC.
+					epInfo, ok = vniGetter.GetEndpointInfoForVNI(ip, 0)
+				}
 			}
 		} else {
 			epInfo, ok = r.endpointGetter.GetEndpointInfo(ip)
@@ -183,22 +192,58 @@ func (r *EndpointResolver) ResolveEndpoint(ip netip.Addr, datapathSecurityIdenti
 	numericIdentity := datapathSecurityIdentity
 	var namespace, podName string
 	var needVNIMetadata bool
+	// contextVNI is the VNI scope the datapath observed for this side of the
+	// flow (0 when the event carries no VNI context). inVPCScope records
+	// whether this peer really resolved inside that scope.
+	contextVNI := context.SrcVNI
+	if ip != context.SrcIP {
+		contextVNI = context.DstVNI
+	}
+	var inVPCScope bool
 	if r.ipGetter != nil {
-		if ipIdentity, ok := r.ipGetter.LookupSecIDByIP(ip); ok {
-			numericIdentity = resolveIdentityConflict(ipIdentity.ID, false)
+		var identityResolved bool
+		if contextVNI > 0 {
+			// Key-exact (VNI, IP) resolution: with overlapping VPC subnets a
+			// plain-IP lookup could return another VPC's entry, or a CIDR
+			// prefix shadowing it.
+			if ipIdentity, ok := r.ipGetter.LookupSecIDByIPForVNI(ip, contextVNI); ok {
+				numericIdentity = resolveIdentityConflict(ipIdentity.ID, false)
+				identityResolved = true
+				inVPCScope = true
+			}
+			if meta := r.ipGetter.GetK8sMetadataForVNI(ip, contextVNI); meta != nil {
+				namespace, podName = meta.Namespace, meta.PodName
+				inVPCScope = true
+			}
 		}
-		if meta := r.ipGetter.GetK8sMetadata(ip); meta != nil {
-			namespace, podName = meta.Namespace, meta.PodName
-		} else {
-			// Native-vpc: the metadata of VNI-scoped entries lives under
-			// "<ip>@vni:<vni>" and is invisible to the plain lookup. Resolve
-			// it below once the identity's VNI identity label yields the VNI.
-			needVNIMetadata = true
+		if !identityResolved {
+			// Non-VPC entities (nodes, host, world, CIDR prefixes) live in the
+			// plain ipcache and are the only entries a bare-IP lookup returns.
+			if ipIdentity, ok := r.ipGetter.LookupSecIDByIP(ip); ok {
+				numericIdentity = resolveIdentityConflict(ipIdentity.ID, false)
+			}
+		}
+		if podName == "" {
+			if meta := r.ipGetter.GetK8sMetadata(ip); meta != nil {
+				namespace, podName = meta.Namespace, meta.PodName
+			} else {
+				// Native-vpc: the metadata of VNI-scoped entries lives under
+				// "<ip>@vni:<vni>" and is invisible to the plain lookup.
+				// Without datapath VNI context it is resolved below, once the
+				// identity's VNI identity label yields the VNI.
+				needVNIMetadata = true
+			}
 		}
 	}
 	var labels []string
 	var clusterName string
+	// Only report a VNI for peers that really are in that VPC scope: the flow's
+	// VNI context must not be pasted onto a non-VPC peer (node, host, world) of
+	// a VPC endpoint.
 	var resolvedVNI uint32
+	if inVPCScope {
+		resolvedVNI = contextVNI
+	}
 	if r.identityGetter != nil {
 		if id, err := r.identityGetter.GetIdentity(numericIdentity); err != nil {
 			r.log.Debug(

--- a/pkg/hubble/parser/common/endpoint.go
+++ b/pkg/hubble/parser/common/endpoint.go
@@ -6,12 +6,15 @@ package common
 import (
 	"log/slog"
 	"net/netip"
+	"strconv"
+	"strings"
 
 	pb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/identity"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/time"
@@ -20,8 +23,10 @@ import (
 type DatapathContext struct {
 	SrcIP                 netip.Addr
 	SrcLabelID            uint32
+	SrcVNI                uint32
 	DstIP                 netip.Addr
 	DstLabelID            uint32
+	DstVNI                uint32
 	TraceObservationPoint pb.TraceObservationPoint
 }
 
@@ -135,9 +140,24 @@ func (r *EndpointResolver) ResolveEndpoint(ip netip.Addr, datapathSecurityIdenti
 		return datapathID.Uint32()
 	}
 
-	// for local endpoints, use the available endpoint information
+	// For local endpoints, use exact (VNI, IP) context when available. A
+	// native-vpc endpoint must never be selected by guessing from a bare IP.
 	if r.endpointGetter != nil {
-		if ep, ok := r.endpointGetter.GetEndpointInfo(ip); ok {
+		var epInfo getters.EndpointInfo
+		var ok bool
+		vni := context.SrcVNI
+		if ip != context.SrcIP {
+			vni = context.DstVNI
+		}
+		if vni > 0 {
+			if vniGetter, supported := r.endpointGetter.(getters.EndpointGetterVNI); supported {
+				epInfo, ok = vniGetter.GetEndpointInfoForVNI(ip, vni)
+			}
+		} else {
+			epInfo, ok = r.endpointGetter.GetEndpointInfo(ip)
+		}
+		if ok {
+			ep := epInfo
 			epIdentity := resolveIdentityConflict(ep.GetIdentity(), true)
 			labels := ep.GetLabels()
 			e := &pb.Endpoint{
@@ -162,16 +182,23 @@ func (r *EndpointResolver) ResolveEndpoint(ip netip.Addr, datapathSecurityIdenti
 	// for remote endpoints, assemble the information via ip and identity
 	numericIdentity := datapathSecurityIdentity
 	var namespace, podName string
+	var needVNIMetadata bool
 	if r.ipGetter != nil {
 		if ipIdentity, ok := r.ipGetter.LookupSecIDByIP(ip); ok {
 			numericIdentity = resolveIdentityConflict(ipIdentity.ID, false)
 		}
 		if meta := r.ipGetter.GetK8sMetadata(ip); meta != nil {
 			namespace, podName = meta.Namespace, meta.PodName
+		} else {
+			// Native-vpc: the metadata of VNI-scoped entries lives under
+			// "<ip>@vni:<vni>" and is invisible to the plain lookup. Resolve
+			// it below once the identity's VNI identity label yields the VNI.
+			needVNIMetadata = true
 		}
 	}
 	var labels []string
 	var clusterName string
+	var resolvedVNI uint32
 	if r.identityGetter != nil {
 		if id, err := r.identityGetter.GetIdentity(numericIdentity); err != nil {
 			r.log.Debug(
@@ -182,6 +209,15 @@ func (r *EndpointResolver) ResolveEndpoint(ip netip.Addr, datapathSecurityIdenti
 		} else {
 			labels = SortAndFilterLabels(r.log, id.Labels.GetModel(), identity.NumericIdentity(numericIdentity))
 			clusterName = (id.Labels[k8sConst.PolicyLabelCluster]).Value
+
+			if vni, ok := vniFromIdentityLabels(id.Labels); ok {
+				resolvedVNI = vni
+				if needVNIMetadata && r.ipGetter != nil {
+					if meta := r.ipGetter.GetK8sMetadataForVNI(ip, vni); meta != nil {
+						namespace, podName = meta.Namespace, meta.PodName
+					}
+				}
+			}
 		}
 	}
 
@@ -191,5 +227,24 @@ func (r *EndpointResolver) ResolveEndpoint(ip netip.Addr, datapathSecurityIdenti
 		Namespace:   namespace,
 		Labels:      labels,
 		PodName:     podName,
+		VniId:       uint64(resolvedVNI),
 	}
+}
+
+// vniFromIdentityLabels returns the native-vpc VNI carried by the internal VNI
+// identity label of the given labels, if present. The identity is VNI-distinct
+// (endpoints on different logical switches carry different VNI identity labels),
+// so the VNI derived here unambiguously identifies the VNI-scoped
+// ipcache/metadata entry
+// of a remote peer.
+func vniFromIdentityLabels(lbls labels.Labels) (uint32, bool) {
+	l, ok := lbls[labels.VNIKey]
+	if !ok || l.Source != labels.LabelSourceVNI {
+		return 0, false
+	}
+	v, err := strconv.ParseUint(strings.TrimSpace(l.Value), 10, 32)
+	if err != nil || v == 0 {
+		return 0, false
+	}
+	return uint32(v), true
 }

--- a/pkg/hubble/parser/common/endpoint_vni_test.go
+++ b/pkg/hubble/parser/common/endpoint_vni_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package common
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/hubble/testutils"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/labels"
+)
+
+// TestEndpointResolverRemoteVNI verifies that a remote native-vpc endpoint is
+// resolved through its VNI-scoped ipcache entry: the plain (bare-IP) lookup
+// misses (overlapping VPC entries live under "<ip>@vni:<vni>"), so the parser
+// derives the VNI from the (VNI-distinct) VNI identity label and does a
+// direct VNI-scoped metadata lookup.
+func TestEndpointResolverRemoteVNI(t *testing.T) {
+	ip := netip.MustParseAddr("192.168.1.2")
+	const datapathIdentity = uint32(21929)
+
+	// The datapath identity carries the VNI identity label of logical switch 36.
+	identityGetter := &testutils.FakeIdentityGetter{
+		OnGetIdentity: func(secID uint32) (*identity.Identity, error) {
+			require.Equal(t, datapathIdentity, secID)
+			return identity.NewIdentity(identity.NumericIdentity(datapathIdentity), labels.Labels{
+				labels.VNIKey: labels.NewLabel(labels.VNIKey, "36", labels.LabelSourceVNI),
+			}), nil
+		},
+	}
+
+	ipGetter := &testutils.FakeIPGetter{
+		// The plain lookup misses: the entry lives under "192.168.1.2@vni:36".
+		OnGetK8sMetadata: func(ip netip.Addr) *ipcache.K8sMetadata {
+			return nil
+		},
+		OnGetK8sMetadataForVNI: func(ip netip.Addr, vni uint32) *ipcache.K8sMetadata {
+			require.Equal(t, uint32(36), vni)
+			return &ipcache.K8sMetadata{Namespace: "ns-a", PodName: "pod-a"}
+		},
+		OnLookupSecIDByIP: func(ip netip.Addr) (ipcache.Identity, bool) {
+			return ipcache.Identity{}, false
+		},
+	}
+
+	resolver := NewEndpointResolver(hivetest.Logger(t), &testutils.NoopEndpointGetter, identityGetter, ipGetter)
+	ep := resolver.ResolveEndpoint(ip, datapathIdentity, DatapathContext{})
+
+	require.Equal(t, "ns-a", ep.Namespace)
+	require.Equal(t, "pod-a", ep.PodName)
+	require.Equal(t, uint32(21929), ep.Identity)
+	require.Equal(t, uint64(36), ep.VniId)
+	require.Contains(t, ep.Labels, "vni:io-cilium-native-vpc-vni=36")
+	require.NotNil(t, ep)
+}
+
+// TestEndpointResolverRemoteNoVNI verifies the plain (non-native-vpc) remote
+// path is unchanged: metadata comes from the bare-IP lookup and the identity
+// has no vpc label.
+func TestEndpointResolverRemoteNoVNI(t *testing.T) {
+	ip := netip.MustParseAddr("10.0.0.5")
+	const datapathIdentity = uint32(21930)
+
+	identityGetter := &testutils.FakeIdentityGetter{
+		OnGetIdentity: func(secID uint32) (*identity.Identity, error) {
+			return identity.NewIdentity(identity.NumericIdentity(datapathIdentity), labels.Labels{
+				"k8s:app": labels.NewLabel("app", "web", labels.LabelSourceK8s),
+			}), nil
+		},
+	}
+
+	var vniLookupCalled bool
+	ipGetter := &testutils.FakeIPGetter{
+		OnGetK8sMetadata: func(ip netip.Addr) *ipcache.K8sMetadata {
+			return &ipcache.K8sMetadata{Namespace: "ns-a", PodName: "pod-a"}
+		},
+		OnGetK8sMetadataForVNI: func(ip netip.Addr, vni uint32) *ipcache.K8sMetadata {
+			vniLookupCalled = true
+			return nil
+		},
+		OnLookupSecIDByIP: func(ip netip.Addr) (ipcache.Identity, bool) {
+			return ipcache.Identity{ID: identity.NumericIdentity(datapathIdentity), Source: "kvstore"}, true
+		},
+	}
+
+	resolver := NewEndpointResolver(hivetest.Logger(t), &testutils.NoopEndpointGetter, identityGetter, ipGetter)
+	ep := resolver.ResolveEndpoint(ip, datapathIdentity, DatapathContext{})
+
+	require.Equal(t, "ns-a", ep.Namespace)
+	require.Equal(t, "pod-a", ep.PodName)
+	require.False(t, vniLookupCalled, "VNI lookup must not be attempted when the plain metadata lookup succeeds")
+}

--- a/pkg/hubble/parser/common/endpoint_vni_test.go
+++ b/pkg/hubble/parser/common/endpoint_vni_test.go
@@ -96,3 +96,100 @@ func TestEndpointResolverRemoteNoVNI(t *testing.T) {
 	require.Equal(t, "pod-a", ep.PodName)
 	require.False(t, vniLookupCalled, "VNI lookup must not be attempted when the plain metadata lookup succeeds")
 }
+
+// TestEndpointResolverVNIContextIsKeyExact verifies that when the datapath
+// gives a VNI context (derived from the local endpoint that emitted the
+// event), the remote peer is resolved key-exact under (VNI, IP): a foreign
+// VPC or CIDR entry sitting under the bare IP must never win.
+func TestEndpointResolverVNIContextIsKeyExact(t *testing.T) {
+	ip := netip.MustParseAddr("192.168.1.2")
+	const (
+		vniIdentity   = uint32(21929) // the peer in VNI 36
+		plainIdentity = uint32(21931) // a foreign/plain entry for the same IP
+	)
+
+	identityGetter := &testutils.FakeIdentityGetter{
+		OnGetIdentity: func(secID uint32) (*identity.Identity, error) {
+			return identity.NewIdentity(identity.NumericIdentity(secID), labels.Labels{
+				labels.VNIKey: labels.NewLabel(labels.VNIKey, "36", labels.LabelSourceVNI),
+			}), nil
+		},
+	}
+
+	plainCalled := false
+	ipGetter := &testutils.FakeIPGetter{
+		OnLookupSecIDByIPForVNI: func(_ netip.Addr, vni uint32) (ipcache.Identity, bool) {
+			require.Equal(t, uint32(36), vni)
+			return ipcache.Identity{ID: identity.NumericIdentity(vniIdentity), Vni: 36}, true
+		},
+		OnLookupSecIDByIP: func(netip.Addr) (ipcache.Identity, bool) {
+			plainCalled = true
+			return ipcache.Identity{ID: identity.NumericIdentity(plainIdentity)}, true
+		},
+		OnGetK8sMetadataForVNI: func(_ netip.Addr, vni uint32) *ipcache.K8sMetadata {
+			require.Equal(t, uint32(36), vni)
+			return &ipcache.K8sMetadata{Namespace: "ns-a", PodName: "pod-a"}
+		},
+		OnGetK8sMetadata: func(netip.Addr) *ipcache.K8sMetadata {
+			return &ipcache.K8sMetadata{Namespace: "foreign", PodName: "foreign"}
+		},
+	}
+
+	resolver := NewEndpointResolver(hivetest.Logger(t), &testutils.NoopEndpointGetter, identityGetter, ipGetter)
+	// datapathSecurityIdentity is unknown here, so the userspace (VNI-scoped)
+	// identity is the one reported.
+	ep := resolver.ResolveEndpoint(ip, uint32(identity.IdentityUnknown), DatapathContext{
+		SrcIP:  ip,
+		SrcVNI: 36,
+		DstIP:  netip.MustParseAddr("192.168.1.3"),
+		DstVNI: 36,
+	})
+
+	require.Equal(t, vniIdentity, ep.Identity)
+	require.Equal(t, uint64(36), ep.VniId)
+	require.Equal(t, "ns-a", ep.Namespace)
+	require.Equal(t, "pod-a", ep.PodName)
+	require.False(t, plainCalled, "the plain bare-IP identity lookup must not run once the VNI-scoped entry resolved")
+}
+
+// TestEndpointResolverVNIContextFallsBackToPlain verifies that a non-VPC peer
+// (node, host, world) of a VPC endpoint is still resolved: the VNI-scoped
+// lookup misses and the plain ipcache is the correct source for it.
+func TestEndpointResolverVNIContextFallsBackToPlain(t *testing.T) {
+	ip := netip.MustParseAddr("10.0.0.5")
+	const plainIdentity = uint32(6) // remote-node like
+
+	identityGetter := &testutils.FakeIdentityGetter{
+		OnGetIdentity: func(secID uint32) (*identity.Identity, error) {
+			return identity.NewIdentity(identity.NumericIdentity(secID), labels.Labels{
+				"reserved:remote-node": labels.NewLabel("remote-node", "", labels.LabelSourceReserved),
+			}), nil
+		},
+	}
+
+	ipGetter := &testutils.FakeIPGetter{
+		OnLookupSecIDByIPForVNI: func(netip.Addr, uint32) (ipcache.Identity, bool) {
+			return ipcache.Identity{}, false
+		},
+		OnLookupSecIDByIP: func(netip.Addr) (ipcache.Identity, bool) {
+			return ipcache.Identity{ID: identity.NumericIdentity(plainIdentity)}, true
+		},
+		OnGetK8sMetadataForVNI: func(netip.Addr, uint32) *ipcache.K8sMetadata {
+			return nil
+		},
+		OnGetK8sMetadata: func(netip.Addr) *ipcache.K8sMetadata {
+			return nil
+		},
+	}
+
+	resolver := NewEndpointResolver(hivetest.Logger(t), &testutils.NoopEndpointGetter, identityGetter, ipGetter)
+	ep := resolver.ResolveEndpoint(ip, uint32(identity.IdentityUnknown), DatapathContext{
+		SrcIP:  netip.MustParseAddr("192.168.1.2"),
+		SrcVNI: 36,
+		DstIP:  ip,
+		DstVNI: 36,
+	})
+
+	require.Equal(t, plainIdentity, ep.Identity)
+	require.Zero(t, ep.VniId, "a non-VPC peer must not inherit the flow's VNI context")
+}

--- a/pkg/hubble/parser/debug/parser.go
+++ b/pkg/hubble/parser/debug/parser.go
@@ -93,6 +93,10 @@ func (p *Parser) decodeEndpoint(id uint16) *flowpb.Endpoint {
 				Namespace:   ep.GetK8sNamespace(),
 				Labels:      common.SortAndFilterLabels(p.log, labels.GetModel(), ep.GetIdentity()),
 				PodName:     ep.GetK8sPodName(),
+				// The endpoint is resolved by id, so its native-vpc VNI is
+				// exact: debug events of two VPCs sharing an IP stay
+				// distinguishable.
+				VniId: ep.GetVNIID(),
 			}
 		}
 	}

--- a/pkg/hubble/parser/getters/getters.go
+++ b/pkg/hubble/parser/getters/getters.go
@@ -39,6 +39,14 @@ type EndpointGetterVNI interface {
 	GetEndpointInfoForVNI(ip netip.Addr, vni uint32) (endpoint EndpointInfo, ok bool)
 }
 
+// EndpointGetterByPod is the optional pod-scoped endpoint lookup used by the
+// socket-level parser: a TraceSock event identifies the local endpoint by
+// cgroup id (hence by pod), which is an exact context and must be preferred
+// over any bare-IP lookup in native-vpc mode.
+type EndpointGetterByPod interface {
+	GetEndpointInfoByPod(namespace, name string) (endpoint EndpointInfo, ok bool)
+}
+
 // IdentityGetter ...
 type IdentityGetter interface {
 	// GetIdentity fetches a full identity object given a numeric security id.

--- a/pkg/hubble/parser/getters/getters.go
+++ b/pkg/hubble/parser/getters/getters.go
@@ -33,6 +33,8 @@ type EndpointGetter interface {
 
 // EndpointGetterVNI is the optional exact endpoint lookup extension for
 // native-vpc flows. Implementations must not infer VNI from a bare IP.
+// A zero VNI selects the plain (non-VPC) scope and is key-exact as well: it
+// resolves only endpoints that are not in any VPC (host, nodes, non-OVN pods).
 type EndpointGetterVNI interface {
 	GetEndpointInfoForVNI(ip netip.Addr, vni uint32) (endpoint EndpointInfo, ok bool)
 }
@@ -55,6 +57,11 @@ type IPGetter interface {
 	// LookupSecIDByIP returns the corresponding security identity that
 	// the specified IP maps to as well as if the corresponding entry exists.
 	LookupSecIDByIP(ip netip.Addr) (ipcache.Identity, bool)
+	// LookupSecIDByIPForVNI returns the identity of the native-vpc VNI-scoped
+	// entry for the given IP. It is key-exact: it never resolves a plain or a
+	// foreign-VPC entry, so a flow whose VNI context is known is never
+	// attributed to another VPC.
+	LookupSecIDByIPForVNI(ip netip.Addr, vni uint32) (ipcache.Identity, bool)
 }
 
 // ServiceGetter fetches service metadata.

--- a/pkg/hubble/parser/getters/getters.go
+++ b/pkg/hubble/parser/getters/getters.go
@@ -25,10 +25,16 @@ type DNSGetter interface {
 
 // EndpointGetter ...
 type EndpointGetter interface {
-	// GetEndpointInfo looks up endpoint by IP address.
+	// GetEndpointInfo looks up non-VPC endpoint by bare IP.
 	GetEndpointInfo(ip netip.Addr) (endpoint EndpointInfo, ok bool)
 	// GetEndpointInfo looks up endpoint by id
 	GetEndpointInfoByID(id uint16) (endpoint EndpointInfo, ok bool)
+}
+
+// EndpointGetterVNI is the optional exact endpoint lookup extension for
+// native-vpc flows. Implementations must not infer VNI from a bare IP.
+type EndpointGetterVNI interface {
+	GetEndpointInfoForVNI(ip netip.Addr, vni uint32) (endpoint EndpointInfo, ok bool)
 }
 
 // IdentityGetter ...
@@ -41,6 +47,11 @@ type IdentityGetter interface {
 type IPGetter interface {
 	// GetK8sMetadata returns Kubernetes metadata for the given IP address.
 	GetK8sMetadata(ip netip.Addr) *ipcache.K8sMetadata
+	// GetK8sMetadataForVNI returns the Kubernetes metadata of the native-vpc
+	// VNI-scoped entry for the given IP (key "<ip>@vni:<vni>"), or nil if no
+	// such entry exists. Overlapping IPs from different VPCs coexist as
+	// VNI-scoped entries that the plain GetK8sMetadata lookup cannot see.
+	GetK8sMetadataForVNI(ip netip.Addr, vni uint32) *ipcache.K8sMetadata
 	// LookupSecIDByIP returns the corresponding security identity that
 	// the specified IP maps to as well as if the corresponding entry exists.
 	LookupSecIDByIP(ip netip.Addr) (ipcache.Identity, bool)

--- a/pkg/hubble/parser/seven/parser.go
+++ b/pkg/hubble/parser/seven/parser.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/hubble/parser/options"
+	"github.com/cilium/cilium/pkg/ipcache"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/monitor/api"
@@ -115,10 +116,15 @@ func (p *Parser) Decode(r *accesslog.LogRecord, decoded *flowpb.Flow) error {
 		destinationNames = p.dnsGetter.GetNamesOf(uint32(r.SourceEndpoint.ID), destinationIP)
 	}
 	if p.ipGetter != nil {
-		if meta := p.ipGetter.GetK8sMetadata(sourceIP); meta != nil {
+		// Native-vpc: resolve pod metadata with the exact (VNI, IP) key when
+		// the proxy recorded a VNI for the address. VNI-scoped ipcache
+		// entries live under "<ip>@vni:<vni>" and are invisible to the plain
+		// bare-IP lookup, which would otherwise leave every OVN pod without
+		// namespace/pod name in L7 flows.
+		if meta := p.k8sMetadata(sourceIP, r.SourceEndpoint.VNIID); meta != nil {
 			sourceNamespace, sourcePod = meta.Namespace, meta.PodName
 		}
-		if meta := p.ipGetter.GetK8sMetadata(destinationIP); meta != nil {
+		if meta := p.k8sMetadata(destinationIP, r.DestinationEndpoint.VNIID); meta != nil {
 			destinationNamespace, destinationPod = meta.Namespace, meta.PodName
 		}
 	}
@@ -126,8 +132,8 @@ func (p *Parser) Decode(r *accesslog.LogRecord, decoded *flowpb.Flow) error {
 	dstEndpoint := decodeEndpoint(r.DestinationEndpoint, destinationNamespace, destinationPod)
 
 	if p.endpointGetter != nil {
-		p.updateEndpointWorkloads(sourceIP, srcEndpoint)
-		p.updateEndpointWorkloads(destinationIP, dstEndpoint)
+		p.updateEndpointWorkloads(sourceIP, r.SourceEndpoint.VNIID, srcEndpoint)
+		p.updateEndpointWorkloads(destinationIP, r.DestinationEndpoint.VNIID, dstEndpoint)
 	}
 
 	l4, sourcePort, destinationPort := decodeLayer4(r.TransportProtocol, r.SourceEndpoint, r.DestinationEndpoint)
@@ -223,15 +229,49 @@ func (p *Parser) computeResponseTime(r *accesslog.LogRecord, timestamp time.Time
 	return 0
 }
 
-func (p *Parser) updateEndpointWorkloads(ip netip.Addr, endpoint *flowpb.Endpoint) {
-	if ep, ok := p.endpointGetter.GetEndpointInfo(ip); ok {
-		if pod := ep.GetPod(); pod != nil {
-			workload, workloadTypeMeta, ok := utils.GetWorkloadMetaFromPod(pod)
-			if ok {
-				endpoint.Workloads = []*flowpb.Workload{{Kind: workloadTypeMeta.Kind, Name: workload.Name}}
-			}
+// k8sMetadata resolves the Kubernetes metadata of an address, preferring the
+// native-vpc (VNI, IP) scoped entry when the L7 record carries a VNI. The
+// plain bare-IP lookup is only used as a fallback for non-VPC entities (nodes,
+// world, non-OVN pods), which never have a VNI-scoped entry.
+func (p *Parser) k8sMetadata(ip netip.Addr, vni uint64) *ipcache.K8sMetadata {
+	if p.ipGetter == nil || !ip.IsValid() {
+		return nil
+	}
+	if vni > 0 {
+		if meta := p.ipGetter.GetK8sMetadataForVNI(ip, uint32(vni)); meta != nil {
+			return meta
 		}
 	}
+	return p.ipGetter.GetK8sMetadata(ip)
+}
+
+func (p *Parser) updateEndpointWorkloads(ip netip.Addr, vni uint64, endpoint *flowpb.Endpoint) {
+	ep, ok := p.lookupEndpoint(ip, vni)
+	if !ok {
+		return
+	}
+	if pod := ep.GetPod(); pod != nil {
+		workload, workloadTypeMeta, ok := utils.GetWorkloadMetaFromPod(pod)
+		if ok {
+			endpoint.Workloads = []*flowpb.Workload{{Kind: workloadTypeMeta.Kind, Name: workload.Name}}
+		}
+	}
+}
+
+// lookupEndpoint resolves a local endpoint, using the exact (VNI, IP) lookup
+// when the L7 record carries a native-vpc VNI. The bare-IP lookup is only used
+// for non-VPC endpoints; it resolves a VNI-scoped endpoint only when exactly
+// one VPC uses the IP on this node (see endpointmanager.LookupIPUnambiguous).
+func (p *Parser) lookupEndpoint(ip netip.Addr, vni uint64) (getters.EndpointInfo, bool) {
+	if vni > 0 {
+		if vniGetter, supported := p.endpointGetter.(getters.EndpointGetterVNI); supported {
+			if ep, ok := vniGetter.GetEndpointInfoForVNI(ip, uint32(vni)); ok {
+				return ep, true
+			}
+			return nil, false
+		}
+	}
+	return p.endpointGetter.GetEndpointInfo(ip)
 }
 
 func decodeTime(timestamp string) (goTime time.Time, pbTime *timestamppb.Timestamp, err error) {
@@ -334,6 +374,8 @@ func decodeEndpoint(endpoint accesslog.EndpointInfo, namespace, podName string) 
 		Namespace:   namespace,
 		Labels:      labels,
 		PodName:     podName,
+		// Native-vpc: L7 flows carry the same (VNI, IP) scope as L3/L4 flows.
+		VniId: endpoint.VNIID,
 	}
 }
 

--- a/pkg/hubble/parser/seven/vni_test.go
+++ b/pkg/hubble/parser/seven/vni_test.go
@@ -35,6 +35,10 @@ func (g *vniIPGetter) LookupSecIDByIP(netip.Addr) (ipcache.Identity, bool) {
 	return ipcache.Identity{}, false
 }
 
+func (g *vniIPGetter) LookupSecIDByIPForVNI(netip.Addr, uint32) (ipcache.Identity, bool) {
+	return ipcache.Identity{}, false
+}
+
 // TestL7FlowCarriesVNI verifies the observability plane of native-vpc: the L7
 // record carries the (VNI, IP) scope resolved by the proxy, the parser uses it
 // to look up pod metadata with the exact VNI-scoped key, and the resulting

--- a/pkg/hubble/parser/seven/vni_test.go
+++ b/pkg/hubble/parser/seven/vni_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package seven
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/parser/getters"
+	"github.com/cilium/cilium/pkg/hubble/testutils"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/proxy/accesslog"
+	"github.com/cilium/cilium/pkg/u8proto"
+)
+
+// vniIPGetter resolves metadata only through the VNI-scoped key, mirroring
+// native-vpc mode where pod entries live under "<ip>@vni:<vni>" and are
+// invisible to the bare-IP lookup.
+type vniIPGetter struct {
+	vniMeta map[uint32]*ipcache.K8sMetadata
+}
+
+func (g *vniIPGetter) GetK8sMetadata(netip.Addr) *ipcache.K8sMetadata { return nil }
+
+func (g *vniIPGetter) GetK8sMetadataForVNI(_ netip.Addr, vni uint32) *ipcache.K8sMetadata {
+	return g.vniMeta[vni]
+}
+
+func (g *vniIPGetter) LookupSecIDByIP(netip.Addr) (ipcache.Identity, bool) {
+	return ipcache.Identity{}, false
+}
+
+// TestL7FlowCarriesVNI verifies the observability plane of native-vpc: the L7
+// record carries the (VNI, IP) scope resolved by the proxy, the parser uses it
+// to look up pod metadata with the exact VNI-scoped key, and the resulting
+// flow exposes the VNI on both endpoints.
+func TestL7FlowCarriesVNI(t *testing.T) {
+	src := accesslog.EndpointInfo{ID: 1234, IPv4: "10.16.32.10", Identity: 9876, VNIID: 36}
+	dst := accesslog.EndpointInfo{ID: 4321, IPv4: "10.16.32.20", Identity: 6789, VNIID: 17, Port: 53}
+
+	lr := &accesslog.LogRecord{
+		Type:                accesslog.TypeRequest,
+		Timestamp:           "2006-01-02T15:04:05.999999999Z",
+		ObservationPoint:    accesslog.Egress,
+		SourceEndpoint:      src,
+		DestinationEndpoint: dst,
+		IPVersion:           accesslog.VersionIPv4,
+		Verdict:             accesslog.VerdictForwarded,
+		TransportProtocol:   accesslog.TransportProtocol(u8proto.UDP),
+		DNS:                 &accesslog.LogRecordDNS{Query: "example.com"},
+	}
+
+	ipGetter := &vniIPGetter{vniMeta: map[uint32]*ipcache.K8sMetadata{
+		36: {Namespace: "vpc-a", PodName: "client"},
+		17: {Namespace: "vpc-b", PodName: "server"},
+	}}
+
+	parser, err := New(hivetest.Logger(t), &testutils.NoopDNSGetter, ipGetter,
+		&testutils.NoopServiceGetter, &testutils.NoopEndpointGetter)
+	require.NoError(t, err)
+
+	f := &flowpb.Flow{}
+	require.NoError(t, parser.Decode(lr, f))
+
+	require.Equal(t, uint64(36), f.GetSource().GetVniId())
+	require.Equal(t, "vpc-a", f.GetSource().GetNamespace())
+	require.Equal(t, "client", f.GetSource().GetPodName())
+	require.Equal(t, uint64(17), f.GetDestination().GetVniId())
+	require.Equal(t, "vpc-b", f.GetDestination().GetNamespace())
+	require.Equal(t, "server", f.GetDestination().GetPodName())
+}
+
+// vniEndpointGetter implements the exact (VNI, IP) endpoint lookup.
+type vniEndpointGetter struct {
+	testutils.FakeEndpointGetter
+	onVNI func(ip netip.Addr, vni uint32) (getters.EndpointInfo, bool)
+}
+
+func (g *vniEndpointGetter) GetEndpointInfoForVNI(ip netip.Addr, vni uint32) (getters.EndpointInfo, bool) {
+	return g.onVNI(ip, vni)
+}
+
+// TestL7WorkloadLookupIsVNIScoped verifies that the workload lookup of an L7
+// flow never falls back to a bare-IP endpoint lookup once a VNI is known: with
+// overlapping IPs that would attribute the flow to a foreign VPC.
+func TestL7WorkloadLookupIsVNIScoped(t *testing.T) {
+	var gotVNI uint32
+	epGetter := &vniEndpointGetter{
+		FakeEndpointGetter: testutils.FakeEndpointGetter{
+			OnGetEndpointInfo: func(netip.Addr) (getters.EndpointInfo, bool) {
+				t.Fatal("bare-IP endpoint lookup must not be used when a VNI is known")
+				return nil, false
+			},
+		},
+		onVNI: func(_ netip.Addr, vni uint32) (getters.EndpointInfo, bool) {
+			gotVNI = vni
+			return nil, false
+		},
+	}
+
+	parser, err := New(hivetest.Logger(t), &testutils.NoopDNSGetter, &testutils.NoopIPGetter,
+		&testutils.NoopServiceGetter, epGetter)
+	require.NoError(t, err)
+
+	lr := &accesslog.LogRecord{
+		Type:                accesslog.TypeRequest,
+		Timestamp:           "2006-01-02T15:04:05.999999999Z",
+		ObservationPoint:    accesslog.Egress,
+		SourceEndpoint:      accesslog.EndpointInfo{ID: 1, IPv4: "10.16.32.10", VNIID: 36},
+		DestinationEndpoint: accesslog.EndpointInfo{ID: 2, IPv4: "10.16.32.20", VNIID: 36},
+		IPVersion:           accesslog.VersionIPv4,
+		Verdict:             accesslog.VerdictForwarded,
+		TransportProtocol:   accesslog.TransportProtocol(u8proto.UDP),
+		DNS:                 &accesslog.LogRecordDNS{Query: "example.com"},
+	}
+
+	f := &flowpb.Flow{}
+	require.NoError(t, parser.Decode(lr, f))
+	require.Equal(t, uint32(36), gotVNI)
+}

--- a/pkg/hubble/parser/sock/parser.go
+++ b/pkg/hubble/parser/sock/parser.go
@@ -6,12 +6,14 @@ package sock
 import (
 	"fmt"
 	"log/slog"
+	"math"
 	"net/netip"
 	"strings"
 
 	"go4.org/netipx"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
+	cgroupManager "github.com/cilium/cilium/pkg/cgroups/manager"
 	"github.com/cilium/cilium/pkg/hubble/parser/common"
 	"github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
@@ -91,7 +93,7 @@ func (p *Parser) Decode(data []byte, decoded *flowpb.Flow) error {
 	}
 
 	ipVersion := decodeIPVersion(sock.Flags)
-	srcIP := p.decodeEndpointIP(sock.CgroupId, ipVersion)
+	srcIP, srcVNI := p.decodeEndpoint(sock.CgroupId, ipVersion)
 	if !srcIP.IsValid() && p.skipUnknownCGroupIDs {
 		// Skip events for which we cannot determine the endpoint ip based on
 		// the numeric cgroup id, since those events do not provide much value
@@ -110,6 +112,12 @@ func (p *Parser) Decode(data []byte, decoded *flowpb.Flow) error {
 		SrcLabelID: 0,
 		DstIP:      dstIP,
 		DstLabelID: 0,
+		// Native-vpc: the local endpoint of a socket event is identified by
+		// its cgroup id (hence by pod), which is exact. Its VNI is the scope
+		// of both sides of the flow, like the emitting endpoint's VNI is for
+		// L3/L4 events.
+		SrcVNI: srcVNI,
+		DstVNI: srcVNI,
 	}
 	srcEndpoint := p.epResolver.ResolveEndpoint(srcIP, 0, datapathContext)
 	dstEndpoint := p.epResolver.ResolveEndpoint(dstIP, 0, datapathContext)
@@ -147,36 +155,56 @@ func decodeIPVersion(flags uint8) flowpb.IPVersion {
 	return flowpb.IPVersion_IPv4
 }
 
-func (p *Parser) decodeEndpointIP(cgroupId uint64, ipVersion flowpb.IPVersion) netip.Addr {
-	if p.cgroupGetter != nil {
-		if m := p.cgroupGetter.GetPodMetadataForContainer(cgroupId); m != nil {
-			for _, podIP := range m.IPs {
-				isIPv6 := strings.Contains(podIP, ":")
-				if isIPv6 && ipVersion == flowpb.IPVersion_IPv6 ||
-					!isIPv6 && ipVersion == flowpb.IPVersion_IPv4 {
-					ip, err := netip.ParseAddr(podIP)
-					if err != nil {
-						p.log.Debug(
-							"failed to parse pod IP",
-							logfields.Error, err,
-							logfields.CGroupID, cgroupId,
-							logfields.K8sPodName, m.Name,
-							logfields.K8sNamespace, m.Namespace,
-							logfields.IPAddr, podIP,
-						)
-						return netip.Addr{}
-					}
-					return ip
-				}
+// decodeEndpoint returns the IP and the native-vpc VNI of the local endpoint
+// that owns the given cgroup id. Both are derived from the exact pod context
+// of the cgroup, never from a bare-IP lookup.
+func (p *Parser) decodeEndpoint(cgroupId uint64, ipVersion flowpb.IPVersion) (netip.Addr, uint32) {
+	if p.cgroupGetter == nil {
+		return netip.Addr{}, 0
+	}
+	m := p.cgroupGetter.GetPodMetadataForContainer(cgroupId)
+	if m == nil {
+		return netip.Addr{}, 0
+	}
+
+	var vni uint32
+	if podGetter, supported := p.endpointGetter.(getters.EndpointGetterByPod); supported {
+		if ep, ok := podGetter.GetEndpointInfoByPod(m.Namespace, m.Name); ok {
+			if v := ep.GetVNIID(); v > 0 && v <= math.MaxUint32 {
+				vni = uint32(v)
 			}
-			p.log.Debug(
-				"no matching IP for pod",
-				logfields.CGroupID, cgroupId,
-				logfields.K8sPodName, m.Name,
-				logfields.K8sNamespace, m.Namespace,
-			)
 		}
 	}
+
+	return p.podIP(m, cgroupId, ipVersion), vni
+}
+
+func (p *Parser) podIP(m *cgroupManager.PodMetadata, cgroupId uint64, ipVersion flowpb.IPVersion) netip.Addr {
+	for _, podIP := range m.IPs {
+		isIPv6 := strings.Contains(podIP, ":")
+		if isIPv6 && ipVersion == flowpb.IPVersion_IPv6 ||
+			!isIPv6 && ipVersion == flowpb.IPVersion_IPv4 {
+			ip, err := netip.ParseAddr(podIP)
+			if err != nil {
+				p.log.Debug(
+					"failed to parse pod IP",
+					logfields.Error, err,
+					logfields.CGroupID, cgroupId,
+					logfields.K8sPodName, m.Name,
+					logfields.K8sNamespace, m.Namespace,
+					logfields.IPAddr, podIP,
+				)
+				return netip.Addr{}
+			}
+			return ip
+		}
+	}
+	p.log.Debug(
+		"no matching IP for pod",
+		logfields.CGroupID, cgroupId,
+		logfields.K8sPodName, m.Name,
+		logfields.K8sNamespace, m.Namespace,
+	)
 	return netip.Addr{}
 }
 

--- a/pkg/hubble/parser/sock/vni_test.go
+++ b/pkg/hubble/parser/sock/vni_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package sock
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/byteorder"
+	cgroupManager "github.com/cilium/cilium/pkg/cgroups/manager"
+	"github.com/cilium/cilium/pkg/hubble/parser/getters"
+	"github.com/cilium/cilium/pkg/hubble/testutils"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/monitor"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	"github.com/cilium/cilium/pkg/types"
+)
+
+// podEndpointGetter resolves endpoints by pod (the exact context a socket
+// event has, through its cgroup id) and by (VNI, IP).
+type podEndpointGetter struct {
+	byPod map[string]getters.EndpointInfo
+	byVNI map[uint32]map[netip.Addr]getters.EndpointInfo
+}
+
+func (g *podEndpointGetter) GetEndpointInfo(netip.Addr) (getters.EndpointInfo, bool) {
+	return nil, false
+}
+
+func (g *podEndpointGetter) GetEndpointInfoByID(uint16) (getters.EndpointInfo, bool) {
+	return nil, false
+}
+
+func (g *podEndpointGetter) GetEndpointInfoByPod(namespace, name string) (getters.EndpointInfo, bool) {
+	ep, ok := g.byPod[namespace+"/"+name]
+	return ep, ok
+}
+
+func (g *podEndpointGetter) GetEndpointInfoForVNI(ip netip.Addr, vni uint32) (getters.EndpointInfo, bool) {
+	ep, ok := g.byVNI[vni][ip]
+	return ep, ok
+}
+
+// TestSockTraceVNIChain verifies that socket-level flows carry the native-vpc
+// VNI derived from the exact cgroup -> pod -> endpoint context, and that the
+// peer is then resolved with the (VNI, IP) key instead of the bare IP.
+func TestSockTraceVNIChain(t *testing.T) {
+	const (
+		cgroupID = uint64(1234)
+		localVNI = uint32(36)
+	)
+	srcAddr := netip.MustParseAddr("10.16.32.10")
+	dstAddr := netip.MustParseAddr("10.16.32.20")
+
+	localEP := &testutils.FakeEndpointInfo{
+		ID: 42, PodName: "client", PodNamespace: "vpc-a", VNIID: uint64(localVNI),
+	}
+	endpointGetter := &podEndpointGetter{
+		byPod: map[string]getters.EndpointInfo{"vpc-a/client": localEP},
+		byVNI: map[uint32]map[netip.Addr]getters.EndpointInfo{
+			localVNI: {srcAddr: localEP},
+		},
+	}
+	cgroupGetter := &testutils.FakePodMetadataGetter{
+		OnGetPodMetadataForContainer: func(id uint64) *cgroupManager.PodMetadata {
+			require.Equal(t, cgroupID, id)
+			return &cgroupManager.PodMetadata{
+				Namespace: "vpc-a", Name: "client", IPs: []string{srcAddr.String()},
+			}
+		},
+	}
+	ipGetter := &testutils.FakeIPGetter{
+		OnLookupSecIDByIPForVNI: func(ip netip.Addr, vni uint32) (ipcache.Identity, bool) {
+			if ip == dstAddr && vni == localVNI {
+				return ipcache.Identity{ID: identity.NumericIdentity(21929), Vni: localVNI}, true
+			}
+			return ipcache.Identity{}, false
+		},
+		OnGetK8sMetadataForVNI: func(ip netip.Addr, vni uint32) *ipcache.K8sMetadata {
+			if ip == dstAddr && vni == localVNI {
+				return &ipcache.K8sMetadata{Namespace: "vpc-a", PodName: "server"}
+			}
+			return nil
+		},
+		OnLookupSecIDByIP: func(netip.Addr) (ipcache.Identity, bool) {
+			return ipcache.Identity{}, false
+		},
+		OnGetK8sMetadata: func(netip.Addr) *ipcache.K8sMetadata {
+			// A foreign VPC pod with the same IP: must never be used.
+			return &ipcache.K8sMetadata{Namespace: "vpc-b", PodName: "foreign"}
+		},
+	}
+
+	// IPv4 addresses are stored in the first four bytes of the dst_ip field.
+	var dstRaw types.IPv6
+	copy(dstRaw[:], dstAddr.AsSlice())
+
+	sock := monitor.TraceSockNotify{
+		Type:       byte(monitorAPI.MessageTypeTraceSock),
+		XlatePoint: monitor.XlatePointPreDirectionFwd,
+		DstIP:      dstRaw,
+		DstPort:    53,
+		CgroupId:   cgroupID,
+		L4Proto:    monitor.L4ProtocolUDP,
+	}
+	buf := &bytes.Buffer{}
+	require.NoError(t, binary.Write(buf, byteorder.Native, &sock))
+
+	parser, err := New(hivetest.Logger(t), endpointGetter, &testutils.NoopIdentityGetter,
+		&testutils.NoopDNSGetter, ipGetter, &testutils.NoopServiceGetter, cgroupGetter)
+	require.NoError(t, err)
+
+	f := &flowpb.Flow{}
+	require.NoError(t, parser.Decode(buf.Bytes(), f))
+
+	require.Equal(t, uint64(42), uint64(f.GetSource().GetID()))
+	require.Equal(t, "client", f.GetSource().GetPodName())
+	require.Equal(t, uint64(localVNI), f.GetSource().GetVniId())
+	require.Equal(t, "server", f.GetDestination().GetPodName())
+	require.Equal(t, uint64(localVNI), f.GetDestination().GetVniId())
+}

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -275,6 +275,12 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 		DstLabelID:            dstLabelID,
 		TraceObservationPoint: decoded.TraceObservationPoint,
 	}
+	if decoded.Tunnel != nil && decoded.Tunnel.Vni > 0 {
+		// The overlay VNI is the exact logical-switch context for the
+		// encapsulated endpoint addresses. Preserve it for endpoint resolution.
+		datapathContext.SrcVNI = decoded.Tunnel.Vni
+		datapathContext.DstVNI = decoded.Tunnel.Vni
+	}
 	srcEndpoint := p.epResolver.ResolveEndpoint(srcIP, srcLabelID, datapathContext)
 	dstEndpoint := p.epResolver.ResolveEndpoint(dstIP, dstLabelID, datapathContext)
 	var sourceService, destinationService *pb.Service

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -6,6 +6,7 @@ package threefour
 import (
 	"fmt"
 	"log/slog"
+	"math"
 	"net/netip"
 	"strings"
 
@@ -274,6 +275,14 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 		DstIP:                 dstIP,
 		DstLabelID:            dstLabelID,
 		TraceObservationPoint: decoded.TraceObservationPoint,
+	}
+	// Native-vpc: derive the VNI scope of the flow from the local endpoint that
+	// emitted the event. This mirrors the datapath exactly: bpf_lxc resolves
+	// the peer of an endpoint with that endpoint's own CONFIG(native_vpc_vni),
+	// so the same VNI is the correct scope for both sides of the flow.
+	if vni, ok := p.vniOfLocalEndpoint(dn, tn, pvn); ok {
+		datapathContext.SrcVNI = vni
+		datapathContext.DstVNI = vni
 	}
 	if decoded.Tunnel != nil && decoded.Tunnel.Vni > 0 {
 		// The overlay VNI is the exact logical-switch context for the
@@ -691,6 +700,45 @@ func decodeIpTraceId(dn *monitor.DropNotify, tn *monitor.TraceNotify) *pb.IPTrac
 		TraceId:      id,
 		IpOptionType: uint32(option.Config.IPTracingOptionType),
 	}
+}
+
+// vniOfLocalEndpoint returns the native-vpc VNI of the local endpoint whose BPF
+// program emitted the event (the "source" field of the notification is the
+// endpoint owning the program, not necessarily the source of the packet).
+//
+// That endpoint's VNI is the exact scope the datapath used to resolve the peer
+// (bpf_lxc looks the peer up in cilium_ipcache_vni with its own
+// CONFIG(native_vpc_vni)), which makes it the right context for resolving both
+// sides of the flow: same-VPC peers resolve exactly, non-VPC peers fall back
+// to the plain scope, and a foreign VPC entry with the same IP can never be
+// selected.
+func (p *Parser) vniOfLocalEndpoint(dn *monitor.DropNotify, tn *monitor.TraceNotify, pvn *monitor.PolicyVerdictNotify) (uint32, bool) {
+	// Outside native-vpc mode every endpoint has VNI 0; skip the extra lookup
+	// on the per-event hot path.
+	if !option.Config.EnableNativeVPC || p.endpointGetter == nil {
+		return 0, false
+	}
+	var epID uint16
+	switch {
+	case dn != nil:
+		epID = dn.Source
+	case tn != nil:
+		epID = tn.Source
+	case pvn != nil:
+		epID = pvn.Source
+	}
+	if epID == 0 {
+		return 0, false
+	}
+	ep, ok := p.endpointGetter.GetEndpointInfoByID(epID)
+	if !ok {
+		return 0, false
+	}
+	vni := ep.GetVNIID()
+	if vni == 0 || vni > math.MaxUint32 {
+		return 0, false
+	}
+	return uint32(vni), true
 }
 
 func decodeSecurityIdentities(dn *monitor.DropNotify, tn *monitor.TraceNotify, pvn *monitor.PolicyVerdictNotify) (

--- a/pkg/hubble/parser/threefour/vni_test.go
+++ b/pkg/hubble/parser/threefour/vni_test.go
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package threefour
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+	"github.com/stretchr/testify/require"
+
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/byteorder"
+	"github.com/cilium/cilium/pkg/hubble/parser/getters"
+	"github.com/cilium/cilium/pkg/hubble/testutils"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/monitor"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// vniEndpointGetter resolves endpoints by the exact (VNI, IP) key and by ID,
+// like the real payloadGetters do.
+type vniEndpointGetter struct {
+	byID  map[uint16]getters.EndpointInfo
+	byVNI map[uint32]map[netip.Addr]getters.EndpointInfo
+}
+
+func (g *vniEndpointGetter) GetEndpointInfo(netip.Addr) (getters.EndpointInfo, bool) {
+	// Native-vpc endpoints are never resolvable from a bare IP: the whole
+	// point of the test is that the parser does not need this path.
+	return nil, false
+}
+
+func (g *vniEndpointGetter) GetEndpointInfoByID(id uint16) (getters.EndpointInfo, bool) {
+	ep, ok := g.byID[id]
+	return ep, ok
+}
+
+func (g *vniEndpointGetter) GetEndpointInfoForVNI(ip netip.Addr, vni uint32) (getters.EndpointInfo, bool) {
+	ep, ok := g.byVNI[vni][ip]
+	return ep, ok
+}
+
+// TestTraceNotifyVNIChain pins the full L3/L4 observability chain of
+// native-vpc mode:
+//
+//	datapath event (local endpoint id)
+//	  -> local endpoint VNI (the same scope bpf_lxc used to resolve the peer)
+//	  -> exact (VNI, IP) endpoint / ipcache lookups
+//	  -> flow with vni_id on both endpoints
+//
+// Both pods use the same IP in two different VPCs, so any bare-IP lookup in
+// the chain would attribute the flow to the wrong VPC.
+func TestTraceNotifyVNIChain(t *testing.T) {
+	oldNativeVPC := option.Config.EnableNativeVPC
+	option.Config.EnableNativeVPC = true
+	t.Cleanup(func() { option.Config.EnableNativeVPC = oldNativeVPC })
+
+	const (
+		localEPID   = uint16(1234)
+		localVNI    = uint32(36)
+		foreignVNI  = uint32(17)
+		remoteSecID = uint32(21929)
+	)
+	srcAddr := netip.MustParseAddr("10.16.32.10")
+	dstAddr := netip.MustParseAddr("10.16.32.20")
+
+	localEP := &testutils.FakeEndpointInfo{
+		ID:           uint64(localEPID),
+		Identity:     identity.NumericIdentity(11111),
+		IPv4:         srcAddr.AsSlice(),
+		PodName:      "client",
+		PodNamespace: "vpc-a",
+		VNIID:        uint64(localVNI),
+	}
+	// Same IP as the peer, but in another VPC: must never be selected.
+	foreignEP := &testutils.FakeEndpointInfo{
+		ID:           uint64(4321),
+		Identity:     identity.NumericIdentity(22222),
+		IPv4:         dstAddr.AsSlice(),
+		PodName:      "foreign",
+		PodNamespace: "vpc-b",
+		VNIID:        uint64(foreignVNI),
+	}
+
+	endpointGetter := &vniEndpointGetter{
+		byID: map[uint16]getters.EndpointInfo{localEPID: localEP},
+		byVNI: map[uint32]map[netip.Addr]getters.EndpointInfo{
+			localVNI:   {srcAddr: localEP},
+			foreignVNI: {dstAddr: foreignEP},
+		},
+	}
+
+	// The destination is a remote pod of the same VPC: it is only present in
+	// the VNI-scoped ipcache. The plain lookups return the foreign VPC entry
+	// to prove they are not consulted.
+	ipGetter := &testutils.FakeIPGetter{
+		OnLookupSecIDByIPForVNI: func(ip netip.Addr, vni uint32) (ipcache.Identity, bool) {
+			if ip == dstAddr && vni == localVNI {
+				return ipcache.Identity{ID: identity.NumericIdentity(remoteSecID), Vni: localVNI}, true
+			}
+			return ipcache.Identity{}, false
+		},
+		OnGetK8sMetadataForVNI: func(ip netip.Addr, vni uint32) *ipcache.K8sMetadata {
+			if ip == dstAddr && vni == localVNI {
+				return &ipcache.K8sMetadata{Namespace: "vpc-a", PodName: "server"}
+			}
+			return nil
+		},
+		OnLookupSecIDByIP: func(netip.Addr) (ipcache.Identity, bool) {
+			return ipcache.Identity{ID: identity.NumericIdentity(33333)}, true
+		},
+		OnGetK8sMetadata: func(netip.Addr) *ipcache.K8sMetadata {
+			return &ipcache.K8sMetadata{Namespace: "vpc-b", PodName: "foreign"}
+		},
+	}
+
+	identityGetter := &testutils.FakeIdentityGetter{
+		OnGetIdentity: func(secID uint32) (*identity.Identity, error) {
+			return identity.NewIdentity(identity.NumericIdentity(secID), labels.Labels{
+				labels.VNIKey: labels.NewLabel(labels.VNIKey, "36", labels.LabelSourceVNI),
+			}), nil
+		},
+	}
+
+	// cil_from_container of the local endpoint: "source" is the emitting
+	// (local) endpoint, and the datapath identity of the peer is unknown.
+	tn := monitor.TraceNotify{
+		Type:     byte(monitorAPI.MessageTypeTrace),
+		Source:   localEPID,
+		SrcLabel: identity.NumericIdentity(11111),
+		Version:  monitor.TraceNotifyVersion2,
+	}
+	buf := &bytes.Buffer{}
+	require.NoError(t, binary.Write(buf, byteorder.Native, &tn))
+	packet := gopacket.NewSerializeBuffer()
+	require.NoError(t, gopacket.SerializeLayers(packet, gopacket.SerializeOptions{},
+		&layers.Ethernet{
+			SrcMAC:       net.HardwareAddr{1, 2, 3, 4, 5, 6},
+			DstMAC:       net.HardwareAddr{7, 8, 9, 0, 1, 2},
+			EthernetType: layers.EthernetTypeIPv4,
+		},
+		&layers.IPv4{
+			Version:  4,
+			IHL:      5,
+			Length:   49,
+			TTL:      64,
+			Protocol: layers.IPProtocolUDP,
+			SrcIP:    srcAddr.AsSlice(),
+			DstIP:    dstAddr.AsSlice(),
+		},
+		&layers.UDP{SrcPort: 23939, DstPort: 53},
+	))
+	buf.Write(packet.Bytes())
+
+	parser, err := New(hivetest.Logger(t), endpointGetter, identityGetter,
+		&testutils.NoopDNSGetter, ipGetter, &testutils.NoopServiceGetter, &testutils.NoopLinkGetter)
+	require.NoError(t, err)
+
+	f := &flowpb.Flow{}
+	require.NoError(t, parser.Decode(buf.Bytes(), f))
+
+	// Source: local endpoint resolved by (VNI, IP), not by bare IP.
+	require.Equal(t, uint32(localEPID), f.GetSource().GetID())
+	require.Equal(t, "vpc-a", f.GetSource().GetNamespace())
+	require.Equal(t, "client", f.GetSource().GetPodName())
+	require.Equal(t, uint64(localVNI), f.GetSource().GetVniId())
+
+	// Destination: remote peer of the same VPC, resolved through the
+	// VNI-scoped ipcache; the foreign VPC entry under the same bare IP is
+	// never used.
+	require.Equal(t, remoteSecID, f.GetDestination().GetIdentity())
+	require.Equal(t, "vpc-a", f.GetDestination().GetNamespace())
+	require.Equal(t, "server", f.GetDestination().GetPodName())
+	require.Equal(t, uint64(localVNI), f.GetDestination().GetVniId())
+	require.NotEqual(t, "foreign", f.GetDestination().GetPodName())
+}
+
+// TestTraceNotifyNoVNIWhenDisabled verifies the extra endpoint-by-ID lookup is
+// not performed outside native-vpc mode (hot path) and that flows keep their
+// previous shape.
+func TestTraceNotifyNoVNIWhenDisabled(t *testing.T) {
+	oldNativeVPC := option.Config.EnableNativeVPC
+	option.Config.EnableNativeVPC = false
+	t.Cleanup(func() { option.Config.EnableNativeVPC = oldNativeVPC })
+
+	endpointGetter := &testutils.FakeEndpointGetter{
+		OnGetEndpointInfo: func(netip.Addr) (getters.EndpointInfo, bool) { return nil, false },
+		OnGetEndpointInfoByID: func(uint16) (getters.EndpointInfo, bool) {
+			t.Fatal("endpoint-by-ID lookup must not run when native-vpc is disabled")
+			return nil, false
+		},
+	}
+
+	tn := monitor.TraceNotify{
+		Type:    byte(monitorAPI.MessageTypeTrace),
+		Source:  1234,
+		Version: monitor.TraceNotifyVersion2,
+	}
+	buf := &bytes.Buffer{}
+	require.NoError(t, binary.Write(buf, byteorder.Native, &tn))
+	packet := gopacket.NewSerializeBuffer()
+	require.NoError(t, gopacket.SerializeLayers(packet, gopacket.SerializeOptions{},
+		&layers.IPv4{
+			Version: 4, IHL: 5, Length: 49, TTL: 64,
+			Protocol: layers.IPProtocolUDP,
+			SrcIP:    net.IPv4(10, 16, 32, 10),
+			DstIP:    net.IPv4(10, 16, 32, 20),
+		},
+		&layers.UDP{SrcPort: 23939, DstPort: 53},
+	))
+	tn.Flags = monitor.TraceNotifyFlagIsL3Device
+	buf.Reset()
+	require.NoError(t, binary.Write(buf, byteorder.Native, &tn))
+	buf.Write(packet.Bytes())
+
+	parser, err := New(hivetest.Logger(t), endpointGetter, &testutils.NoopIdentityGetter,
+		&testutils.NoopDNSGetter, &testutils.NoopIPGetter, &testutils.NoopServiceGetter, &testutils.NoopLinkGetter)
+	require.NoError(t, err)
+
+	f := &flowpb.Flow{}
+	require.NoError(t, parser.Decode(buf.Bytes(), f))
+	require.Zero(t, f.GetSource().GetVniId())
+	require.Zero(t, f.GetDestination().GetVniId())
+}

--- a/pkg/hubble/testutils/fake.go
+++ b/pkg/hubble/testutils/fake.go
@@ -342,9 +342,10 @@ var NoopLinkGetter = FakeLinkGetter{}
 
 // FakeIPGetter is used for unit tests that needs IPGetter.
 type FakeIPGetter struct {
-	OnGetK8sMetadata       func(ip netip.Addr) *ipcache.K8sMetadata
-	OnGetK8sMetadataForVNI func(ip netip.Addr, vni uint32) *ipcache.K8sMetadata
-	OnLookupSecIDByIP      func(ip netip.Addr) (ipcache.Identity, bool)
+	OnGetK8sMetadata        func(ip netip.Addr) *ipcache.K8sMetadata
+	OnGetK8sMetadataForVNI  func(ip netip.Addr, vni uint32) *ipcache.K8sMetadata
+	OnLookupSecIDByIP       func(ip netip.Addr) (ipcache.Identity, bool)
+	OnLookupSecIDByIPForVNI func(ip netip.Addr, vni uint32) (ipcache.Identity, bool)
 }
 
 // GetK8sMetadata implements FakeIPGetter.GetK8sMetadata.
@@ -371,6 +372,14 @@ func (f *FakeIPGetter) LookupSecIDByIP(ip netip.Addr) (ipcache.Identity, bool) {
 	panic("OnLookupByIP not set")
 }
 
+// LookupSecIDByIPForVNI implements FakeIPGetter.LookupSecIDByIPForVNI.
+func (f *FakeIPGetter) LookupSecIDByIPForVNI(ip netip.Addr, vni uint32) (ipcache.Identity, bool) {
+	if f.OnLookupSecIDByIPForVNI != nil {
+		return f.OnLookupSecIDByIPForVNI(ip, vni)
+	}
+	return ipcache.Identity{}, false
+}
+
 // NoopIPGetter always returns an empty response.
 var NoopIPGetter = FakeIPGetter{
 	OnGetK8sMetadata: func(ip netip.Addr) *ipcache.K8sMetadata {
@@ -380,6 +389,9 @@ var NoopIPGetter = FakeIPGetter{
 		return nil
 	},
 	OnLookupSecIDByIP: func(ip netip.Addr) (ipcache.Identity, bool) {
+		return ipcache.Identity{}, false
+	},
+	OnLookupSecIDByIPForVNI: func(ip netip.Addr, vni uint32) (ipcache.Identity, bool) {
 		return ipcache.Identity{}, false
 	},
 }

--- a/pkg/hubble/testutils/fake.go
+++ b/pkg/hubble/testutils/fake.go
@@ -342,8 +342,9 @@ var NoopLinkGetter = FakeLinkGetter{}
 
 // FakeIPGetter is used for unit tests that needs IPGetter.
 type FakeIPGetter struct {
-	OnGetK8sMetadata  func(ip netip.Addr) *ipcache.K8sMetadata
-	OnLookupSecIDByIP func(ip netip.Addr) (ipcache.Identity, bool)
+	OnGetK8sMetadata       func(ip netip.Addr) *ipcache.K8sMetadata
+	OnGetK8sMetadataForVNI func(ip netip.Addr, vni uint32) *ipcache.K8sMetadata
+	OnLookupSecIDByIP      func(ip netip.Addr) (ipcache.Identity, bool)
 }
 
 // GetK8sMetadata implements FakeIPGetter.GetK8sMetadata.
@@ -352,6 +353,14 @@ func (f *FakeIPGetter) GetK8sMetadata(ip netip.Addr) *ipcache.K8sMetadata {
 		return f.OnGetK8sMetadata(ip)
 	}
 	panic("OnGetK8sMetadata not set")
+}
+
+// GetK8sMetadataForVNI implements FakeIPGetter.GetK8sMetadataForVNI.
+func (f *FakeIPGetter) GetK8sMetadataForVNI(ip netip.Addr, vni uint32) *ipcache.K8sMetadata {
+	if f.OnGetK8sMetadataForVNI != nil {
+		return f.OnGetK8sMetadataForVNI(ip, vni)
+	}
+	return nil
 }
 
 // LookupSecIDByIP implements FakeIPGetter.LookupSecIDByIP.
@@ -365,6 +374,9 @@ func (f *FakeIPGetter) LookupSecIDByIP(ip netip.Addr) (ipcache.Identity, bool) {
 // NoopIPGetter always returns an empty response.
 var NoopIPGetter = FakeIPGetter{
 	OnGetK8sMetadata: func(ip netip.Addr) *ipcache.K8sMetadata {
+		return nil
+	},
+	OnGetK8sMetadataForVNI: func(ip netip.Addr, vni uint32) *ipcache.K8sMetadata {
 		return nil
 	},
 	OnLookupSecIDByIP: func(ip netip.Addr) (ipcache.Identity, bool) {

--- a/pkg/identity/cache/cell/cell.go
+++ b/pkg/identity/cache/cell/cell.go
@@ -128,6 +128,28 @@ func newIdentityAllocator(params identityAllocatorParams) identityAllocatorOut {
 		logger:          params.Log,
 	}
 
+	// Native-vpc: the identity of an endpoint carries its VNI label, which is
+	// derived from the pod's tunnel_key annotation by the *agent*. The
+	// operator's CiliumIdentity controller computes identities from pod and
+	// namespace labels only, so with operator-managed CIDs it would create
+	// identities without the VNI label, consider the agent's VNI-scoped
+	// identities unused and garbage collect them - merging all VPCs into one
+	// identity. Refuse to start instead.
+	//
+	// Checked unconditionally: the combination is invalid regardless of
+	// whether this agent currently enforces network policy, and the operator
+	// would act on the identities either way.
+	if err := nativeVPCIdentityModeError(params.Config.IdentityManagementMode); err != nil {
+		params.Log.Error(
+			"native-vpc mode requires agent-managed CiliumIdentities",
+			logfields.Error, err,
+			logfields.Value, params.Config.IdentityManagementMode,
+		)
+		params.Lifecycle.Append(cell.Hook{
+			OnStart: func(cell.HookContext) error { return err },
+		})
+	}
+
 	var idAlloc CachingIdentityAllocator
 
 	if option.NetworkPolicyEnabled(option.Config) {
@@ -135,24 +157,6 @@ func newIdentityAllocator(params identityAllocatorParams) identityAllocatorOut {
 			params.Config.IdentityManagementMode == option.IdentityManagementModeOperator,
 			params.Config.IdentityManagementMode == option.IdentityManagementModeBoth,
 		)
-
-		// Native-vpc: the identity of an endpoint carries its VNI label, which
-		// is derived from the pod's tunnel_key annotation by the *agent*. The
-		// operator's CiliumIdentity controller computes identities from pod and
-		// namespace labels only, so with operator-managed CIDs it would create
-		// identities without the VNI label, consider the agent's VNI-scoped
-		// identities unused and garbage collect them - merging all VPCs into
-		// one identity. Refuse to start instead.
-		if err := nativeVPCIdentityModeError(params.Config.IdentityManagementMode); err != nil {
-			params.Log.Error(
-				"native-vpc mode requires agent-managed CiliumIdentities",
-				logfields.Error, err,
-				logfields.Value, params.Config.IdentityManagementMode,
-			)
-			params.Lifecycle.Append(cell.Hook{
-				OnStart: func(cell.HookContext) error { return err },
-			})
-		}
 
 		allocatorConfig := cache.AllocatorConfig{
 			EnableOperatorManageCIDs: isOperatorManageCIDsEnabled,

--- a/pkg/identity/cache/cell/cell.go
+++ b/pkg/identity/cache/cell/cell.go
@@ -5,6 +5,7 @@ package identitycachecell
 
 import (
 	"cmp"
+	"fmt"
 	"log/slog"
 	"net"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
@@ -100,6 +102,24 @@ var defaultConfig = config{
 	IdentityAllocationSyncInterval: allocator.DefaultSyncInterval,
 }
 
+// nativeVPCIdentityModeError reports whether the configured identity
+// management mode is compatible with native-vpc. The VNI identity label is
+// computed by the agent from the pod's tunnel_key annotation; the operator's
+// CiliumIdentity controller derives identities from pod and namespace labels
+// only, so operator-managed CIDs would drop the VNI label and garbage collect
+// the agent's VNI-scoped identities, merging every VPC into one identity.
+func nativeVPCIdentityModeError(mode string) error {
+	if !option.Config.EnableNativeVPC {
+		return nil
+	}
+	switch mode {
+	case option.IdentityManagementModeOperator, option.IdentityManagementModeBoth:
+		return fmt.Errorf("native-vpc mode is incompatible with --%s=%s: identities must be managed by the agent so that the VNI identity label is preserved",
+			option.IdentityManagementMode, mode)
+	}
+	return nil
+}
+
 func newIdentityAllocator(params identityAllocatorParams) identityAllocatorOut {
 	// iao: updates SelectorCache and regenerates endpoints when
 	// identity allocation / deallocation has occurred.
@@ -115,6 +135,24 @@ func newIdentityAllocator(params identityAllocatorParams) identityAllocatorOut {
 			params.Config.IdentityManagementMode == option.IdentityManagementModeOperator,
 			params.Config.IdentityManagementMode == option.IdentityManagementModeBoth,
 		)
+
+		// Native-vpc: the identity of an endpoint carries its VNI label, which
+		// is derived from the pod's tunnel_key annotation by the *agent*. The
+		// operator's CiliumIdentity controller computes identities from pod and
+		// namespace labels only, so with operator-managed CIDs it would create
+		// identities without the VNI label, consider the agent's VNI-scoped
+		// identities unused and garbage collect them - merging all VPCs into
+		// one identity. Refuse to start instead.
+		if err := nativeVPCIdentityModeError(params.Config.IdentityManagementMode); err != nil {
+			params.Log.Error(
+				"native-vpc mode requires agent-managed CiliumIdentities",
+				logfields.Error, err,
+				logfields.Value, params.Config.IdentityManagementMode,
+			)
+			params.Lifecycle.Append(cell.Hook{
+				OnStart: func(cell.HookContext) error { return err },
+			})
+		}
 
 		allocatorConfig := cache.AllocatorConfig{
 			EnableOperatorManageCIDs: isOperatorManageCIDsEnabled,

--- a/pkg/identity/cache/cell/native_vpc_test.go
+++ b/pkg/identity/cache/cell/native_vpc_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package identitycachecell
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// TestNativeVPCRequiresAgentManagedIdentities pins the policy-plane guard: the
+// VNI identity label is computed by the agent from the pod annotation, while
+// the operator's CiliumIdentity controller derives identities from pod and
+// namespace labels only. With operator-managed CIDs the agent's VNI-scoped
+// identities would be considered unused and garbage collected, merging every
+// VPC into a single identity, so the combination must be rejected.
+func TestNativeVPCRequiresAgentManagedIdentities(t *testing.T) {
+	prev := option.Config.EnableNativeVPC
+	t.Cleanup(func() { option.Config.EnableNativeVPC = prev })
+
+	for _, tc := range []struct {
+		mode      string
+		nativeVPC bool
+		reject    bool
+	}{
+		{mode: option.IdentityManagementModeAgent, nativeVPC: true},
+		{mode: option.IdentityManagementModeOperator, nativeVPC: true, reject: true},
+		{mode: option.IdentityManagementModeBoth, nativeVPC: true, reject: true},
+		{mode: option.IdentityManagementModeOperator},
+		{mode: option.IdentityManagementModeBoth},
+	} {
+		name := tc.mode
+		if tc.nativeVPC {
+			name += "/native-vpc"
+		}
+		t.Run(name, func(t *testing.T) {
+			option.Config.EnableNativeVPC = tc.nativeVPC
+			err := nativeVPCIdentityModeError(tc.mode)
+			if !tc.reject {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, "identity-management-mode")
+		})
+	}
+}

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -57,12 +57,34 @@ type IPIdentityPair struct {
 	K8sPodName        string          `json:"K8sPodName,omitempty"`
 	K8sServiceAccount string          `json:"K8sServiceAccount,omitempty"`
 	NamedPorts        []NamedPort     `json:"NamedPorts,omitempty"`
+	// Vni is the native-vpc Virtual Network Identifier of the entry. When
+	// non-zero the entry (and its kvstore/ipcache key) is scoped to that VPC as
+	// "<ip>@vni:<N>", so overlapping IPs from different VPCs coexist.
+	// omitempty keeps non-native-vpc entries byte-compatible. Native-vpc mixed
+	// versions are intentionally unsupported: an older reader does not include
+	// Vni in GetKeyName and rejects the scoped physical key in Unmarshal.
+	Vni uint64 `json:"Vni,omitempty"`
 }
 
 type IdentityMap map[NumericIdentity]labels.LabelArray
 
-// GetKeyName returns the kvstore key to be used for the IPIdentityPair
-func (pair *IPIdentityPair) GetKeyName() string { return pair.PrefixString() }
+// VNISuffix is the suffix used to encode a native-vpc VNI into identity keys
+// ("<ip>@vni:<N>"). It must stay in sync with the ipcache key encoding
+// (pkg/ipcache KeyWithVNI) and the LPM map display strings.
+const VNISuffix = "@vni:"
+
+// GetKeyName returns the kvstore key to be used for the IPIdentityPair. For
+// native-vpc entries (Vni > 0) the key carries the VNI suffix so that the
+// same IP in different VPCs maps to distinct kvstore keys (the kvstore has no
+// per-VPC namespace of its own). Must be consistent with the key passed to
+// Unmarshal, which validates GetKeyName against the physical key.
+func (pair *IPIdentityPair) GetKeyName() string {
+	name := pair.PrefixString()
+	if pair.Vni > 0 {
+		return name + VNISuffix + strconv.FormatUint(pair.Vni, 10)
+	}
+	return name
+}
 
 // Marshal returns the IPIdentityPair object as JSON byte slice
 func (pair *IPIdentityPair) Marshal() ([]byte, error) { return json.Marshal(pair) }

--- a/pkg/identity/key/vni_key_test.go
+++ b/pkg/identity/key/vni_key_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package key
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/labels"
+)
+
+// TestVNIIdentityKeySeparation pins the policy-plane invariant of native-vpc:
+// the numeric identity is derived from the identity label set, and the VNI
+// identity label is part of it. Two pods that are identical in every other
+// respect (same Kubernetes labels, and possibly the same IP in two VPCs)
+// therefore never collapse into one identity, which is what keeps
+// fromEndpoints/toEndpoints and the policy map VNI-scoped.
+func TestVNIIdentityKeySeparation(t *testing.T) {
+	withVNI := func(vni string) *GlobalIdentity {
+		lbls := labels.Labels{
+			"k8s:app": labels.NewLabel("app", "web", labels.LabelSourceK8s),
+		}
+		if vni != "" {
+			lbls[labels.VNIKey] = labels.NewLabel(labels.VNIKey, vni, labels.LabelSourceVNI)
+		}
+		return &GlobalIdentity{LabelArray: lbls.LabelArray()}
+	}
+
+	vpcA, vpcB, plain := withVNI("36"), withVNI("17"), withVNI("")
+
+	require.NotEqual(t, vpcA.GetKey(), vpcB.GetKey(),
+		"endpoints of two VPCs must not share an identity key")
+	require.NotEqual(t, vpcA.GetKey(), plain.GetKey(),
+		"a VPC endpoint must not share the identity of a non-VPC endpoint")
+	require.Equal(t, vpcA.GetKey(), withVNI("36").GetKey(),
+		"the same VPC and labels must reuse one identity")
+
+	// The label must be visible to selectors under its own source.
+	require.Contains(t, vpcA.GetAsMap(), labels.LabelSourceVNI+":"+labels.VNIKey)
+}

--- a/pkg/ipam/api/ipam_api_handler.go
+++ b/pkg/ipam/api/ipam_api_handler.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/netip"
 	"strings"
 
 	"github.com/go-openapi/runtime/middleware"
@@ -134,12 +135,13 @@ func (r *IpamPostIpamIPHandler) Handle(params ipamapi.PostIpamIPParams) middlewa
 }
 
 func (r *IpamDeleteIpamIPHandler) Handle(params ipamapi.DeleteIpamIPParams) middleware.Responder {
-	// Release of an IP that is in use is not allowed
-	if ep := r.EndpointManager.LookupIPv4(params.IP); ep != nil {
-		return api.Error(ipamapi.DeleteIpamIPFailureCode, fmt.Errorf("IP is in use by endpoint %d", ep.ID))
-	}
-	if ep := r.EndpointManager.LookupIPv6(params.IP); ep != nil {
-		return api.Error(ipamapi.DeleteIpamIPFailureCode, fmt.Errorf("IP is in use by endpoint %d", ep.ID))
+	// Release of an IP that is in use is not allowed. In native-vpc mode the
+	// endpoint may only be indexed under its (VNI, IP) key, so use the
+	// VNI-agnostic "in use" lookup rather than the bare-IP index.
+	if addr, err := netip.ParseAddr(params.IP); err == nil {
+		if ep := endpointmanager.LookupIPAnyVNI(r.EndpointManager, addr); ep != nil {
+			return api.Error(ipamapi.DeleteIpamIPFailureCode, fmt.Errorf("IP is in use by endpoint %d", ep.ID))
+		}
 	}
 
 	ip := net.ParseIP(params.IP)

--- a/pkg/ipcache/api/ipcache_api_handler.go
+++ b/pkg/ipcache/api/ipcache_api_handler.go
@@ -108,6 +108,13 @@ func (ipc *ipCacheDumpListener) OnIPIdentityCacheChange(modType ipcache.CacheMod
 		HostIP:     hostIP,
 		EncryptKey: int64(encryptKey),
 	}
+	// Expose the native-vpc VNI so diagnostics can distinguish overlapping
+	// IPs from different VPCs. Leave the optional field absent for non-VPC
+	// entries (VNI 0).
+	if newID.Vni > 0 {
+		vni := int64(newID.Vni)
+		entry.VniID = &vni
+	}
 
 	if k8sMeta != nil {
 		entry.Metadata = &models.IPListEntryMetadata{

--- a/pkg/ipcache/cell/cell.go
+++ b/pkg/ipcache/cell/cell.go
@@ -119,6 +119,14 @@ func newIPCache(params ipCacheParams) *ipcache.IPCache {
 				return fmt.Errorf("initializing ipcache map: %w", err)
 			}
 
+			// In native-vpc mode also (re)create the VNI-scoped ipcache map so
+			// that bpf programs referencing cilium_ipcache_vni can be loaded.
+			if option.Config.EnableNativeVPC {
+				if err := ipcachemap.IPCacheVniMap(params.MetricsRegistry).Recreate(); err != nil {
+					return fmt.Errorf("initializing native-vpc ipcache map: %w", err)
+				}
+			}
+
 			return nil
 		},
 		OnStop: func(hc cell.HookContext) error {

--- a/pkg/ipcache/cell/cell.go
+++ b/pkg/ipcache/cell/cell.go
@@ -37,6 +37,11 @@ var Cell = cell.Module(
 
 	cell.Provide(
 		newIPCache,
+		// The local-ipcache fallback of the identity synchronizer takes an
+		// interface: hive can only build it if a constructor returns it, so
+		// provide the adapter explicitly. Without this the whole agent object
+		// graph fails with "missing type: ipcache.LocalIPCache".
+		func(ipc *ipcache.IPCache) ipcache.LocalIPCache { return ipc },
 		ipcache.NewLocalIPIdentityWatcher,
 		ipcache.NewIPIdentitySynchronizer,
 		newIPCacheAPIHandler,

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -11,6 +11,9 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"strconv"
+	"strings"
+
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/counter"
@@ -26,8 +29,6 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/types"
-	"strconv"
-	"strings"
 )
 
 // Identity is the identity representation of an IP<->Identity cache.

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -812,9 +812,30 @@ func (ipc *IPCache) dumpToListenerLocked(listener IPIdentityMappingListener) {
 		hostIP, encryptKey := ipc.getHostIPCacheRLocked(ip)
 		k8sMeta := ipc.getK8sMetadata(ip)
 		endpointFlags := ipc.getEndpointFlagsRLocked(ip)
-		cidrCluster, err := cmtypes.ParsePrefixCluster(ip)
+
+		// Native-vpc entries are keyed "<ip>@vni:<vni>", which is not a
+		// parsable prefix/AddrCluster. Strip the suffix and carry the VNI in
+		// the identity (as the incremental Upsert path does), so that
+		// listeners see the same (prefix, Identity.Vni) pair on a full dump as
+		// on an incremental update.
+		plainIP, keyVNI := splitVNIKey(ip)
+		if identity.Vni == 0 {
+			identity.Vni = keyVNI
+		}
+
+		cidrCluster, err := cmtypes.ParsePrefixCluster(plainIP)
 		if err != nil {
-			addrCluster := cmtypes.MustParseAddrCluster(ip)
+			addrCluster, addrErr := cmtypes.ParseAddrCluster(plainIP)
+			if addrErr != nil {
+				// Never panic on a malformed key: this function backs the
+				// ipcache API dump and the BPF listener registration.
+				ipc.logger.Error(
+					"unable to parse ipcache key, skipping entry in dump",
+					logfields.Error, addrErr,
+					logfields.IPAddr, ip,
+				)
+				continue
+			}
 			cidrCluster = addrCluster.AsPrefixCluster()
 		}
 		listener.OnIPIdentityCacheChange(Upsert, cidrCluster, nil, hostIP, nil, identity, encryptKey, k8sMeta, endpointFlags)
@@ -1071,6 +1092,11 @@ func (ipc *IPCache) LookupSecIDByIP(ip netip.Addr) (id Identity, ok bool) {
 
 // LookupByIdentity returns the set of IPs (endpoint or CIDR prefix) that have
 // security identity ID, or nil if the entry does not exist.
+//
+// Native-vpc entries are stored under "<ip>@vni:<vni>" keys; they are returned
+// as plain IPs here because every consumer (DNS rule restoration) matches
+// packets by address. This does not mix VPCs: the selection is by identity,
+// and identities are VNI-distinct in native-vpc mode.
 func (ipc *IPCache) LookupByIdentity(id identity.NumericIdentity) (ips []string) {
 	ipc.mutex.RLock()
 	defer ipc.mutex.RUnlock()
@@ -1080,7 +1106,8 @@ func (ipc *IPCache) LookupByIdentity(id identity.NumericIdentity) (ips []string)
 	if length > 0 {
 		ips = make([]string, 0, length)
 		for ip := range ipc.identityToIPCache[id] {
-			ips = append(ips, ip)
+			plainIP, _ := splitVNIKey(ip)
+			ips = append(ips, plainIP)
 		}
 	}
 	return ips
@@ -1092,9 +1119,22 @@ func (ipc *IPCache) LookupByIdentity(id identity.NumericIdentity) (ips []string)
 func (ipc *IPCache) LookupByHostRLocked(hostIPv4, hostIPv6 net.IP) (cidrs []net.IPNet) {
 	for ip, host := range ipc.ipToHostIPCache {
 		if hostIPv4 != nil && host.IP.Equal(hostIPv4) || hostIPv6 != nil && host.IP.Equal(hostIPv6) {
-			_, cidr, err := net.ParseCIDR(ip)
+			// Native-vpc keys carry an "@vni:<vni>" suffix which is not
+			// parsable; the caller (WireGuard AllowedIPs) works on plain
+			// prefixes.
+			plainIP, _ := splitVNIKey(ip)
+			_, cidr, err := net.ParseCIDR(plainIP)
 			if err != nil {
-				endpointIP := net.ParseIP(ip)
+				endpointIP := net.ParseIP(plainIP)
+				if endpointIP == nil {
+					// Never append a zero-value prefix for a key we
+					// cannot parse.
+					ipc.logger.Error(
+						"unable to parse ipcache key, skipping entry",
+						logfields.IPAddr, ip,
+					)
+					continue
+				}
 				cidr = iputil.IPToPrefix(endpointIP)
 			}
 			cidrs = append(cidrs, *cidr)

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -327,6 +327,21 @@ func (ipc *IPCache) getK8sMetadata(ip string) *K8sMetadata {
 	return nil
 }
 
+// LookupSecIDByIPForVNI resolves the identity of the native-vpc VNI-scoped
+// entry for the given IP (key "<ip>@vni:<vni>"). It is key-exact: it never
+// falls back to the plain (non-VPC) entry or to a shorter prefix, so a caller
+// that knows the VNI of a packet can never be given a foreign VPC's identity.
+// Callers must fall back to the plain lookups explicitly for non-VPC entities
+// (nodes, host, world, CIDRs).
+func (ipc *IPCache) LookupSecIDByIPForVNI(ip netip.Addr, vni uint32) (Identity, bool) {
+	if !ip.IsValid() || vni == 0 {
+		return Identity{}, false
+	}
+	ipc.mutex.RLock()
+	defer ipc.mutex.RUnlock()
+	return ipc.lookupByIPRLocked(KeyWithVNI(ip.String(), vni))
+}
+
 // LookupSecIDByIPUnambiguous is the deliberate exception to the key-exact
 // rule: it additionally resolves a native-vpc VNI-scoped entry when exactly
 // one VPC uses the given IP, and reports a miss when several VPCs overlap on

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -26,6 +26,8 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/types"
+	"strconv"
+	"strings"
 )
 
 // Identity is the identity representation of an IP<->Identity cache.
@@ -42,6 +44,13 @@ type Identity struct {
 
 	// ID is the numeric identity
 	ID identity.NumericIdentity
+
+	// Vni is the Virtual Network Identifier (VNI) of the endpoint for
+	// native-vpc mode. Entries with a non-zero VNI are scoped to that VPC
+	// (keyed by IP+VNI), which allows overlapping IPs in different VPCs to
+	// coexist in the ipcache. A zero VNI means the entry is a plain
+	// cluster-wide IP mapping.
+	Vni uint32
 
 	// This blank field ensures that the == operator cannot be used on this
 	// type, to avoid external packages accidentally comparing the private
@@ -67,6 +76,7 @@ type Identity struct {
 func (i Identity) equals(o Identity) bool {
 	return i.ID == o.ID &&
 		i.Source == o.Source &&
+		i.Vni == o.Vni &&
 		i.shadowed == o.shadowed &&
 		i.modifiedByLegacyAPI == o.modifiedByLegacyAPI &&
 		i.overwrittenLegacySource == o.overwrittenLegacySource
@@ -88,6 +98,55 @@ func (i Identity) ownedByLegacyAndMetadataAPI() bool {
 type IPKeyPair struct {
 	IP  net.IP
 	Key uint8
+}
+
+// vniKeySuffix is the suffix used to encode a VNI into an ipcache key string.
+// The plain IP/prefix parsers (cmtypes.ParsePrefixCluster / ParseAddrCluster)
+// do not understand this suffix, so ipcache callers that manage entries for
+// native-vpc endpoints must encode the VNI this way to keep overlapping IPs
+// from different VPCs as distinct entries. upsertLocked strips the suffix
+// before parsing the IP, and re-attaches it for all internal map keys.
+//
+// Design note (fork decision): this is the "local ClusterID" split.
+// Cilium upstream solves overlapping IPs across clusters with (IP, ClusterID)
+// cluster-aware addressing (PrefixCluster, "ip@clusterID", cluster_id field in
+// the ipcache key, clusterID bits in the identity). In our multi-tenant VPC
+// model a VPC is the single-cluster equivalent of a cluster, so we reuse the
+// same addressing pattern with the kube-ovn tunnel_key (VNI) as the scoping
+// id. We deliberately do NOT reuse the clusterID bit range / field: VPC and
+// ClusterMesh must not share semantics, and the identity number's clusterID
+// bits are reserved for ClusterMesh. VNI stays in the addressing/resolution
+// layer (this key suffix, cilium_ipcache_vni, endpoint vni-ipv4 identifiers),
+// while the identity/policy layer gets the same VNI dimension via a
+// VNI identity label (injected by endpoint.metadataResolver).
+//
+// The suffix string itself lives in pkg/identity (identity.VNISuffix) so that
+// the kvstore identity path (IPIdentityPair.GetKeyName) can build matching
+// scoped keys without an import cycle.
+const vniKeySuffix = identity.VNISuffix
+
+// KeyWithVNI returns the ipcache key string for the given IP/prefix string and
+// VNI. A zero VNI returns the key unchanged (plain cluster-wide entry).
+//
+// Ordering rule: apply any ClusterID annotation first, then KeyWithVNI last
+// ("ip@clusterID@vni:N"). splitVNIKey deliberately uses LastIndex to strip the
+// final VNI suffix before the cluster-aware parser sees the remaining key.
+func KeyWithVNI(ip string, vni uint32) string {
+	if vni == 0 {
+		return ip
+	}
+	return ip + vniKeySuffix + strconv.FormatUint(uint64(vni), 10)
+}
+
+// splitVNIKey splits a possibly VNI-encoded ipcache key back into the plain
+// IP/prefix string and the VNI (0 if the key is not VNI-encoded).
+func splitVNIKey(key string) (string, uint32) {
+	if i := strings.LastIndex(key, vniKeySuffix); i > 0 {
+		if v, err := strconv.ParseUint(key[i+len(vniKeySuffix):], 10, 32); err == nil {
+			return key[:i], uint32(v)
+		}
+	}
+	return key, 0
 }
 
 // K8sMetadata contains Kubernetes pod information of the IP
@@ -121,6 +180,13 @@ type IPCache struct {
 	identityToIPCache map[identity.NumericIdentity]map[string]struct{}
 	ipToHostIPCache   map[string]IPKeyPair
 	ipToK8sMetadata   map[string]K8sMetadata
+	// ipToVNIKeys maps a plain IP to the set of native-vpc VNI-scoped ipcache
+	// keys ("<ip>@vni:<vni>") currently present for it. It backs only the
+	// explicit best-effort read APIs (LookupSecIDByIPUnambiguous /
+	// GetK8sMetadataUnambiguous), never the generic key-exact paths used by
+	// writers/deleters. When several VPCs share the IP these APIs report a miss
+	// rather than guessing a VPC.
+	ipToVNIKeys       map[string]map[string]struct{}
 	ipToEndpointFlags map[string]uint8
 
 	listeners []IPIdentityMappingListener
@@ -165,6 +231,7 @@ func NewIPCache(c *Configuration) *IPCache {
 		mutex:             lock.NewSemaphoredMutex(),
 		ipToIdentityCache: map[string]Identity{},
 		identityToIPCache: map[identity.NumericIdentity]map[string]struct{}{},
+		ipToVNIKeys:       map[string]map[string]struct{}{},
 		ipToHostIPCache:   map[string]IPKeyPair{},
 		ipToK8sMetadata:   map[string]K8sMetadata{},
 		ipToEndpointFlags: map[string]uint8{},
@@ -238,10 +305,85 @@ func (ipc *IPCache) GetK8sMetadata(ip netip.Addr) *K8sMetadata {
 	return ipc.getK8sMetadata(ip.String())
 }
 
+// GetK8sMetadataForVNI returns the Kubernetes metadata of the native-vpc
+// VNI-scoped entry for the given IP (key "<ip>@vni:<vni>"), or nil if no such
+// entry exists. Overlapping IPs from different VPCs coexist as VNI-scoped
+// entries, which the plain GetK8sMetadata lookup (keyed by the bare IP) cannot
+// see. The returned pointer should *never* be modified.
+func (ipc *IPCache) GetK8sMetadataForVNI(ip netip.Addr, vni uint32) *K8sMetadata {
+	if !ip.IsValid() || vni == 0 {
+		return nil
+	}
+	ipc.mutex.RLock()
+	defer ipc.mutex.RUnlock()
+	return ipc.getK8sMetadata(KeyWithVNI(ip.String(), vni))
+}
+
 // getK8sMetadata returns Kubernetes metadata for the given IP address.
 func (ipc *IPCache) getK8sMetadata(ip string) *K8sMetadata {
 	if k8sMeta, ok := ipc.ipToK8sMetadata[ip]; ok {
 		return &k8sMeta
+	}
+	return nil
+}
+
+// LookupSecIDByIPUnambiguous is the deliberate exception to the key-exact
+// rule: it additionally resolves a native-vpc VNI-scoped entry when exactly
+// one VPC uses the given IP, and reports a miss when several VPCs overlap on
+// it (never guessing a VPC). It is meant for best-effort, read-only consumers
+// that only have a bare IP (L7 accesslog, DNS proxy) and must never be used
+// by writers or by the generic LookupByIP/LookupSecIDByIP paths, whose
+// callers pair their lookups with bare-IP writes.
+func (ipc *IPCache) LookupSecIDByIPUnambiguous(ip netip.Addr) (Identity, bool) {
+	if !ip.IsValid() {
+		return Identity{}, false
+	}
+	ipc.mutex.RLock()
+	defer ipc.mutex.RUnlock()
+	return ipc.lookupByIPUnambiguousLocked(ip.String())
+}
+
+// GetK8sMetadataUnambiguous is the metadata counterpart of
+// LookupSecIDByIPUnambiguous (same caveats apply).
+func (ipc *IPCache) GetK8sMetadataUnambiguous(ip netip.Addr) *K8sMetadata {
+	if !ip.IsValid() {
+		return nil
+	}
+	ipc.mutex.RLock()
+	defer ipc.mutex.RUnlock()
+	return ipc.getK8sMetadataUnambiguousLocked(ip.String())
+}
+
+// lookupByIPUnambiguousLocked resolves a VNI-scoped entry for the given bare
+// IP when it is unambiguous (exactly one VNI key), using the two-value form so
+// that a divergence between ipToVNIKeys and ipToIdentityCache degrades to a
+// miss instead of returning a zero Identity with exists=true.
+func (ipc *IPCache) lookupByIPUnambiguousLocked(ip string) (Identity, bool) {
+	if idn, ok := ipc.ipToIdentityCache[ip]; ok {
+		return idn, true
+	}
+	if keySet := ipc.ipToVNIKeys[ip]; len(keySet) == 1 {
+		for key := range keySet {
+			if idn, ok := ipc.ipToIdentityCache[key]; ok {
+				return idn, true
+			}
+		}
+	}
+	return Identity{}, false
+}
+
+// getK8sMetadataUnambiguousLocked is the metadata counterpart of
+// lookupByIPUnambiguousLocked.
+func (ipc *IPCache) getK8sMetadataUnambiguousLocked(ip string) *K8sMetadata {
+	if k8sMeta, ok := ipc.ipToK8sMetadata[ip]; ok {
+		return &k8sMeta
+	}
+	if keySet := ipc.ipToVNIKeys[ip]; len(keySet) == 1 {
+		for key := range keySet {
+			if k8sMeta, ok := ipc.ipToK8sMetadata[key]; ok {
+				return &k8sMeta
+			}
+		}
 	}
 	return nil
 }
@@ -307,6 +449,14 @@ func (ipc *IPCache) upsertLocked(
 	var newNamedPorts types.NamedPortMap
 	if k8sMeta != nil {
 		newNamedPorts = k8sMeta.NamedPorts
+	}
+
+	// Native-vpc entries are keyed by IP+VNI so that overlapping IPs from
+	// different VPCs can coexist. Strip the VNI suffix for parsing, but keep
+	// the encoded string for all internal map keys.
+	plainIP, keyVNI := splitVNIKey(ip)
+	if newIdentity.Vni == 0 {
+		newIdentity.Vni = keyVNI
 	}
 
 	scopedLog := ipc.logger
@@ -394,22 +544,22 @@ func (ipc *IPCache) upsertLocked(
 	// Endpoint IP identities take precedence over CIDR identities, so if the
 	// IP is a full CIDR prefix and there's an existing equivalent endpoint IP,
 	// don't notify the listeners.
-	if cidrCluster, err = cmtypes.ParsePrefixCluster(ip); err == nil {
+	if cidrCluster, err = cmtypes.ParsePrefixCluster(plainIP); err == nil {
 		if cidrCluster.IsSingleIP() {
-			if _, endpointIPFound := ipc.ipToIdentityCache[cidrCluster.AddrCluster().String()]; endpointIPFound {
+			if _, endpointIPFound := ipc.ipToIdentityCache[KeyWithVNI(cidrCluster.AddrCluster().String(), keyVNI)]; endpointIPFound {
 				scopedLog.Debug("Ignoring CIDR to identity mapping as it is shadowed by an endpoint IP")
 				// Skip calling back the listeners, since the endpoint IP has
 				// precedence over the new CIDR.
 				newIdentity.shadowed = true
 			}
 		}
-	} else if addrCluster, err := cmtypes.ParseAddrCluster(ip); err == nil { // Endpoint IP or Endpoint IP with ClusterID
+	} else if addrCluster, err := cmtypes.ParseAddrCluster(plainIP); err == nil { // Endpoint IP or Endpoint IP with ClusterID
 		cidrCluster = addrCluster.AsPrefixCluster()
 
 		// Check whether the upserted endpoint IP will shadow that CIDR, and
 		// replace its mapping with the listeners if that was the case.
 		if !found {
-			cidrClusterStr := cidrCluster.String()
+			cidrClusterStr := KeyWithVNI(cidrCluster.String(), keyVNI)
 			if cidrIdentity, cidrFound := ipc.ipToIdentityCache[cidrClusterStr]; cidrFound {
 				oldHostIP, _ = ipc.getHostIPCacheRLocked(cidrClusterStr)
 				if cidrIdentity.ID != newIdentity.ID || !oldHostIP.Equal(hostIP) {
@@ -442,6 +592,16 @@ func (ipc *IPCache) upsertLocked(
 
 	// Update both maps.
 	ipc.ipToIdentityCache[ip] = newIdentity
+	// Keep the per-IP VNI index in sync so pure-IP lookups can resolve a
+	// VNI-scoped entry when unambiguous.
+	if keyVNI > 0 {
+		keySet, ok := ipc.ipToVNIKeys[plainIP]
+		if !ok {
+			keySet = make(map[string]struct{})
+			ipc.ipToVNIKeys[plainIP] = keySet
+		}
+		keySet[ip] = struct{}{}
+	}
 	// Delete the old identity, if any.
 	if found {
 		delete(ipc.identityToIPCache[cachedIdentity.ID], ip)
@@ -683,23 +843,26 @@ func (ipc *IPCache) deleteLocked(ip string, source source.Source) (namedPortsCha
 	callbackListeners := true
 
 	var err error
-	if cidrCluster, err = cmtypes.ParsePrefixCluster(ip); err == nil {
+	// Same as upsertLocked: strip the VNI suffix for parsing while keeping
+	// the encoded key for internal maps.
+	plainIP, keyVNI := splitVNIKey(ip)
+	if cidrCluster, err = cmtypes.ParsePrefixCluster(plainIP); err == nil {
 		// Check whether the deleted CIDR was shadowed by an endpoint IP. In
 		// this case, skip calling back the listeners since they don't know
 		// about its mapping.
-		if _, endpointIPFound := ipc.ipToIdentityCache[cidrCluster.AddrCluster().String()]; endpointIPFound {
+		if _, endpointIPFound := ipc.ipToIdentityCache[KeyWithVNI(cidrCluster.AddrCluster().String(), keyVNI)]; endpointIPFound {
 			ipc.logger.Debug(
 				"Deleting CIDR shadowed by endpoint IP",
 			)
 			callbackListeners = false
 		}
-	} else if addrCluster, err := cmtypes.ParseAddrCluster(ip); err == nil { // Endpoint IP or Endpoint IP with ClusterID
+	} else if addrCluster, err := cmtypes.ParseAddrCluster(plainIP); err == nil { // Endpoint IP or Endpoint IP with ClusterID
 		// Convert the endpoint IP into an equivalent full CIDR.
 		cidrCluster = addrCluster.AsPrefixCluster()
 
 		// Check whether the deleted endpoint IP was shadowing that CIDR, and
 		// restore its mapping with the listeners if that was the case.
-		cidrClusterStr := cidrCluster.String()
+		cidrClusterStr := KeyWithVNI(cidrCluster.String(), keyVNI)
 		if cidrIdentity, cidrFound := ipc.ipToIdentityCache[cidrClusterStr]; cidrFound {
 			newHostIP, _ = ipc.getHostIPCacheRLocked(cidrClusterStr)
 			if cidrIdentity.ID != cachedIdentity.ID || !oldHostIP.Equal(newHostIP) {
@@ -735,6 +898,15 @@ func (ipc *IPCache) deleteLocked(ip string, source source.Source) (namedPortsCha
 	delete(ipc.identityToIPCache[cachedIdentity.ID], ip)
 	if len(ipc.identityToIPCache[cachedIdentity.ID]) == 0 {
 		delete(ipc.identityToIPCache, cachedIdentity.ID)
+	}
+	// Keep the per-IP VNI index in sync (see the matching upsert code).
+	if keyVNI > 0 {
+		if keySet, ok := ipc.ipToVNIKeys[plainIP]; ok {
+			delete(keySet, ip)
+			if len(keySet) == 0 {
+				delete(ipc.ipToVNIKeys, plainIP)
+			}
+		}
 	}
 	delete(ipc.ipToHostIPCache, ip)
 	delete(ipc.ipToK8sMetadata, ip)
@@ -812,7 +984,10 @@ func (ipc *IPCache) LookupByIP(IP string) (Identity, bool) {
 
 // lookupByIPRLocked returns the corresponding security identity that endpoint IP maps
 // to within the provided IPCache, as well as if the corresponding entry exists
-// in the IPCache.
+// in the IPCache. The lookup is key-exact: native-vpc entries live under
+// "<ip>@vni:<vni>" and are intentionally invisible here (generic readers must
+// not resolve VPC-scoped entries under a bare-IP key, see
+// LookupSecIDByIPUnambiguous for the deliberate exception).
 func (ipc *IPCache) lookupByIPRLocked(IP string) (Identity, bool) {
 	identity, exists := ipc.ipToIdentityCache[IP]
 	return identity, exists

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -61,7 +61,10 @@ type kvstoreClient interface {
 // with "missing type: ipcache.localIPCache".
 type LocalIPCache interface {
 	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *K8sMetadata, newIdentity Identity) (namedPortsChanged bool, err error)
-	Delete(IP string, source source.Source) (namedPortsChanged bool)
+	// DeleteOnMetadataMatch removes the entry only while it still describes the
+	// given pod. An address is reusable, so an unconditional delete could take
+	// away the entry of whichever pod holds it now.
+	DeleteOnMetadataMatch(IP string, source source.Source, namespace, name string) (namedPortsChanged bool)
 }
 
 // IPIdentitySynchronizer handles the synchronization of ipcache entries into the kvstore.
@@ -208,13 +211,19 @@ func (s *IPIdentitySynchronizer) upsertLocal(params *UpsertParams) error {
 // different VPCs (even on the same node) delete the correct entry. Passing the
 // VNI explicitly (rather than remembering it in a map keyed by IP) avoids a
 // same-IP-different-VPC overwrite.
-func (s *IPIdentitySynchronizer) Delete(ctx context.Context, ip string, vni uint64) error {
+//
+// namespace and podName name the pod this entry was created for. An address is
+// reusable: kube-ovn hands it to another pod once it is free, and that pod's
+// endpoint registers the same (VNI, IP) key. Removing the entry then would
+// take the new owner's entry away, so the removal only applies while the entry
+// still describes the pod it was created for.
+func (s *IPIdentitySynchronizer) Delete(ctx context.Context, ip string, vni uint64, namespace, podName string) error {
 	ipKey := path.Join(IPIdentitiesPath, AddressSpace, KeyWithVNI(ip, uint32(vni)))
 	s.tracker.Delete(ipKey)
 
 	if !s.client.IsEnabled() {
 		if s.ipc != nil {
-			s.ipc.Delete(KeyWithVNI(ip, uint32(vni)), source.Local)
+			s.ipc.DeleteOnMetadataMatch(KeyWithVNI(ip, uint32(vni)), source.Local, namespace, podName)
 		}
 		return nil
 	}

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -22,6 +22,7 @@ import (
 	storepkg "github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -53,15 +54,28 @@ type kvstoreClient interface {
 	Delete(ctx context.Context, key string) error
 }
 
+// localIPCache is the subset of *IPCache used by the kvstore-disabled local
+// fallback path. Kept as an interface for testability.
+type localIPCache interface {
+	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *K8sMetadata, newIdentity Identity) (namedPortsChanged bool, err error)
+	Delete(IP string, source source.Source) (namedPortsChanged bool)
+}
+
 // IPIdentitySynchronizer handles the synchronization of ipcache entries into the kvstore.
+// When the kvstore is disabled (e.g. CRD-only identity mode), it falls back to registering
+// the mapping directly into the local ipcache so that local endpoints are always visible to
+// the datapath. In native-vpc mode the local registration is keyed by IP+VNI.
 type IPIdentitySynchronizer struct {
 	logger  *slog.Logger
 	client  kvstoreClient
 	tracker lock.Map[string, []byte]
+
+	// ipc is the local ipcache used as a fallback when the kvstore is disabled.
+	ipc localIPCache
 }
 
-func NewIPIdentitySynchronizer(logger *slog.Logger, client kvstore.Client) *IPIdentitySynchronizer {
-	return &IPIdentitySynchronizer{logger: logger, client: client}
+func NewIPIdentitySynchronizer(logger *slog.Logger, client kvstore.Client, ipc localIPCache) *IPIdentitySynchronizer {
+	return &IPIdentitySynchronizer{logger: logger, client: client, ipc: ipc}
 }
 
 // UpsertParams provides a structured set of parameters for IPIdentitySynchronizer.Upsert.
@@ -75,10 +89,21 @@ type UpsertParams struct {
 	K8sPodName        string
 	K8sServiceAccount string
 	NPM               types.NamedPortMap
+	// Vni is the Virtual Network Identifier for native-vpc endpoints. When
+	// non-zero, the local ipcache entry (kvstore-disabled path) is keyed by
+	// IP+VNI.
+	Vni uint64
 }
 
 // Upsert updates / inserts the provided IP->Identity mapping into the kvstore.
 func (s *IPIdentitySynchronizer) Upsert(ctx context.Context, params *UpsertParams) error {
+	// Without a kvstore, register the mapping directly in the local ipcache so
+	// that the datapath can resolve the source identity of local endpoints
+	// (keyed by IP+VNI in native-vpc mode).
+	if !s.client.IsEnabled() {
+		return s.upsertLocal(params)
+	}
+
 	// Sort named ports into a slice
 	namedPorts := make([]identity.NamedPort, 0, len(params.NPM))
 	for name, value := range params.NPM {
@@ -92,7 +117,7 @@ func (s *IPIdentitySynchronizer) Upsert(ctx context.Context, params *UpsertParam
 		return namedPorts[i].Name < namedPorts[j].Name
 	})
 
-	ipKey := path.Join(IPIdentitiesPath, AddressSpace, params.IP.String())
+	ipKey := path.Join(IPIdentitiesPath, AddressSpace, KeyWithVNI(params.IP.String(), uint32(params.Vni)))
 	ipIDPair := identity.IPIdentityPair{
 		IP:                params.IP.AsSlice(),
 		ID:                params.ID,
@@ -103,6 +128,7 @@ func (s *IPIdentitySynchronizer) Upsert(ctx context.Context, params *UpsertParam
 		K8sPodName:        params.K8sPodName,
 		K8sServiceAccount: params.K8sServiceAccount,
 		NamedPorts:        namedPorts,
+		Vni:               params.Vni,
 	}
 
 	marshaledIPIDPair, err := json.Marshal(ipIDPair)
@@ -125,12 +151,65 @@ func (s *IPIdentitySynchronizer) Upsert(ctx context.Context, params *UpsertParam
 	return err
 }
 
-// Delete removes the IP->Identity mapping for the specified ip
-// from the kvstore, which will subsequently trigger an event in
-// NewIPIdentityWatcher().
-func (s *IPIdentitySynchronizer) Delete(ctx context.Context, ip string) error {
-	ipKey := path.Join(IPIdentitiesPath, AddressSpace, ip)
+// upsertLocal registers the IP->Identity mapping directly in the local
+// ipcache. It is used when no kvstore is configured so that local endpoints
+// are still resolvable by the datapath. In native-vpc mode the entry is keyed
+// by IP+VNI to keep overlapping IPs from different VPCs distinct.
+func (s *IPIdentitySynchronizer) upsertLocal(params *UpsertParams) error {
+	if s.ipc == nil {
+		return nil
+	}
+
+	// In native-vpc mode a zero VNI is an error (the endpoint-create path
+	// rejects such pods); refuse to register a plain-IP entry that would
+	// collide with overlapping VPC subnets.
+	if option.Config.EnableNativeVPC && params.Vni == 0 {
+		s.logger.Error("native-vpc endpoint is missing a valid VNI; skipping local ipcache registration",
+			logfields.IPAddr, params.IP,
+			logfields.K8sPodName, params.K8sNamespace+"/"+params.K8sPodName,
+		)
+		return nil
+	}
+
+	var hostIP net.IP
+	if params.HostIP.IsValid() {
+		hostIP = params.HostIP.AsSlice()
+	}
+
+	k8sMeta := &K8sMetadata{
+		Namespace:  params.K8sNamespace,
+		PodName:    params.K8sPodName,
+		NamedPorts: params.NPM,
+	}
+	vni := uint32(params.Vni)
+
+	_, err := s.ipc.Upsert(
+		KeyWithVNI(params.IP.String(), vni),
+		hostIP, params.Key, k8sMeta,
+		Identity{ID: params.ID, Source: source.Local, Vni: vni},
+	)
+	return err
+}
+
+// Delete removes the IP->Identity mapping for the specified ip from the
+// kvstore, which will subsequently trigger an event in NewIPIdentityWatcher().
+// Without a kvstore, it removes the local ipcache entry that was created by
+// upsertLocal instead. vni is the native-vpc VNI of the endpoint being
+// deleted; it scopes the kvstore/ipcache key so that overlapping IPs from
+// different VPCs (even on the same node) delete the correct entry. Passing the
+// VNI explicitly (rather than remembering it in a map keyed by IP) avoids a
+// same-IP-different-VPC overwrite.
+func (s *IPIdentitySynchronizer) Delete(ctx context.Context, ip string, vni uint64) error {
+	ipKey := path.Join(IPIdentitiesPath, AddressSpace, KeyWithVNI(ip, uint32(vni)))
 	s.tracker.Delete(ipKey)
+
+	if !s.client.IsEnabled() {
+		if s.ipc != nil {
+			s.ipc.Delete(KeyWithVNI(ip, uint32(vni)), source.Local)
+		}
+		return nil
+	}
+
 	return s.client.Delete(ctx, ipKey)
 }
 
@@ -446,15 +525,21 @@ func (iw *IPIdentityWatcher) OnUpdate(k storepkg.Key) {
 		ip = cmtypes.AnnotateIPCacheKeyWithClusterID(ip, iw.clusterID)
 	}
 
+	// Native-vpc: scope the ipcache entry by the pair's VNI so that
+	// overlapping IPs from different VPCs stay distinct (see KeyWithVNI).
+	vni := uint32(ipIDPair.Vni)
+	ipKey := KeyWithVNI(ip, vni)
+
 	// There is no need to delete the "old" IP addresses from this
 	// ip ID pair. The only places where the ip ID pair are created
 	// is the clustermesh, where it sends a delete to the KVStore,
 	// and the endpoint-runIPIdentitySync where it bounded to a
 	// lease and a controller which is stopped/removed when the
 	// endpoint is gone.
-	iw.ipcache.Upsert(ip, ipIDPair.HostIP, ipIDPair.Key, k8sMeta, Identity{
+	iw.ipcache.Upsert(ipKey, ipIDPair.HostIP, ipIDPair.Key, k8sMeta, Identity{
 		ID:     peerIdentity,
 		Source: iw.source,
+		Vni:    vni,
 	})
 }
 
@@ -472,12 +557,16 @@ func (iw *IPIdentityWatcher) OnDelete(k storepkg.NamedKey) {
 	ipIDPair := k.(*identity.IPIdentityPair)
 	ip := ipIDPair.PrefixString()
 
+	// Native-vpc: scope the key by the pair's VNI (see KeyWithVNI).
+	vni := uint32(ipIDPair.Vni)
+	ipKey := KeyWithVNI(ip, vni)
+
 	iw.log.Debug(
 		"Observed deletion event",
 		logfields.IPAddr, ip,
 	)
 
-	if iw.withSelfDeletionProtection && iw.selfDeletionProtection(ip) {
+	if iw.withSelfDeletionProtection && iw.selfDeletionProtection(ipKey) {
 		return
 	}
 
@@ -489,7 +578,7 @@ func (iw *IPIdentityWatcher) OnDelete(k storepkg.NamedKey) {
 	// The key no longer exists in the
 	// local cache, it is safe to remove
 	// from the datapath ipcache.
-	iw.ipcache.Delete(ip, iw.source)
+	iw.ipcache.Delete(KeyWithVNI(ip, vni), iw.source)
 }
 
 func (iw *IPIdentityWatcher) onSync(context.Context) {

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -78,6 +78,12 @@ type IPIdentitySynchronizer struct {
 
 	// ipc is the local ipcache used as a fallback when the kvstore is disabled.
 	ipc LocalIPCache
+
+	// owners records which endpoint last registered each key, so that a
+	// teardown can tell whether the entry it is about to remove is still its
+	// own. An address is reusable and a pod can come back under its own name,
+	// so nothing in the entry itself distinguishes the endpoint that wrote it.
+	owners lock.Map[string, uint16]
 }
 
 func NewIPIdentitySynchronizer(logger *slog.Logger, client kvstore.Client, ipc LocalIPCache) *IPIdentitySynchronizer {
@@ -105,6 +111,11 @@ type UpsertParams struct {
 	// non-zero, the local ipcache entry (kvstore-disabled path) is keyed by
 	// IP+VNI.
 	Vni uint64
+	// EndpointID identifies the endpoint this entry is registered for. It is
+	// what tells two endpoints apart when everything else about them matches -
+	// a pod recreated under the same name on the same address produces the same
+	// namespace, name, address and VNI, and only a different endpoint.
+	EndpointID uint16
 }
 
 // Upsert updates / inserts the provided IP->Identity mapping into the kvstore.
@@ -195,11 +206,15 @@ func (s *IPIdentitySynchronizer) upsertLocal(params *UpsertParams) error {
 	}
 	vni := uint32(params.Vni)
 
+	key := KeyWithVNI(params.IP.String(), vni)
 	_, err := s.ipc.Upsert(
-		KeyWithVNI(params.IP.String(), vni),
+		key,
 		hostIP, params.Key, k8sMeta,
 		Identity{ID: params.ID, Source: source.Local, Vni: vni},
 	)
+	if err == nil {
+		s.owners.Store(key, params.EndpointID)
+	}
 	return err
 }
 
@@ -217,13 +232,30 @@ func (s *IPIdentitySynchronizer) upsertLocal(params *UpsertParams) error {
 // endpoint registers the same (VNI, IP) key. Removing the entry then would
 // take the new owner's entry away, so the removal only applies while the entry
 // still describes the pod it was created for.
-func (s *IPIdentitySynchronizer) Delete(ctx context.Context, ip string, vni uint64, namespace, podName string) error {
-	ipKey := path.Join(IPIdentitiesPath, AddressSpace, KeyWithVNI(ip, uint32(vni)))
+func (s *IPIdentitySynchronizer) Delete(ctx context.Context, ip string, vni uint64, namespace, podName string, endpointID uint16) error {
+	key := KeyWithVNI(ip, uint32(vni))
+	ipKey := path.Join(IPIdentitiesPath, AddressSpace, key)
 	s.tracker.Delete(ipKey)
 
 	if !s.client.IsEnabled() {
 		if s.ipc != nil {
-			s.ipc.DeleteOnMetadataMatch(KeyWithVNI(ip, uint32(vni)), source.Local, namespace, podName)
+			// Skip only when both sides are known and disagree: an unknown
+			// owner (nothing recorded, or a caller that does not identify
+			// itself) must not turn a legitimate removal into a leak.
+			if owner, known := s.owners.Load(key); known && owner != 0 && endpointID != 0 && owner != endpointID {
+				// The address has been registered again by another endpoint -
+				// a pod recreated on it, possibly under the same name. Its
+				// entry is the live one; this teardown has nothing left to do.
+				if s.logger != nil {
+					s.logger.Debug("Skipping removal of an ipcache entry owned by another endpoint",
+						logfields.IPAddr, key,
+						logfields.EndpointID, endpointID,
+					)
+				}
+				return nil
+			}
+			s.ipc.DeleteOnMetadataMatch(key, source.Local, namespace, podName)
+			s.owners.Delete(key)
 		}
 		return nil
 	}

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -54,9 +54,12 @@ type kvstoreClient interface {
 	Delete(ctx context.Context, key string) error
 }
 
-// localIPCache is the subset of *IPCache used by the kvstore-disabled local
-// fallback path. Kept as an interface for testability.
-type localIPCache interface {
+// LocalIPCache is the subset of *IPCache used by the kvstore-disabled local
+// fallback path. It is exported so that the ipcache cell can provide it
+// explicitly: hive cannot build an interface type that no constructor returns,
+// and an unexported parameter type makes the whole agent object graph fail
+// with "missing type: ipcache.localIPCache".
+type LocalIPCache interface {
 	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *K8sMetadata, newIdentity Identity) (namedPortsChanged bool, err error)
 	Delete(IP string, source source.Source) (namedPortsChanged bool)
 }
@@ -71,10 +74,16 @@ type IPIdentitySynchronizer struct {
 	tracker lock.Map[string, []byte]
 
 	// ipc is the local ipcache used as a fallback when the kvstore is disabled.
-	ipc localIPCache
+	ipc LocalIPCache
 }
 
-func NewIPIdentitySynchronizer(logger *slog.Logger, client kvstore.Client, ipc localIPCache) *IPIdentitySynchronizer {
+func NewIPIdentitySynchronizer(logger *slog.Logger, client kvstore.Client, ipc LocalIPCache) *IPIdentitySynchronizer {
+	return newIPIdentitySynchronizer(logger, client, ipc)
+}
+
+// newIPIdentitySynchronizer is the package-internal constructor accepting the
+// narrow kvstore client interface used by the tests.
+func newIPIdentitySynchronizer(logger *slog.Logger, client kvstoreClient, ipc LocalIPCache) *IPIdentitySynchronizer {
 	return &IPIdentitySynchronizer{logger: logger, client: client, ipc: ipc}
 }
 

--- a/pkg/ipcache/kvstore_vni_test.go
+++ b/pkg/ipcache/kvstore_vni_test.go
@@ -48,7 +48,7 @@ func TestIPIdentitySynchronizerLocalFallbackVNI(t *testing.T) {
 	require.Equal(t, source.Local, ipc.upserts[0].id.Source)
 
 	// Delete must remove the same VNI-encoded key.
-	err = sync.Delete(t.Context(), "192.168.1.2", 36)
+	err = sync.Delete(t.Context(), "192.168.1.2", 36, "ns", "pod")
 	require.NoError(t, err)
 	require.Len(t, ipc.deletes, 1)
 	require.Equal(t, KeyWithVNI("192.168.1.2", 36), ipc.deletes[0])
@@ -86,12 +86,12 @@ func TestIPIdentitySynchronizerKVStoreVNI(t *testing.T) {
 	require.Equal(t, uint64(36), pair.Vni)
 
 	// Deleting with the wrong VNI must not remove the entry (same IP, other VPC).
-	require.NoError(t, sync.Delete(t.Context(), "192.168.1.2", 17))
+	require.NoError(t, sync.Delete(t.Context(), "192.168.1.2", 17, "ns", "pod"))
 	_, ok = client.store[ipKey]
 	require.True(t, ok, "entry of VPC 36 must survive deletion of VPC 17")
 
 	// Deleting with the right VNI removes it.
-	require.NoError(t, sync.Delete(t.Context(), "192.168.1.2", 36))
+	require.NoError(t, sync.Delete(t.Context(), "192.168.1.2", 36, "ns", "pod"))
 	_, ok = client.store[ipKey]
 	require.False(t, ok, "entry of VPC 36 must be removed by its own deletion")
 }
@@ -124,6 +124,9 @@ type localIPCacheSpy struct {
 		id  Identity
 	}
 	deletes []string
+	// owner is the pod the spy pretends each entry describes, so that a
+	// metadata-matched delete can be told apart from an unconditional one.
+	owner map[string]string
 }
 
 func newLocalIPCacheSpy() *localIPCacheSpy { return &localIPCacheSpy{} }
@@ -136,7 +139,17 @@ func (s *localIPCacheSpy) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMet
 	return false, nil
 }
 
+// Delete satisfies IPCacher for the watcher tests, which exercise the remote
+// path where the entry carries no pod metadata.
 func (s *localIPCacheSpy) Delete(IP string, src source.Source) bool {
+	s.deletes = append(s.deletes, IP)
+	return true
+}
+
+func (s *localIPCacheSpy) DeleteOnMetadataMatch(IP string, src source.Source, namespace, name string) bool {
+	if want, tracked := s.owner[IP]; tracked && want != namespace+"/"+name {
+		return false
+	}
 	s.deletes = append(s.deletes, IP)
 	return true
 }
@@ -179,4 +192,26 @@ func TestIPIdentityWatcherVNIKeyOrdering(t *testing.T) {
 			require.Equal(t, tc.vni > 0, strings.HasSuffix(pair.GetKeyName(), "@vni:"+strconv.FormatUint(tc.vni, 10)))
 		})
 	}
+}
+
+// TestSynchronizerDeleteLeavesTheNewOwnerAlone covers an address being reused.
+//
+// An address outlives the pod it was given to: once released, kube-ovn can hand
+// it to another pod, whose endpoint registers the very same (VNI, IP) key. The
+// teardown of the previous endpoint runs on its own schedule, so it can arrive
+// after that. Removing the entry then would take the running pod's entry away,
+// and for an endpoint in a VPC there is no bare-address entry left to fall back
+// on.
+func TestSynchronizerDeleteLeavesTheNewOwnerAlone(t *testing.T) {
+	spy := newLocalIPCacheSpy()
+	spy.owner = map[string]string{"192.168.1.2@vni:36": "ns/successor"}
+	sync := newIPIdentitySynchronizer(hivetest.Logger(t), kvstore.SetupDummy(t, kvstore.DisabledBackendName), spy)
+
+	// The predecessor tears down after the address has been handed on.
+	require.NoError(t, sync.Delete(t.Context(), "192.168.1.2", 36, "ns", "predecessor"))
+	require.Empty(t, spy.deletes, "the entry of the pod holding the address must survive")
+
+	// The owner removing its own entry still works.
+	require.NoError(t, sync.Delete(t.Context(), "192.168.1.2", 36, "ns", "successor"))
+	require.Equal(t, []string{"192.168.1.2@vni:36"}, spy.deletes)
 }

--- a/pkg/ipcache/kvstore_vni_test.go
+++ b/pkg/ipcache/kvstore_vni_test.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"net/netip"
 	"path"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/cilium/hive/hivetest"
@@ -137,4 +139,44 @@ func (s *localIPCacheSpy) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMet
 func (s *localIPCacheSpy) Delete(IP string, src source.Source) bool {
 	s.deletes = append(s.deletes, IP)
 	return true
+}
+
+// TestIPIdentityWatcherVNIKeyOrdering pins the key-composition rule at the
+// cache plane's kvstore seam: the ClusterID annotation is applied first and
+// the VNI suffix last ("<ip>@<clusterID>@vni:<N>"), so that the cluster-aware
+// parser sees a well-formed key after splitVNIKey has stripped the suffix.
+// It also pins that the deletion key is byte-identical to the upsert key.
+func TestIPIdentityWatcherVNIKeyOrdering(t *testing.T) {
+	ip := netip.MustParseAddr("192.168.1.2")
+
+	for _, tc := range []struct {
+		name      string
+		clusterID uint32
+		vni       uint64
+		want      string
+	}{
+		{name: "plain", want: "192.168.1.2"},
+		{name: "vni only", vni: 36, want: "192.168.1.2@vni:36"},
+		{name: "clusterID only", clusterID: 5, want: "192.168.1.2@5"},
+		{name: "clusterID and vni", clusterID: 5, vni: 36, want: "192.168.1.2@5@vni:36"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			spy := newLocalIPCacheSpy()
+			w := &IPIdentityWatcher{ipcache: spy, clusterID: tc.clusterID, source: source.KVStore, log: hivetest.Logger(t)}
+
+			pair := &identity.IPIdentityPair{IP: ip.AsSlice(), ID: 21929, Vni: tc.vni}
+			w.OnUpdate(pair)
+			require.Len(t, spy.upserts, 1)
+			require.Equal(t, tc.want, spy.upserts[0].key)
+			require.Equal(t, uint32(tc.vni), spy.upserts[0].id.Vni)
+
+			w.OnDelete(pair)
+			require.Equal(t, []string{tc.want}, spy.deletes,
+				"the deletion key must be identical to the upsert key")
+
+			// The key that the local agent writes into the kvstore must round
+			// trip through the stable-API key name.
+			require.Equal(t, tc.vni > 0, strings.HasSuffix(pair.GetKeyName(), "@vni:"+strconv.FormatUint(tc.vni, 10)))
+		})
+	}
 }

--- a/pkg/ipcache/kvstore_vni_test.go
+++ b/pkg/ipcache/kvstore_vni_test.go
@@ -48,7 +48,7 @@ func TestIPIdentitySynchronizerLocalFallbackVNI(t *testing.T) {
 	require.Equal(t, source.Local, ipc.upserts[0].id.Source)
 
 	// Delete must remove the same VNI-encoded key.
-	err = sync.Delete(t.Context(), "192.168.1.2", 36, "ns", "pod")
+	err = sync.Delete(t.Context(), "192.168.1.2", 36, "ns", "pod", 1)
 	require.NoError(t, err)
 	require.Len(t, ipc.deletes, 1)
 	require.Equal(t, KeyWithVNI("192.168.1.2", 36), ipc.deletes[0])
@@ -86,12 +86,12 @@ func TestIPIdentitySynchronizerKVStoreVNI(t *testing.T) {
 	require.Equal(t, uint64(36), pair.Vni)
 
 	// Deleting with the wrong VNI must not remove the entry (same IP, other VPC).
-	require.NoError(t, sync.Delete(t.Context(), "192.168.1.2", 17, "ns", "pod"))
+	require.NoError(t, sync.Delete(t.Context(), "192.168.1.2", 17, "ns", "pod", 1))
 	_, ok = client.store[ipKey]
 	require.True(t, ok, "entry of VPC 36 must survive deletion of VPC 17")
 
 	// Deleting with the right VNI removes it.
-	require.NoError(t, sync.Delete(t.Context(), "192.168.1.2", 36, "ns", "pod"))
+	require.NoError(t, sync.Delete(t.Context(), "192.168.1.2", 36, "ns", "pod", 1))
 	_, ok = client.store[ipKey]
 	require.False(t, ok, "entry of VPC 36 must be removed by its own deletion")
 }
@@ -208,10 +208,46 @@ func TestSynchronizerDeleteLeavesTheNewOwnerAlone(t *testing.T) {
 	sync := newIPIdentitySynchronizer(hivetest.Logger(t), kvstore.SetupDummy(t, kvstore.DisabledBackendName), spy)
 
 	// The predecessor tears down after the address has been handed on.
-	require.NoError(t, sync.Delete(t.Context(), "192.168.1.2", 36, "ns", "predecessor"))
+	require.NoError(t, sync.Delete(t.Context(), "192.168.1.2", 36, "ns", "predecessor", 1))
 	require.Empty(t, spy.deletes, "the entry of the pod holding the address must survive")
 
 	// The owner removing its own entry still works.
-	require.NoError(t, sync.Delete(t.Context(), "192.168.1.2", 36, "ns", "successor"))
+	require.NoError(t, sync.Delete(t.Context(), "192.168.1.2", 36, "ns", "successor", 2))
 	require.Equal(t, []string{"192.168.1.2@vni:36"}, spy.deletes)
+}
+
+// TestSynchronizerDeleteAfterSameNameRestart covers the case the pod metadata
+// cannot describe: a pod that comes back under its own name, on its own
+// address, in its own VPC.
+//
+// CNI DEL returns before the endpoint's controllers have finished stopping, so
+// the new endpoint can register the address before the old one's teardown gets
+// to run. Namespace, name, address and VNI are then all identical, and the only
+// thing that differs is which endpoint registered the entry. Losing it would
+// leave the running pod unresolvable by (VNI, IP), with no bare-address entry
+// to fall back on.
+func TestSynchronizerDeleteAfterSameNameRestart(t *testing.T) {
+	spy := newLocalIPCacheSpy()
+	sync := newIPIdentitySynchronizer(hivetest.Logger(t), kvstore.SetupDummy(t, kvstore.DisabledBackendName), spy)
+	params := func(epID uint16) *UpsertParams {
+		return &UpsertParams{
+			IP:           netip.MustParseAddr("10.99.0.11"),
+			ID:           1234,
+			Vni:          5,
+			K8sNamespace: "vpc-a",
+			K8sPodName:   "server",
+			EndpointID:   epID,
+		}
+	}
+
+	require.NoError(t, sync.Upsert(t.Context(), params(100)))
+	// The pod comes back with the same name and address; a new endpoint
+	// registers it while the previous one is still being torn down.
+	require.NoError(t, sync.Upsert(t.Context(), params(101)))
+
+	require.NoError(t, sync.Delete(t.Context(), "10.99.0.11", 5, "vpc-a", "server", 100))
+	require.Empty(t, spy.deletes, "the entry now belongs to the endpoint that came back")
+
+	require.NoError(t, sync.Delete(t.Context(), "10.99.0.11", 5, "vpc-a", "server", 101))
+	require.Equal(t, []string{"10.99.0.11@vni:5"}, spy.deletes, "its own teardown still removes it")
 }

--- a/pkg/ipcache/kvstore_vni_test.go
+++ b/pkg/ipcache/kvstore_vni_test.go
@@ -25,7 +25,7 @@ import (
 func TestIPIdentitySynchronizerLocalFallbackVNI(t *testing.T) {
 	client := kvstore.SetupDummy(t, kvstore.DisabledBackendName)
 	ipc := newLocalIPCacheSpy()
-	sync := NewIPIdentitySynchronizer(nil, client, ipc)
+	sync := newIPIdentitySynchronizer(nil, client, ipc)
 
 	ip := netip.MustParseAddr("192.168.1.2")
 	hostIP := netip.MustParseAddr("10.58.55.23")
@@ -59,7 +59,7 @@ func TestIPIdentitySynchronizerLocalFallbackVNI(t *testing.T) {
 // collided with overlapping VPC subnets).
 func TestIPIdentitySynchronizerKVStoreVNI(t *testing.T) {
 	client := &fakeKVStoreClient{enabled: true, store: map[string][]byte{}}
-	sync := NewIPIdentitySynchronizer(hivetest.Logger(t), client, nil)
+	sync := newIPIdentitySynchronizer(hivetest.Logger(t), client, nil)
 
 	ip := netip.MustParseAddr("192.168.1.2")
 	hostIP := netip.MustParseAddr("10.58.55.23")

--- a/pkg/ipcache/kvstore_vni_test.go
+++ b/pkg/ipcache/kvstore_vni_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipcache
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"path"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/source"
+)
+
+// TestIPIdentitySynchronizerLocalFallbackVNI verifies that, when the kvstore
+// is disabled (CRD-only identity mode), the synchronizer registers the
+// endpoint mapping directly in the local ipcache keyed by IP+VNI, so that
+// native-vpc endpoints are resolvable by the datapath even without a kvstore.
+func TestIPIdentitySynchronizerLocalFallbackVNI(t *testing.T) {
+	client := kvstore.SetupDummy(t, kvstore.DisabledBackendName)
+	ipc := newLocalIPCacheSpy()
+	sync := NewIPIdentitySynchronizer(nil, client, ipc)
+
+	ip := netip.MustParseAddr("192.168.1.2")
+	hostIP := netip.MustParseAddr("10.58.55.23")
+	err := sync.Upsert(t.Context(), &UpsertParams{
+		IP:           ip,
+		HostIP:       hostIP,
+		ID:           identity.NumericIdentity(21929),
+		K8sNamespace: "vm-a",
+		K8sPodName:   "pod-a",
+		Vni:          36,
+	})
+	require.NoError(t, err)
+
+	// The local ipcache must have received the VNI-encoded key with the VNI set.
+	require.Len(t, ipc.upserts, 1)
+	require.Equal(t, KeyWithVNI("192.168.1.2", 36), ipc.upserts[0].key)
+	require.Equal(t, uint32(36), ipc.upserts[0].id.Vni)
+	require.Equal(t, source.Local, ipc.upserts[0].id.Source)
+
+	// Delete must remove the same VNI-encoded key.
+	err = sync.Delete(t.Context(), "192.168.1.2", 36)
+	require.NoError(t, err)
+	require.Len(t, ipc.deletes, 1)
+	require.Equal(t, KeyWithVNI("192.168.1.2", 36), ipc.deletes[0])
+}
+
+// TestIPIdentitySynchronizerKVStoreVNI verifies the kvstore-enabled path: the
+// mapping is written under a VNI-scoped kvstore key and the pair carries the
+// VNI, so the watcher can re-insert it into the ipcache keyed by IP+VNI (the
+// previous behavior dropped the VNI and registered a plain-IP entry, which
+// collided with overlapping VPC subnets).
+func TestIPIdentitySynchronizerKVStoreVNI(t *testing.T) {
+	client := &fakeKVStoreClient{enabled: true, store: map[string][]byte{}}
+	sync := NewIPIdentitySynchronizer(hivetest.Logger(t), client, nil)
+
+	ip := netip.MustParseAddr("192.168.1.2")
+	hostIP := netip.MustParseAddr("10.58.55.23")
+	err := sync.Upsert(t.Context(), &UpsertParams{
+		IP:           ip,
+		HostIP:       hostIP,
+		ID:           identity.NumericIdentity(21929),
+		K8sNamespace: "vm-a",
+		K8sPodName:   "pod-a",
+		Vni:          36,
+	})
+	require.NoError(t, err)
+
+	// The kvstore key must be VNI-scoped so the same IP in a different VPC
+	// does not overwrite it.
+	ipKey := path.Join(IPIdentitiesPath, AddressSpace, KeyWithVNI("192.168.1.2", 36))
+	val, ok := client.store[ipKey]
+	require.True(t, ok, "mapping must be stored under the VNI-scoped key")
+
+	pair := &identity.IPIdentityPair{}
+	require.NoError(t, pair.Unmarshal(KeyWithVNI("192.168.1.2", 36), val))
+	require.Equal(t, uint64(36), pair.Vni)
+
+	// Deleting with the wrong VNI must not remove the entry (same IP, other VPC).
+	require.NoError(t, sync.Delete(t.Context(), "192.168.1.2", 17))
+	_, ok = client.store[ipKey]
+	require.True(t, ok, "entry of VPC 36 must survive deletion of VPC 17")
+
+	// Deleting with the right VNI removes it.
+	require.NoError(t, sync.Delete(t.Context(), "192.168.1.2", 36))
+	_, ok = client.store[ipKey]
+	require.False(t, ok, "entry of VPC 36 must be removed by its own deletion")
+}
+
+// fakeKVStoreClient is a minimal in-memory kvstore.Client for tests. It embeds
+// the (nil) BackendOperations interface to satisfy the type; only the methods
+// exercised by IPIdentitySynchronizer are overridden.
+type fakeKVStoreClient struct {
+	kvstore.BackendOperations
+	enabled bool
+	store   map[string][]byte
+}
+
+func (f *fakeKVStoreClient) IsEnabled() bool { return f.enabled }
+
+func (f *fakeKVStoreClient) UpdateIfDifferent(ctx context.Context, key string, value []byte, lease bool) (bool, error) {
+	f.store[key] = value
+	return true, nil
+}
+
+func (f *fakeKVStoreClient) Delete(ctx context.Context, key string) error {
+	delete(f.store, key)
+	return nil
+}
+
+// localIPCacheSpy records the Upsert/Delete calls for the local fallback path.
+type localIPCacheSpy struct {
+	upserts []struct {
+		key string
+		id  Identity
+	}
+	deletes []string
+}
+
+func newLocalIPCacheSpy() *localIPCacheSpy { return &localIPCacheSpy{} }
+
+func (s *localIPCacheSpy) Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *K8sMetadata, newIdentity Identity) (bool, error) {
+	s.upserts = append(s.upserts, struct {
+		key string
+		id  Identity
+	}{ip, newIdentity})
+	return false, nil
+}
+
+func (s *localIPCacheSpy) Delete(IP string, src source.Source) bool {
+	s.deletes = append(s.deletes, IP)
+	return true
+}

--- a/pkg/ipcache/vni_test.go
+++ b/pkg/ipcache/vni_test.go
@@ -241,3 +241,43 @@ func TestIPCachePlainAndVNIEntryIsolation(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint16(81), port)
 }
+
+// TestLookupSecIDByIPForVNI verifies the key-exact (VNI, IP) identity lookup
+// used by the Hubble parsers: it must never resolve a plain entry, a foreign
+// VPC entry, or a shorter prefix for the same IP.
+func TestLookupSecIDByIPForVNI(t *testing.T) {
+	s := setupIPCacheTestSuite(t)
+	ip := "192.168.1.2"
+	addr := netip.MustParseAddr(ip)
+
+	_, err := s.IPIdentityCache.Upsert(KeyWithVNI(ip, 36), nil, 0, nil, Identity{
+		ID: identity.NumericIdentity(21929), Source: source.CustomResource, Vni: 36,
+	})
+	require.NoError(t, err)
+	_, err = s.IPIdentityCache.Upsert(KeyWithVNI(ip, 17), nil, 0, nil, Identity{
+		ID: identity.NumericIdentity(21930), Source: source.CustomResource, Vni: 17,
+	})
+	require.NoError(t, err)
+
+	got, ok := s.IPIdentityCache.LookupSecIDByIPForVNI(addr, 36)
+	require.True(t, ok)
+	require.Equal(t, identity.NumericIdentity(21929), got.ID)
+	require.Equal(t, uint32(36), got.Vni)
+
+	got, ok = s.IPIdentityCache.LookupSecIDByIPForVNI(addr, 17)
+	require.True(t, ok)
+	require.Equal(t, identity.NumericIdentity(21930), got.ID)
+
+	// A VPC that does not use the IP must miss, even though a plain /24 entry
+	// covering it exists (LPM fallbacks are not allowed here).
+	_, err = s.IPIdentityCache.Upsert("192.168.1.0/24", nil, 0, nil, Identity{
+		ID: identity.NumericIdentity(21931), Source: source.Generated,
+	})
+	require.NoError(t, err)
+	_, ok = s.IPIdentityCache.LookupSecIDByIPForVNI(addr, 99)
+	require.False(t, ok)
+
+	// A zero VNI is not a VPC scope.
+	_, ok = s.IPIdentityCache.LookupSecIDByIPForVNI(addr, 0)
+	require.False(t, ok)
+}

--- a/pkg/ipcache/vni_test.go
+++ b/pkg/ipcache/vni_test.go
@@ -4,6 +4,7 @@
 package ipcache
 
 import (
+	"fmt"
 	"net"
 	"net/netip"
 	"testing"
@@ -280,4 +281,71 @@ func TestLookupSecIDByIPForVNI(t *testing.T) {
 	// A zero VNI is not a VPC scope.
 	_, ok = s.IPIdentityCache.LookupSecIDByIPForVNI(addr, 0)
 	require.False(t, ok)
+}
+
+// TestDumpToListenerVNI is a regression test for the full-dump path: the
+// ipcache API handler and the BPF listener registration both dump every entry,
+// and native-vpc keys ("<ip>@vni:<vni>") are not parsable as a prefix. The
+// dump must not panic, must report the plain prefix, and must carry the VNI in
+// the identity so listeners route the entry to the VNI-scoped map.
+func TestDumpToListenerVNI(t *testing.T) {
+	s := setupIPCacheTestSuite(t)
+
+	_, err := s.IPIdentityCache.Upsert(KeyWithVNI("192.168.1.2", 36), nil, 0, nil, Identity{
+		ID: identity.NumericIdentity(21929), Source: source.CustomResource, Vni: 36,
+	})
+	require.NoError(t, err)
+	_, err = s.IPIdentityCache.Upsert(KeyWithVNI("192.168.1.2", 17), nil, 0, nil, Identity{
+		ID: identity.NumericIdentity(21930), Source: source.CustomResource, Vni: 17,
+	})
+	require.NoError(t, err)
+	_, err = s.IPIdentityCache.Upsert("10.0.0.1", nil, 0, nil, Identity{
+		ID: identity.NumericIdentity(21931), Source: source.KubeAPIServer,
+	})
+	require.NoError(t, err)
+
+	l := &dumpCollector{}
+	require.NotPanics(t, func() { s.IPIdentityCache.DumpToListener(l) })
+
+	require.Equal(t, map[string]uint32{
+		"192.168.1.2/32@36": 36,
+		"192.168.1.2/32@17": 17,
+		"10.0.0.1/32@0":     0,
+	}, l.seen)
+}
+
+type dumpCollector struct {
+	seen map[string]uint32
+}
+
+func (d *dumpCollector) OnIPIdentityCacheChange(_ CacheModification, cidr cmtypes.PrefixCluster,
+	_, _ net.IP, _ *Identity, newID Identity, _ uint8, _ *K8sMetadata, _ uint8,
+) {
+	if d.seen == nil {
+		d.seen = map[string]uint32{}
+	}
+	d.seen[fmt.Sprintf("%s@%d", cidr.String(), newID.Vni)] = newID.Vni
+}
+
+// TestLookupByIdentityAndHostStripVNI verifies that the two ipcache readers
+// which return raw key strings (DNS rule restoration and the WireGuard
+// AllowedIPs list) never leak the internal "<ip>@vni:<vni>" key: their
+// consumers parse the result as an address and would drop the entry.
+func TestLookupByIdentityAndHostStripVNI(t *testing.T) {
+	s := setupIPCacheTestSuite(t)
+	id := identity.NumericIdentity(21929)
+	hostIP := net.ParseIP("10.58.55.23")
+
+	_, err := s.IPIdentityCache.Upsert(KeyWithVNI("192.168.1.2", 36), hostIP, 0, nil, Identity{
+		ID: id, Source: source.CustomResource, Vni: 36,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"192.168.1.2"}, s.IPIdentityCache.LookupByIdentity(id))
+
+	s.IPIdentityCache.mutex.RLock()
+	cidrs := s.IPIdentityCache.LookupByHostRLocked(hostIP, nil)
+	s.IPIdentityCache.mutex.RUnlock()
+	require.Len(t, cidrs, 1)
+	require.Equal(t, "192.168.1.2/32", cidrs[0].String())
 }

--- a/pkg/ipcache/vni_test.go
+++ b/pkg/ipcache/vni_test.go
@@ -349,3 +349,83 @@ func TestLookupByIdentityAndHostStripVNI(t *testing.T) {
 	require.Len(t, cidrs, 1)
 	require.Equal(t, "192.168.1.2/32", cidrs[0].String())
 }
+
+// TestPlainModeUnaffected is the compatibility guard for the cache plane: with
+// VNI 0 (every non-native-vpc deployment and every non-VPC entity) the ipcache
+// must behave exactly as before - plain keys, no VNI index, plain lookups
+// resolving, and no VNI leaking into the identity.
+func TestPlainModeUnaffected(t *testing.T) {
+	s := setupIPCacheTestSuite(t)
+	ip := "10.0.0.1"
+	addr := netip.MustParseAddr(ip)
+
+	require.Equal(t, ip, KeyWithVNI(ip, 0), "a zero VNI must not change the key")
+
+	_, err := s.IPIdentityCache.Upsert(ip, net.ParseIP("10.58.55.23"), 0, &K8sMetadata{
+		Namespace: "ns", PodName: "pod",
+	}, Identity{ID: identity.NumericIdentity(1234), Source: source.Kubernetes})
+	require.NoError(t, err)
+
+	got, ok := s.IPIdentityCache.LookupByIP(ip)
+	require.True(t, ok)
+	require.Zero(t, got.Vni)
+	id, ok := s.IPIdentityCache.LookupSecIDByIP(addr)
+	require.True(t, ok)
+	require.Equal(t, identity.NumericIdentity(1234), id.ID)
+	require.NotNil(t, s.IPIdentityCache.GetK8sMetadata(addr))
+
+	s.IPIdentityCache.mutex.RLock()
+	require.Empty(t, s.IPIdentityCache.ipToVNIKeys, "no VNI index entries for plain upserts")
+	s.IPIdentityCache.mutex.RUnlock()
+
+	// The VNI-scoped readers must not answer for a plain entry.
+	_, ok = s.IPIdentityCache.LookupSecIDByIPForVNI(addr, 36)
+	require.False(t, ok)
+	require.Nil(t, s.IPIdentityCache.GetK8sMetadataForVNI(addr, 36))
+
+	// ... and the plain delete must clean everything up.
+	s.IPIdentityCache.Delete(ip, source.Kubernetes)
+	_, ok = s.IPIdentityCache.LookupByIP(ip)
+	require.False(t, ok)
+}
+
+// TestVNIWriteDeleteSymmetry checks question 3 of the audit method for the
+// cache plane: the delete key is identical to the write key, deleting one VPC
+// never affects the other, and the per-IP VNI index is cleaned up exactly.
+func TestVNIWriteDeleteSymmetry(t *testing.T) {
+	s := setupIPCacheTestSuite(t)
+	ip := "192.168.1.2"
+	addr := netip.MustParseAddr(ip)
+
+	for _, vni := range []uint32{36, 17} {
+		_, err := s.IPIdentityCache.Upsert(KeyWithVNI(ip, vni), nil, 0, &K8sMetadata{
+			Namespace: "ns", PodName: "pod",
+		}, Identity{ID: identity.NumericIdentity(20000 + vni), Source: source.CustomResource, Vni: vni})
+		require.NoError(t, err)
+	}
+
+	s.IPIdentityCache.mutex.RLock()
+	require.Len(t, s.IPIdentityCache.ipToVNIKeys[ip], 2)
+	s.IPIdentityCache.mutex.RUnlock()
+
+	// Deleting VPC 36 must leave VPC 17 fully intact.
+	s.IPIdentityCache.Delete(KeyWithVNI(ip, 36), source.CustomResource)
+	_, ok := s.IPIdentityCache.LookupSecIDByIPForVNI(addr, 36)
+	require.False(t, ok)
+	got, ok := s.IPIdentityCache.LookupSecIDByIPForVNI(addr, 17)
+	require.True(t, ok)
+	require.Equal(t, identity.NumericIdentity(20017), got.ID)
+	require.NotNil(t, s.IPIdentityCache.GetK8sMetadataForVNI(addr, 17))
+
+	// With a single VNI left the IP is unambiguous again.
+	got, ok = s.IPIdentityCache.LookupSecIDByIPUnambiguous(addr)
+	require.True(t, ok)
+	require.Equal(t, identity.NumericIdentity(20017), got.ID)
+
+	s.IPIdentityCache.Delete(KeyWithVNI(ip, 17), source.CustomResource)
+	s.IPIdentityCache.mutex.RLock()
+	require.NotContains(t, s.IPIdentityCache.ipToVNIKeys, ip, "the per-IP VNI index must be emptied")
+	s.IPIdentityCache.mutex.RUnlock()
+	_, ok = s.IPIdentityCache.LookupSecIDByIPUnambiguous(addr)
+	require.False(t, ok)
+}

--- a/pkg/ipcache/vni_test.go
+++ b/pkg/ipcache/vni_test.go
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipcache
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/types"
+	"github.com/cilium/cilium/pkg/u8proto"
+)
+
+func TestKeyWithVNIRoundtrip(t *testing.T) {
+	for _, tc := range []struct {
+		ip   string
+		vni  uint32
+		want string
+	}{
+		{"192.168.1.2", 0, "192.168.1.2"},
+		{"192.168.1.2", 36, "192.168.1.2@vni:36"},
+		{"10.0.0.0/24", 17, "10.0.0.0/24@vni:17"},
+		{"192.168.1.2@1", 10, "192.168.1.2@1@vni:10"}, // clusterID suffix + VNI suffix
+	} {
+		key := KeyWithVNI(tc.ip, tc.vni)
+		require.Equal(t, tc.want, key)
+
+		plain, vni := splitVNIKey(key)
+		require.Equal(t, tc.ip, plain)
+		require.Equal(t, tc.vni, vni)
+	}
+
+	// A key without the VNI suffix yields vni 0.
+	plain, vni := splitVNIKey("192.168.1.2")
+	require.Equal(t, "192.168.1.2", plain)
+	require.Zero(t, vni)
+}
+
+// TestIPCacheVNICoexistence verifies that the same IP in two different VPCs
+// (different VNI) maps to two distinct ipcache entries, and that each entry
+// carries its own identity and VNI. This is the core fix for overlapping VPC
+// subnets.
+func TestIPCacheVNICoexistence(t *testing.T) {
+	s := setupIPCacheTestSuite(t)
+
+	endpointIP := "192.168.1.2"
+	// Same IP in VPC A (vni 36) and VPC B (vni 17) with different identities.
+	idA := identity.NumericIdentity(21929)
+	idB := identity.NumericIdentity(21930)
+
+	_, err := s.IPIdentityCache.Upsert(KeyWithVNI(endpointIP, 36), nil, 0, nil, Identity{
+		ID:     idA,
+		Source: source.CustomResource,
+		Vni:    36,
+	})
+	require.NoError(t, err)
+	_, err = s.IPIdentityCache.Upsert(KeyWithVNI(endpointIP, 17), nil, 0, nil, Identity{
+		ID:     idB,
+		Source: source.CustomResource,
+		Vni:    17,
+	})
+	require.NoError(t, err)
+
+	// Both entries coexist.
+	require.Len(t, s.IPIdentityCache.ipToIdentityCache, 2)
+
+	// Lookup each VPC-scoped entry.
+	ia, ok := s.IPIdentityCache.LookupByIP(KeyWithVNI(endpointIP, 36))
+	require.True(t, ok)
+	require.Equal(t, idA, ia.ID)
+	require.Equal(t, uint32(36), ia.Vni)
+
+	ib, ok := s.IPIdentityCache.LookupByIP(KeyWithVNI(endpointIP, 17))
+	require.True(t, ok)
+	require.Equal(t, idB, ib.ID)
+	require.Equal(t, uint32(17), ib.Vni)
+
+	// The reverse identity->IP index contains both encoded keys.
+	require.Contains(t, s.IPIdentityCache.identityToIPCache[idA], KeyWithVNI(endpointIP, 36))
+	require.Contains(t, s.IPIdentityCache.identityToIPCache[idB], KeyWithVNI(endpointIP, 17))
+
+	// Deleting one VPC's entry must not remove the other.
+	s.IPIdentityCache.Delete(KeyWithVNI(endpointIP, 36), source.CustomResource)
+	_, ok = s.IPIdentityCache.LookupByIP(KeyWithVNI(endpointIP, 36))
+	require.False(t, ok)
+	ib, ok = s.IPIdentityCache.LookupByIP(KeyWithVNI(endpointIP, 17))
+	require.True(t, ok)
+	require.Equal(t, idB, ib.ID)
+	require.Len(t, s.IPIdentityCache.ipToIdentityCache, 1)
+}
+
+// TestIPCacheVNIMetadataListener verifies that the ipcache listener observes
+// the VNI on upsert and delete for native-vpc entries.
+func TestIPCacheVNIMetadataListener(t *testing.T) {
+	s := setupIPCacheTestSuite(t)
+
+	listener := &mockIPCacheListener{t: t}
+	s.IPIdentityCache.AddListener(listener)
+
+	endpointIP := "192.168.1.3"
+	idA := identity.NumericIdentity(7979)
+	_, err := s.IPIdentityCache.Upsert(KeyWithVNI(endpointIP, 36), nil, 0, nil, Identity{
+		ID:     idA,
+		Source: source.CustomResource,
+		Vni:    36,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, listener.upserts, 1)
+	require.Equal(t, uint32(36), listener.upserts[0].vni)
+	require.Equal(t, idA, listener.upserts[0].id)
+
+	s.IPIdentityCache.Delete(KeyWithVNI(endpointIP, 36), source.CustomResource)
+	require.Len(t, listener.deletes, 1)
+	require.Equal(t, uint32(36), listener.deletes[0].vni)
+}
+
+type ipCacheEvent struct {
+	id  identity.NumericIdentity
+	vni uint32
+}
+
+type mockIPCacheListener struct {
+	t       *testing.T
+	upserts []ipCacheEvent
+	deletes []ipCacheEvent
+}
+
+func (m *mockIPCacheListener) OnIPIdentityCacheChange(modType CacheModification, cidrCluster cmtypes.PrefixCluster,
+	oldHostIP, newHostIP net.IP, oldID *Identity, newID Identity, encryptKey uint8, k8sMeta *K8sMetadata, endpointFlags uint8) {
+	m.t.Helper()
+	ev := ipCacheEvent{id: newID.ID, vni: newID.Vni}
+	switch modType {
+	case Upsert:
+		m.upserts = append(m.upserts, ev)
+	case Delete:
+		m.deletes = append(m.deletes, ev)
+	}
+}
+
+// TestIPCacheVNIPureIPLookup verifies that generic bare-IP lookups remain
+// key-exact, while the explicit best-effort helpers resolve a VNI-scoped entry
+// when exactly one VPC uses the IP (L7 accesslog / DNS proxy), and report a
+// miss when several VPCs overlap rather than guessing a VPC.
+func TestIPCacheVNIPureIPLookup(t *testing.T) {
+	s := setupIPCacheTestSuite(t)
+
+	endpointIP := "192.168.1.2"
+	idA := identity.NumericIdentity(21929)
+	idB := identity.NumericIdentity(21930)
+
+	// Single VNI entry: bare-IP lookups resolve it.
+	_, err := s.IPIdentityCache.Upsert(KeyWithVNI(endpointIP, 36), nil, 0, &K8sMetadata{Namespace: "ns-a", PodName: "pod-a"}, Identity{
+		ID:     idA,
+		Source: source.CustomResource,
+		Vni:    36,
+	})
+	require.NoError(t, err)
+
+	_, ok := s.IPIdentityCache.LookupByIP(endpointIP)
+	require.False(t, ok, "generic bare-IP lookup must remain key-exact")
+	require.Nil(t, s.IPIdentityCache.GetK8sMetadata(netip.MustParseAddr(endpointIP)),
+		"generic metadata lookup must remain key-exact")
+
+	got, ok := s.IPIdentityCache.LookupSecIDByIPUnambiguous(netip.MustParseAddr(endpointIP))
+	require.True(t, ok, "explicit best-effort lookup must resolve the single VNI-scoped entry")
+	require.Equal(t, idA, got.ID)
+	require.Equal(t, uint32(36), got.Vni)
+
+	meta := s.IPIdentityCache.GetK8sMetadataUnambiguous(netip.MustParseAddr(endpointIP))
+	require.NotNil(t, meta)
+	require.Equal(t, "pod-a", meta.PodName)
+
+	// Second VPC uses the same IP: the bare-IP lookup must now miss (ambiguous),
+	// while the VNI-scoped lookups still work.
+	_, err = s.IPIdentityCache.Upsert(KeyWithVNI(endpointIP, 17), nil, 0, &K8sMetadata{Namespace: "ns-b", PodName: "pod-b"}, Identity{
+		ID:     idB,
+		Source: source.CustomResource,
+		Vni:    17,
+	})
+	require.NoError(t, err)
+
+	_, ok = s.IPIdentityCache.LookupSecIDByIPUnambiguous(netip.MustParseAddr(endpointIP))
+	require.False(t, ok, "overlapping IPs must stay ambiguous for the explicit best-effort lookup")
+
+	// Removing one VPC restores unambiguous best-effort resolution, while the
+	// generic lookup remains key-exact.
+	s.IPIdentityCache.Delete(KeyWithVNI(endpointIP, 17), source.CustomResource)
+	got, ok = s.IPIdentityCache.LookupSecIDByIPUnambiguous(netip.MustParseAddr(endpointIP))
+	require.True(t, ok)
+	require.Equal(t, idA, got.ID)
+	_, ok = s.IPIdentityCache.LookupByIP(endpointIP)
+	require.False(t, ok)
+}
+
+// TestIPCachePlainAndVNIEntryIsolation verifies the M1 regression case: a
+// plain entry and a VNI-scoped entry may share the same IP, and deleting the
+// plain entry must never read the VNI entry's metadata or remove its named
+// ports.
+func TestIPCachePlainAndVNIEntryIsolation(t *testing.T) {
+	s := setupIPCacheTestSuite(t)
+	endpointIP := "192.168.1.2"
+
+	plainPorts := types.NamedPortMap{
+		"plain": {Port: 80, Proto: u8proto.TCP},
+	}
+	vpcPorts := types.NamedPortMap{
+		"vpc": {Port: 81, Proto: u8proto.TCP},
+	}
+
+	_, err := s.IPIdentityCache.Upsert(endpointIP, nil, 0,
+		&K8sMetadata{Namespace: "native", PodName: "plain", NamedPorts: plainPorts},
+		Identity{ID: identity.NumericIdentity(21928), Source: source.CustomResource})
+	require.NoError(t, err)
+	_, err = s.IPIdentityCache.Upsert(KeyWithVNI(endpointIP, 36), nil, 0,
+		&K8sMetadata{Namespace: "vpc", PodName: "vpc", NamedPorts: vpcPorts},
+		Identity{ID: identity.NumericIdentity(21929), Source: source.CustomResource, Vni: 36})
+	require.NoError(t, err)
+
+	npm := s.IPIdentityCache.GetNamedPorts()
+	require.Equal(t, 2, npm.Len())
+
+	s.IPIdentityCache.Delete(endpointIP, source.CustomResource)
+
+	// VNI-scoped identity/metadata and named port remain intact.
+	id, ok := s.IPIdentityCache.LookupByIP(KeyWithVNI(endpointIP, 36))
+	require.True(t, ok)
+	require.Equal(t, identity.NumericIdentity(21929), id.ID)
+	meta := s.IPIdentityCache.GetK8sMetadataForVNI(netip.MustParseAddr(endpointIP), 36)
+	require.NotNil(t, meta)
+	require.Equal(t, "vpc", meta.PodName)
+	_, err = npm.GetNamedPort("plain", u8proto.TCP)
+	require.Error(t, err)
+	port, err := npm.GetNamedPort("vpc", u8proto.TCP)
+	require.NoError(t, err)
+	require.Equal(t, uint16(81), port)
+}

--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -8,11 +8,26 @@ import (
 
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/cilium/cilium/pkg/annotation"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/k8s/types"
 )
+
+// nativeVPCCEPAnnotations returns the subset of the CiliumEndpoint annotations
+// that the CEP handlers need. Only the native-vpc VNI annotation is kept: it is
+// the (VNI, IP) scope used to register the endpoint IP in the VNI-scoped
+// ipcache, so dropping it would make every remote endpoint of a native-vpc
+// cluster unresolvable. All other annotations are dropped to keep the informer
+// cache small.
+func nativeVPCCEPAnnotations(annotations map[string]string) map[string]string {
+	vni, ok := annotations[annotation.CiliumEndpointNativeVPCVNI]
+	if !ok {
+		return nil
+	}
+	return map[string]string{annotation.CiliumEndpointNativeVPCVNI: vni}
+}
 
 // AnnotationsEqual returns whether the annotation with any key in
 // relevantAnnotations is equal in anno1 and anno2.
@@ -138,10 +153,11 @@ func TransformToCiliumEndpoint(obj any) (any, error) {
 				Namespace:       concreteObj.ObjectMeta.Namespace,
 				UID:             concreteObj.ObjectMeta.UID,
 				ResourceVersion: concreteObj.ObjectMeta.ResourceVersion,
-				// We don't need to store labels nor annotations because
-				// they are not used by the CEP handlers.
+				// We don't need to store labels because they are not used by
+				// the CEP handlers. Of the annotations, only the native-vpc VNI
+				// is kept (see nativeVPCCEPAnnotations).
 				Labels:      nil,
-				Annotations: nil,
+				Annotations: nativeVPCCEPAnnotations(concreteObj.ObjectMeta.Annotations),
 				// OwnerReferences is needed for ztunnel xDS to extract Pod UID.
 				OwnerReferences: slim_metav1.SlimOwnerReferences(concreteObj.ObjectMeta.OwnerReferences),
 			},
@@ -176,10 +192,11 @@ func TransformToCiliumEndpoint(obj any) (any, error) {
 					Namespace:       ciliumEndpoint.ObjectMeta.Namespace,
 					UID:             ciliumEndpoint.ObjectMeta.UID,
 					ResourceVersion: ciliumEndpoint.ObjectMeta.ResourceVersion,
-					// We don't need to store labels nor annotations because
-					// they are not used by the CEP handlers.
+					// We don't need to store labels because they are not used by
+					// the CEP handlers. Of the annotations, only the native-vpc VNI
+					// is kept (see nativeVPCCEPAnnotations).
 					Labels:      nil,
-					Annotations: nil,
+					Annotations: nativeVPCCEPAnnotations(ciliumEndpoint.ObjectMeta.Annotations),
 					// OwnerReferences is needed for ztunnel xDS to extract Pod UID.
 					OwnerReferences: slim_metav1.SlimOwnerReferences(ciliumEndpoint.ObjectMeta.OwnerReferences),
 				},

--- a/pkg/k8s/factory_functions_vni_test.go
+++ b/pkg/k8s/factory_functions_vni_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/cilium/cilium/pkg/annotation"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/types"
+)
+
+// TestTransformToCiliumEndpointKeepsVNIAnnotation pins the native-vpc contract
+// on the informer transform: the CiliumEndpoint VNI annotation is the only way
+// a watcher on another node learns the (VNI, IP) scope of a remote endpoint.
+// Dropping it (as the transform does for every other annotation) would make
+// every remote native-vpc endpoint unresolvable.
+func TestTransformToCiliumEndpointKeepsVNIAnnotation(t *testing.T) {
+	cep := &v2.CiliumEndpoint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "bar",
+			Annotations: map[string]string{
+				annotation.CiliumEndpointNativeVPCVNI: "36",
+				"unrelated":                           "dropped",
+			},
+			Labels: map[string]string{"app": "dropped"},
+		},
+	}
+
+	got, err := TransformToCiliumEndpoint(cep)
+	require.NoError(t, err)
+	slim := got.(*types.CiliumEndpoint)
+	require.Equal(t, map[string]string{annotation.CiliumEndpointNativeVPCVNI: "36"}, slim.Annotations)
+	require.Nil(t, slim.Labels)
+
+	got, err = TransformToCiliumEndpoint(cache.DeletedFinalStateUnknown{Key: "bar/foo", Obj: cep})
+	require.NoError(t, err)
+	slim = got.(cache.DeletedFinalStateUnknown).Obj.(*types.CiliumEndpoint)
+	require.Equal(t, map[string]string{annotation.CiliumEndpointNativeVPCVNI: "36"}, slim.Annotations)
+
+	// Non native-vpc CEPs keep the previous behavior (no annotations kept).
+	cep.Annotations = map[string]string{"unrelated": "dropped"}
+	got, err = TransformToCiliumEndpoint(cep)
+	require.NoError(t, err)
+	require.Nil(t, got.(*types.CiliumEndpoint).Annotations)
+}

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -7,11 +7,13 @@ import (
 	"context"
 	"log/slog"
 	"net"
+	"strconv"
 	"sync/atomic"
 
 	"github.com/cilium/hive/cell"
 
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
+	"github.com/cilium/cilium/pkg/annotation"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	hubblemetrics "github.com/cilium/cilium/pkg/hubble/metrics"
@@ -136,6 +138,24 @@ func (k *K8sCiliumEndpointsWatcher) ciliumEndpointsInit(ctx context.Context) {
 	}()
 }
 
+// ciliumEndpointVNI returns the native-vpc VNI carried in the CiliumEndpoint
+// annotation (written by the endpoint's managing agent), or 0 when the
+// endpoint is not a native-vpc endpoint.
+func ciliumEndpointVNI(endpoint *types.CiliumEndpoint) uint32 {
+	if endpoint == nil || endpoint.Annotations == nil {
+		return 0
+	}
+	vniStr, ok := endpoint.Annotations[annotation.NativeVPCVNIPrefix+"/vni"]
+	if !ok || vniStr == "" {
+		return 0
+	}
+	vni, err := strconv.ParseUint(vniStr, 10, 32)
+	if err != nil {
+		return 0
+	}
+	return uint32(vni)
+}
+
 func (k *K8sCiliumEndpointsWatcher) endpointUpdated(oldEndpoint, endpoint *types.CiliumEndpoint) {
 	var namedPortsChanged bool
 	defer func() {
@@ -145,7 +165,11 @@ func (k *K8sCiliumEndpointsWatcher) endpointUpdated(oldEndpoint, endpoint *types
 	}()
 	var ipsAdded []string
 	if oldEndpoint != nil && oldEndpoint.Networking != nil {
-		// Delete the old IP addresses from the IP cache
+		// Delete the old IP addresses from the IP cache, scoped by the OLD
+		// endpoint's VNI (native-vpc): the new entries are upserted with the new
+		// VNI below, so the old VNI-scoped entries must be removed with the old
+		// key to avoid leaking them.
+		oldVNI := ciliumEndpointVNI(oldEndpoint)
 		defer func() {
 			for _, oldPair := range oldEndpoint.Networking.Addressing {
 				v4Added, v6Added := false, false
@@ -158,13 +182,13 @@ func (k *K8sCiliumEndpointsWatcher) endpointUpdated(oldEndpoint, endpoint *types
 					}
 				}
 				if !v4Added {
-					portsChanged := k.ipcache.DeleteOnMetadataMatch(oldPair.IPV4, source.CustomResource, endpoint.Namespace, endpoint.Name)
+					portsChanged := k.ipcache.DeleteOnMetadataMatch(ipcache.KeyWithVNI(oldPair.IPV4, oldVNI), source.CustomResource, endpoint.Namespace, endpoint.Name)
 					if portsChanged {
 						namedPortsChanged = true
 					}
 				}
 				if !v6Added {
-					portsChanged := k.ipcache.DeleteOnMetadataMatch(oldPair.IPV6, source.CustomResource, endpoint.Namespace, endpoint.Name)
+					portsChanged := k.ipcache.DeleteOnMetadataMatch(ipcache.KeyWithVNI(oldPair.IPV6, oldVNI), source.CustomResource, endpoint.Namespace, endpoint.Name)
 					if portsChanged {
 						namedPortsChanged = true
 					}
@@ -223,11 +247,22 @@ func (k *K8sCiliumEndpointsWatcher) endpointUpdated(oldEndpoint, endpoint *types
 		}
 	}
 
+	vni := ciliumEndpointVNI(endpoint)
+	// In native-vpc mode a CEP without a VNI is an error (the endpoint-create
+	// path rejects such pods). Skip registration instead of writing a plain-IP
+	// entry that collides with overlapping VPC subnets.
+	if option.Config.EnableNativeVPC && vni == 0 {
+		k.logger.Error("native-vpc CiliumEndpoint is missing a valid VNI annotation; skipping ipcache registration",
+			logfields.K8sPodName, endpoint.Namespace+"/"+endpoint.Name,
+		)
+		return
+	}
+
 	for _, pair := range endpoint.Networking.Addressing {
 		if pair.IPV4 != "" {
 			ipsAdded = append(ipsAdded, pair.IPV4)
-			portsChanged, _ := k.ipcache.Upsert(pair.IPV4, nodeIP, encryptionKey, k8sMeta,
-				ipcache.Identity{ID: id, Source: source.CustomResource})
+			portsChanged, _ := k.ipcache.Upsert(ipcache.KeyWithVNI(pair.IPV4, vni), nodeIP, encryptionKey, k8sMeta,
+				ipcache.Identity{ID: id, Source: source.CustomResource, Vni: vni})
 			if portsChanged {
 				namedPortsChanged = true
 			}
@@ -235,8 +270,8 @@ func (k *K8sCiliumEndpointsWatcher) endpointUpdated(oldEndpoint, endpoint *types
 
 		if pair.IPV6 != "" {
 			ipsAdded = append(ipsAdded, pair.IPV6)
-			portsChanged, _ := k.ipcache.Upsert(pair.IPV6, nodeIP, encryptionKey, k8sMeta,
-				ipcache.Identity{ID: id, Source: source.CustomResource})
+			portsChanged, _ := k.ipcache.Upsert(ipcache.KeyWithVNI(pair.IPV6, vni), nodeIP, encryptionKey, k8sMeta,
+				ipcache.Identity{ID: id, Source: source.CustomResource, Vni: vni})
 			if portsChanged {
 				namedPortsChanged = true
 			}
@@ -249,14 +284,16 @@ func (k *K8sCiliumEndpointsWatcher) endpointDeleted(endpoint *types.CiliumEndpoi
 		namedPortsChanged := false
 		for _, pair := range endpoint.Networking.Addressing {
 			if pair.IPV4 != "" {
-				portsChanged := k.ipcache.DeleteOnMetadataMatch(pair.IPV4, source.CustomResource, endpoint.Namespace, endpoint.Name)
+				vni := ciliumEndpointVNI(endpoint)
+				portsChanged := k.ipcache.DeleteOnMetadataMatch(ipcache.KeyWithVNI(pair.IPV4, vni), source.CustomResource, endpoint.Namespace, endpoint.Name)
 				if portsChanged {
 					namedPortsChanged = true
 				}
 			}
 
 			if pair.IPV6 != "" {
-				portsChanged := k.ipcache.DeleteOnMetadataMatch(pair.IPV6, source.CustomResource, endpoint.Namespace, endpoint.Name)
+				vni := ciliumEndpointVNI(endpoint)
+				portsChanged := k.ipcache.DeleteOnMetadataMatch(ipcache.KeyWithVNI(pair.IPV6, vni), source.CustomResource, endpoint.Namespace, endpoint.Name)
 				if portsChanged {
 					namedPortsChanged = true
 				}

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -145,7 +145,7 @@ func ciliumEndpointVNI(endpoint *types.CiliumEndpoint) uint32 {
 	if endpoint == nil || endpoint.Annotations == nil {
 		return 0
 	}
-	vniStr, ok := endpoint.Annotations[annotation.NativeVPCVNIPrefix+"/vni"]
+	vniStr, ok := endpoint.Annotations[annotation.CiliumEndpointNativeVPCVNI]
 	if !ok || vniStr == "" {
 		return 0
 	}

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"log/slog"
 	"net"
+	"slices"
 	"strconv"
 	"sync/atomic"
 
@@ -163,33 +164,30 @@ func (k *K8sCiliumEndpointsWatcher) endpointUpdated(oldEndpoint, endpoint *types
 			k.policyManager.TriggerPolicyUpdates("Named ports added or updated")
 		}
 	}()
-	var ipsAdded []string
+	// keysAdded holds the ipcache keys written below rather than the bare
+	// addresses they are built from. An entry is identified by the (VNI, IP)
+	// pair, so "is this address still present?" cannot be answered by comparing
+	// addresses alone: an endpoint that keeps its address while moving to
+	// another VPC still has to lose the entry of the VPC it left, otherwise the
+	// old scope keeps resolving that address to an endpoint that no longer
+	// belongs to it - and another VPC may legitimately own the same address.
+	//
+	// KeyWithVNI is the identity function when native-vpc is off, so outside
+	// that mode the comparison is exactly the address comparison it replaces.
+	var keysAdded []string
 	if oldEndpoint != nil && oldEndpoint.Networking != nil {
-		// Delete the old IP addresses from the IP cache, scoped by the OLD
-		// endpoint's VNI (native-vpc): the new entries are upserted with the new
-		// VNI below, so the old VNI-scoped entries must be removed with the old
-		// key to avoid leaking them.
 		oldVNI := ciliumEndpointVNI(oldEndpoint)
 		defer func() {
 			for _, oldPair := range oldEndpoint.Networking.Addressing {
-				v4Added, v6Added := false, false
-				for _, ipAdded := range ipsAdded {
-					if ipAdded == oldPair.IPV4 {
-						v4Added = true
+				for _, oldIP := range []string{oldPair.IPV4, oldPair.IPV6} {
+					if oldIP == "" {
+						continue
 					}
-					if ipAdded == oldPair.IPV6 {
-						v6Added = true
+					oldKey := ipcache.KeyWithVNI(oldIP, oldVNI)
+					if slices.Contains(keysAdded, oldKey) {
+						continue
 					}
-				}
-				if !v4Added {
-					portsChanged := k.ipcache.DeleteOnMetadataMatch(ipcache.KeyWithVNI(oldPair.IPV4, oldVNI), source.CustomResource, endpoint.Namespace, endpoint.Name)
-					if portsChanged {
-						namedPortsChanged = true
-					}
-				}
-				if !v6Added {
-					portsChanged := k.ipcache.DeleteOnMetadataMatch(ipcache.KeyWithVNI(oldPair.IPV6, oldVNI), source.CustomResource, endpoint.Namespace, endpoint.Name)
-					if portsChanged {
+					if k.ipcache.DeleteOnMetadataMatch(oldKey, source.CustomResource, endpoint.Namespace, endpoint.Name) {
 						namedPortsChanged = true
 					}
 				}
@@ -260,7 +258,7 @@ func (k *K8sCiliumEndpointsWatcher) endpointUpdated(oldEndpoint, endpoint *types
 
 	for _, pair := range endpoint.Networking.Addressing {
 		if pair.IPV4 != "" {
-			ipsAdded = append(ipsAdded, pair.IPV4)
+			keysAdded = append(keysAdded, ipcache.KeyWithVNI(pair.IPV4, vni))
 			portsChanged, _ := k.ipcache.Upsert(ipcache.KeyWithVNI(pair.IPV4, vni), nodeIP, encryptionKey, k8sMeta,
 				ipcache.Identity{ID: id, Source: source.CustomResource, Vni: vni})
 			if portsChanged {
@@ -269,7 +267,7 @@ func (k *K8sCiliumEndpointsWatcher) endpointUpdated(oldEndpoint, endpoint *types
 		}
 
 		if pair.IPV6 != "" {
-			ipsAdded = append(ipsAdded, pair.IPV6)
+			keysAdded = append(keysAdded, ipcache.KeyWithVNI(pair.IPV6, vni))
 			portsChanged, _ := k.ipcache.Upsert(ipcache.KeyWithVNI(pair.IPV6, vni), nodeIP, encryptionKey, k8sMeta,
 				ipcache.Identity{ID: id, Source: source.CustomResource, Vni: vni})
 			if portsChanged {

--- a/pkg/k8s/watchers/cilium_endpoint_vni_test.go
+++ b/pkg/k8s/watchers/cilium_endpoint_vni_test.go
@@ -4,6 +4,7 @@
 package watchers
 
 import (
+	"context"
 	"net"
 	"testing"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/annotation"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
+	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -21,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/types"
 	k8sTypes "github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/labels"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 )
@@ -31,6 +34,16 @@ import (
 // testVNIAnnotation stands in for the kube-ovn annotation the deployment
 // configures; the watcher reads whatever key option.Config names.
 const testVNIAnnotation = "ovn.kubernetes.io/tunnel_key"
+
+// fakeEndpointManager answers the pod watcher's question "is there a local
+// endpoint for this pod, and which VPC is it actually in?".
+type fakeEndpointManager struct{ eps []*endpoint.Endpoint }
+
+func (f fakeEndpointManager) GetEndpointsByPodName(string) []*endpoint.Endpoint { return f.eps }
+func (fakeEndpointManager) LookupCEPName(string) *endpoint.Endpoint             { return nil }
+func (fakeEndpointManager) GetEndpoints() []*endpoint.Endpoint                  { return nil }
+func (fakeEndpointManager) GetHostEndpoint() *endpoint.Endpoint                 { return nil }
+func (fakeEndpointManager) UpdatePolicyMaps(context.Context) error              { return nil }
 
 // fakePolicyManager swallows the policy recalculation triggers.
 type fakePolicyManager struct{}
@@ -219,11 +232,12 @@ func TestUpdatePodHostDataVNIChange(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ipc := &recordingIPCache{}
 			w := &K8sPodWatcher{
-				logger:        hivetest.Logger(t),
-				ipcache:       ipc,
-				policyManager: fakePolicyManager{},
-				wgConfig:      fakeTypes.WireguardConfig{},
-				ipsecConfig:   fakeTypes.IPsecConfig{},
+				logger:          hivetest.Logger(t),
+				ipcache:         ipc,
+				policyManager:   fakePolicyManager{},
+				endpointManager: fakeEndpointManager{},
+				wgConfig:        fakeTypes.WireguardConfig{},
+				ipsecConfig:     fakeTypes.IPsecConfig{},
 			}
 
 			oldPod := vniPod("client", tc.oldIP, "192.168.0.1", tc.oldVNI)
@@ -237,4 +251,84 @@ func TestUpdatePodHostDataVNIChange(t *testing.T) {
 				"the entry must be removed with the VNI it was written under")
 		})
 	}
+}
+
+// TestUpdatePodHostDataDriftFollowsEndpoint pins which of the two sources wins
+// when they disagree.
+//
+// A ready endpoint does not adopt a new VNI from its pod annotation: the VNI is
+// an identity and datapath dimension, and only a recreation converges it. The
+// pod watcher therefore must not publish the annotation's scope either -
+// doing so would announce the address in a VPC that no endpoint is in, which is
+// exactly the cross-VPC lie the scoping exists to prevent. The entry stays
+// where the datapath actually is until the pod is recreated.
+func TestUpdatePodHostDataDriftFollowsEndpoint(t *testing.T) {
+	prev := option.Config.EnableNativeVPC
+	prevAnn := option.Config.NativeVPCVNIAnnotation
+	option.Config.EnableNativeVPC = true
+	option.Config.NativeVPCVNIAnnotation = testVNIAnnotation
+	t.Cleanup(func() {
+		option.Config.EnableNativeVPC = prev
+		option.Config.NativeVPCVNIAnnotation = prevAnn
+	})
+
+	ep := &endpoint.Endpoint{VNIID: 9}
+	ipc := &recordingIPCache{}
+	w := &K8sPodWatcher{
+		logger:          hivetest.Logger(t),
+		ipcache:         ipc,
+		policyManager:   fakePolicyManager{},
+		endpointManager: fakeEndpointManager{eps: []*endpoint.Endpoint{ep}},
+		wgConfig:        fakeTypes.WireguardConfig{},
+		ipsecConfig:     fakeTypes.IPsecConfig{},
+	}
+
+	oldPod := vniPod("client", "10.99.0.11", "192.168.0.1", "9")
+	newPod := vniPod("client", "10.99.0.11", "192.168.0.1", "99") // annotation drifted
+
+	require.NoError(t, w.updatePodHostData(oldPod, newPod,
+		k8sTypes.IPSlice{"10.99.0.11"}, k8sTypes.IPSlice{"10.99.0.11"}))
+
+	require.Empty(t, ipc.upserted, "no entry may be published under a VPC the endpoint is not in")
+	require.Empty(t, ipc.deleted, "the entry backing the running datapath must stay")
+}
+
+// TestUpdatePodHostDataLocalPodWithoutEndpoint covers the startup ordering: pod
+// events are delivered before endpoint restore has finished, so the watcher has
+// no endpoint to consult yet. It must not fall back to the annotation for a pod
+// on this node - the annotation may be one the endpoint is about to refuse, and
+// the placeholder would then name a VPC the endpoint never joins. The endpoint
+// registers the real entry itself a moment later.
+func TestUpdatePodHostDataLocalPodWithoutEndpoint(t *testing.T) {
+	prev := option.Config.EnableNativeVPC
+	prevAnn := option.Config.NativeVPCVNIAnnotation
+	option.Config.EnableNativeVPC = true
+	option.Config.NativeVPCVNIAnnotation = testVNIAnnotation
+	t.Cleanup(func() {
+		option.Config.EnableNativeVPC = prev
+		option.Config.NativeVPCVNIAnnotation = prevAnn
+	})
+
+	ipc := &recordingIPCache{}
+	w := &K8sPodWatcher{
+		logger:          hivetest.Logger(t),
+		ipcache:         ipc,
+		policyManager:   fakePolicyManager{},
+		endpointManager: fakeEndpointManager{}, // restore has not exposed it yet
+		wgConfig:        fakeTypes.WireguardConfig{},
+		ipsecConfig:     fakeTypes.IPsecConfig{},
+	}
+
+	pod := vniPod("client", "10.99.0.11", "192.168.0.1", "99")
+	pod.Spec.NodeName = nodeTypes.GetName()
+
+	require.NoError(t, w.updatePodHostData(nil, pod, nil, k8sTypes.IPSlice{"10.99.0.11"}))
+	require.Empty(t, ipc.upserted, "the scope of a local pod is the endpoint's to publish")
+
+	// A pod on another node has no local endpoint to wait for, so the
+	// annotation remains the only available scope.
+	remote := vniPod("peer", "10.99.0.12", "192.168.0.2", "99")
+	remote.Spec.NodeName = "other-node"
+	require.NoError(t, w.updatePodHostData(nil, remote, nil, k8sTypes.IPSlice{"10.99.0.12"}))
+	require.Equal(t, []string{"10.99.0.12@vni:99"}, ipc.upserted)
 }

--- a/pkg/k8s/watchers/cilium_endpoint_vni_test.go
+++ b/pkg/k8s/watchers/cilium_endpoint_vni_test.go
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchers
+
+import (
+	"net"
+	"testing"
+
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/annotation"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	fakeTypes "github.com/cilium/cilium/pkg/datapath/fake/types"
+	"github.com/cilium/cilium/pkg/ipcache"
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/k8s/types"
+	k8sTypes "github.com/cilium/cilium/pkg/k8s/types"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/source"
+)
+
+// recordingIPCache records the keys the CiliumEndpoint watcher writes and
+// removes, so a test can assert on the exact key strings rather than on the
+// bare addresses they are derived from.
+// testVNIAnnotation stands in for the kube-ovn annotation the deployment
+// configures; the watcher reads whatever key option.Config names.
+const testVNIAnnotation = "ovn.kubernetes.io/tunnel_key"
+
+// fakePolicyManager swallows the policy recalculation triggers.
+type fakePolicyManager struct{}
+
+func (fakePolicyManager) TriggerPolicyUpdates(string) {}
+
+type recordingIPCache struct {
+	upserted []string
+	deleted  []string
+}
+
+func (r *recordingIPCache) Upsert(ip string, _ net.IP, _ uint8, _ *ipcache.K8sMetadata, _ ipcache.Identity) (bool, error) {
+	r.upserted = append(r.upserted, ip)
+	return false, nil
+}
+
+func (r *recordingIPCache) LookupByIP(string) (ipcache.Identity, bool) {
+	return ipcache.Identity{}, false
+}
+
+func (r *recordingIPCache) Delete(ip string, _ source.Source) bool {
+	r.deleted = append(r.deleted, ip)
+	return false
+}
+
+func (r *recordingIPCache) DeleteOnMetadataMatch(ip string, _ source.Source, _, _ string) bool {
+	r.deleted = append(r.deleted, ip)
+	return false
+}
+
+func (r *recordingIPCache) UpsertMetadata(cmtypes.PrefixCluster, source.Source, ipcacheTypes.ResourceID, ...ipcache.IPMetadata) {
+}
+
+func (r *recordingIPCache) RemoveLabelsExcluded(labels.Labels, map[cmtypes.PrefixCluster]struct{}, ipcacheTypes.ResourceID) {
+}
+
+func (r *recordingIPCache) RemoveMetadata(cmtypes.PrefixCluster, ipcacheTypes.ResourceID, ...ipcache.IPMetadata) {
+}
+
+func vniCEP(name, ip string, vni string, identity int64) *types.CiliumEndpoint {
+	cep := &types.CiliumEndpoint{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Identity:   &v2.EndpointIdentity{ID: identity},
+		Networking: &v2.EndpointNetworking{NodeIP: "10.0.0.1"},
+	}
+	cep.Networking.Addressing = append(cep.Networking.Addressing, &v2.AddressPair{IPV4: ip})
+	if vni != "" {
+		cep.Annotations = map[string]string{annotation.CiliumEndpointNativeVPCVNI: vni}
+	}
+	return cep
+}
+
+// TestEndpointUpdatedVNIChangeRemovesOldKey covers a CiliumEndpoint that keeps
+// its address while moving to another VPC.
+//
+// The remote endpoint is registered under a (VNI, IP) scoped key, so "does this
+// address still exist?" cannot be answered by comparing bare addresses: the
+// address is unchanged, yet the entry that has to be removed is the one scoped
+// by the *old* VNI. Leaving it behind lets the old VPC keep resolving that
+// address to an endpoint that no longer belongs to it - and in native-vpc mode
+// another VPC may legitimately own the very same address.
+func TestEndpointUpdatedVNIChangeRemovesOldKey(t *testing.T) {
+	prev := option.Config.EnableNativeVPC
+	option.Config.EnableNativeVPC = true
+	t.Cleanup(func() { option.Config.EnableNativeVPC = prev })
+
+	for _, tc := range []struct {
+		name         string
+		oldVNI       string
+		newVNI       string
+		wantUpserted string
+		wantDeleted  []string
+	}{
+		{
+			name:         "VNI changes while the address stays",
+			oldVNI:       "5",
+			newVNI:       "7",
+			wantUpserted: "10.99.0.11@vni:7",
+			wantDeleted:  []string{"10.99.0.11@vni:5"},
+		},
+		{
+			name:         "nothing changes",
+			oldVNI:       "5",
+			newVNI:       "5",
+			wantUpserted: "10.99.0.11@vni:5",
+			wantDeleted:  nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ipc := &recordingIPCache{}
+			w := &K8sCiliumEndpointsWatcher{
+				logger:      hivetest.Logger(t),
+				ipcache:     ipc,
+				wgConfig:    fakeTypes.WireguardConfig{},
+				ipsecConfig: fakeTypes.IPsecConfig{},
+			}
+
+			old := vniCEP("client", "10.99.0.11", tc.oldVNI, 1234)
+			new := vniCEP("client", "10.99.0.11", tc.newVNI, 1234)
+			w.endpointUpdated(old, new)
+
+			require.Equal(t, []string{tc.wantUpserted}, ipc.upserted)
+			var deleted []string
+			for _, d := range ipc.deleted {
+				if d != "" { // the v6 slot of a v4-only endpoint
+					deleted = append(deleted, d)
+				}
+			}
+			require.Equal(t, tc.wantDeleted, deleted,
+				"the entry of the VPC the endpoint left must be removed")
+		})
+	}
+}
+
+func vniPod(name, ip, hostIP, vni string) *slim_corev1.Pod {
+	pod := &slim_corev1.Pod{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Status: slim_corev1.PodStatus{
+			HostIP: hostIP,
+			PodIP:  ip,
+			PodIPs: []slim_corev1.PodIP{{IP: ip}},
+		},
+	}
+	if vni != "" {
+		pod.Annotations = map[string]string{testVNIAnnotation: vni}
+	}
+	return pod
+}
+
+// TestUpdatePodHostDataVNIChange covers the pod watcher side of the same rule:
+// the entry it maintains is keyed by (VNI, IP), so a pod that changes VPC has
+// to lose the entry of the VPC it left, and that entry can only be addressed
+// with the VNI it was written under - not with the pod's current one.
+func TestUpdatePodHostDataVNIChange(t *testing.T) {
+	prev := option.Config.EnableNativeVPC
+	prevAnn := option.Config.NativeVPCVNIAnnotation
+	option.Config.EnableNativeVPC = true
+	option.Config.NativeVPCVNIAnnotation = testVNIAnnotation
+	t.Cleanup(func() {
+		option.Config.EnableNativeVPC = prev
+		option.Config.NativeVPCVNIAnnotation = prevAnn
+	})
+
+	for _, tc := range []struct {
+		name           string
+		oldIP, newIP   string
+		oldVNI, newVNI string
+		wantUpserted   []string
+		wantDeleted    []string
+	}{
+		{
+			name:  "VPC change with the same address",
+			oldIP: "10.99.0.11", newIP: "10.99.0.11",
+			oldVNI: "5", newVNI: "7",
+			wantUpserted: []string{"10.99.0.11@vni:7"},
+			wantDeleted:  []string{"10.99.0.11@vni:5"},
+		},
+		{
+			name:  "address change within one VPC",
+			oldIP: "10.99.0.11", newIP: "10.99.0.12",
+			oldVNI: "5", newVNI: "5",
+			wantUpserted: []string{"10.99.0.12@vni:5"},
+			wantDeleted:  []string{"10.99.0.11@vni:5"},
+		},
+		{
+			name:  "address and VPC both change",
+			oldIP: "10.99.0.11", newIP: "10.99.0.12",
+			oldVNI: "5", newVNI: "7",
+			wantUpserted: []string{"10.99.0.12@vni:7"},
+			wantDeleted:  []string{"10.99.0.11@vni:5"},
+		},
+		{
+			name:  "nothing changes",
+			oldIP: "10.99.0.11", newIP: "10.99.0.11",
+			oldVNI: "5", newVNI: "5",
+			wantUpserted: nil,
+			wantDeleted:  nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ipc := &recordingIPCache{}
+			w := &K8sPodWatcher{
+				logger:        hivetest.Logger(t),
+				ipcache:       ipc,
+				policyManager: fakePolicyManager{},
+				wgConfig:      fakeTypes.WireguardConfig{},
+				ipsecConfig:   fakeTypes.IPsecConfig{},
+			}
+
+			oldPod := vniPod("client", tc.oldIP, "192.168.0.1", tc.oldVNI)
+			newPod := vniPod("client", tc.newIP, "192.168.0.1", tc.newVNI)
+			err := w.updatePodHostData(oldPod, newPod,
+				k8sTypes.IPSlice{tc.oldIP}, k8sTypes.IPSlice{tc.newIP})
+			require.NoError(t, err)
+
+			require.Equal(t, tc.wantUpserted, ipc.upserted)
+			require.Equal(t, tc.wantDeleted, ipc.deleted,
+				"the entry must be removed with the VNI it was written under")
+		})
+	}
+}

--- a/pkg/k8s/watchers/native_vpc_vni_test.go
+++ b/pkg/k8s/watchers/native_vpc_vni_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package watchers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/annotation"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	k8sTypes "github.com/cilium/cilium/pkg/k8s/types"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+func TestPodVNI(t *testing.T) {
+	oldEnable := option.Config.EnableNativeVPC
+	oldAnnot := option.Config.NativeVPCVNIAnnotation
+	t.Cleanup(func() {
+		option.Config.EnableNativeVPC = oldEnable
+		option.Config.NativeVPCVNIAnnotation = oldAnnot
+	})
+	option.Config.EnableNativeVPC = true
+	option.Config.NativeVPCVNIAnnotation = "ovn.kubernetes.io/tunnel_key"
+
+	// Valid annotation.
+	pod := &slim_corev1.Pod{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Annotations: map[string]string{"ovn.kubernetes.io/tunnel_key": "36"},
+		},
+	}
+	require.Equal(t, uint32(36), podVNI(pod))
+
+	// Missing annotation -> 0.
+	pod = &slim_corev1.Pod{ObjectMeta: slim_metav1.ObjectMeta{Annotations: map[string]string{}}}
+	require.Zero(t, podVNI(pod))
+
+	// Invalid value -> 0.
+	pod = &slim_corev1.Pod{ObjectMeta: slim_metav1.ObjectMeta{Annotations: map[string]string{"ovn.kubernetes.io/tunnel_key": "abc"}}}
+	require.Zero(t, podVNI(pod))
+
+	// nil pod -> 0.
+	require.Zero(t, podVNI(nil))
+
+	// native-vpc disabled -> 0 even with the annotation.
+	option.Config.EnableNativeVPC = false
+	pod = &slim_corev1.Pod{ObjectMeta: slim_metav1.ObjectMeta{Annotations: map[string]string{"ovn.kubernetes.io/tunnel_key": "36"}}}
+	require.Zero(t, podVNI(pod))
+}
+
+func TestCiliumEndpointVNI(t *testing.T) {
+	cep := &k8sTypes.CiliumEndpoint{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Annotations: map[string]string{annotation.NativeVPCVNIPrefix + "/vni": "17"},
+		},
+	}
+	require.Equal(t, uint32(17), ciliumEndpointVNI(cep))
+
+	// Missing annotation.
+	cep = &k8sTypes.CiliumEndpoint{ObjectMeta: slim_metav1.ObjectMeta{Annotations: map[string]string{}}}
+	require.Zero(t, ciliumEndpointVNI(cep))
+
+	// Invalid value.
+	cep = &k8sTypes.CiliumEndpoint{ObjectMeta: slim_metav1.ObjectMeta{Annotations: map[string]string{annotation.NativeVPCVNIPrefix + "/vni": "x"}}}
+	require.Zero(t, ciliumEndpointVNI(cep))
+
+	// nil.
+	require.Zero(t, ciliumEndpointVNI(nil))
+}

--- a/pkg/k8s/watchers/native_vpc_vni_test.go
+++ b/pkg/k8s/watchers/native_vpc_vni_test.go
@@ -69,3 +69,39 @@ func TestCiliumEndpointVNI(t *testing.T) {
 	// nil.
 	require.Zero(t, ciliumEndpointVNI(nil))
 }
+
+// TestPodVNIMatchesControlPlane pins the control/cache seam: the pod watcher
+// must classify a pod exactly like endpoint creation does. Any value that
+// endpoint creation rejects must yield VNI 0 here (no VPC-scoped ipcache
+// entry), never a VPC scope that no endpoint has.
+func TestPodVNIMatchesControlPlane(t *testing.T) {
+	prevEnabled, prevKey := option.Config.EnableNativeVPC, option.Config.NativeVPCVNIAnnotation
+	option.Config.EnableNativeVPC = true
+	option.Config.NativeVPCVNIAnnotation = "ovn.kubernetes.io/tunnel_key"
+	t.Cleanup(func() {
+		option.Config.EnableNativeVPC = prevEnabled
+		option.Config.NativeVPCVNIAnnotation = prevKey
+	})
+
+	pod := func(value string) *slim_corev1.Pod {
+		return &slim_corev1.Pod{
+			ObjectMeta: slim_metav1.ObjectMeta{
+				Name: "p", Namespace: "ns",
+				Annotations: map[string]string{option.Config.NativeVPCVNIAnnotation: value},
+			},
+		}
+	}
+
+	require.Equal(t, uint32(36), podVNI(pod("36")))
+	require.Equal(t, uint32(36), podVNI(pod(" 36 ")), "whitespace is tolerated like on the control plane")
+	require.Equal(t, uint32(16777215), podVNI(pod("16777215")))
+
+	// Values rejected by endpoint creation must not become a cache-plane scope.
+	for _, bad := range []string{"0", "-1", "abc", "16777216", "4294967295", ""} {
+		require.Zero(t, podVNI(pod(bad)), "value %q must not yield a VPC scope", bad)
+	}
+	require.Zero(t, podVNI(nil))
+
+	option.Config.EnableNativeVPC = false
+	require.Zero(t, podVNI(pod("36")), "inert when native-vpc is disabled")
+}

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/nativevpc"
 	"github.com/cilium/cilium/pkg/node"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/source"
@@ -609,6 +610,31 @@ func (k *K8sPodWatcher) updatePodHostData(oldPod, newPod *slim_corev1.Pod, oldPo
 	// native-vpc mode. Zero for non-native-vpc pods.
 	vni := podVNI(newPod)
 
+	// A managed endpoint deliberately does not follow annotation drift: its VNI
+	// is an identity and datapath dimension that only a recreation can change
+	// (see Endpoint.SyncVNIFromPodAnnotation). Announcing the annotation's scope
+	// here would publish the address in a VPC that no endpoint is in, so the
+	// endpoint's own scope wins whenever there is one. A zero VNI is never taken
+	// from the endpoint: that direction would merge the address back into the
+	// shared plain-IP scope.
+	//
+	// For a pod scheduled on this node the endpoint is the authority even when
+	// it is not known yet - pod events arrive before endpoint restore completes,
+	// and the annotation read here may be one the endpoint is going to refuse.
+	// The placeholder entry is then simply left to the endpoint, which registers
+	// the real one under the scope it was admitted with.
+	deferToEndpoint := false
+	if option.Config.EnableNativeVPC {
+		switch eps := k.endpointManager.GetEndpointsByPodName(k8sUtils.GetObjNamespaceName(&newPod.ObjectMeta)); {
+		case len(eps) > 0:
+			if epVNI := uint32(eps[0].GetVNIID()); epVNI != 0 {
+				vni = epVNI
+			}
+		case newPod.Spec.NodeName == nodeTypes.GetName():
+			deferToEndpoint = true
+		}
+	}
+
 	// In native-vpc mode every non-hostNetwork pod must carry a non-zero VNI
 	// (the OVN subnet's tunnel key). A missing/zero VNI is an error: registering
 	// nothing under the plain-IP scheme would collide with overlapping VPC
@@ -704,6 +730,9 @@ func (k *K8sPodWatcher) updatePodHostData(oldPod, newPod *slim_corev1.Pod, oldPo
 
 	var errs []string
 	for _, podIP := range newPodIPs {
+		if deferToEndpoint {
+			break
+		}
 		// Initial mapping of podIP <-> hostIP <-> identity. The mapping is
 		// later updated once the allocator has determined the real identity.
 		// If the endpoint remains unmanaged, the identity remains untouched.

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -21,7 +21,6 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"strconv"
 
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/annotation"
@@ -47,6 +46,7 @@ import (
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/nativevpc"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
@@ -581,19 +581,14 @@ func (k *K8sPodWatcher) deleteK8sPodV1(pod *slim_corev1.Pod) error {
 // (option.Config.NativeVPCVNIAnnotation, e.g. ovn.kubernetes.io/tunnel_key).
 // Returns 0 when native-vpc mode is disabled or the annotation is missing or
 // invalid, in which case the pod uses the plain cluster-wide IP scheme.
+// podVNI returns the native-vpc VNI of a pod for the cache-plane
+// registration. It uses the single shared decision table (nativevpc), so the
+// pod watcher can never register an ipcache entry under a VNI that endpoint
+// creation would have rejected. A missing or invalid annotation yields 0,
+// which the callers treat as "do not register a VPC-scoped entry".
 func podVNI(pod *slim_corev1.Pod) uint32 {
-	if !option.Config.EnableNativeVPC || option.Config.NativeVPCVNIAnnotation == "" {
-		return 0
-	}
-	if pod == nil {
-		return 0
-	}
-	vniStr, ok := pod.Annotations[option.Config.NativeVPCVNIAnnotation]
-	if !ok || vniStr == "" {
-		return 0
-	}
-	vni, err := strconv.ParseUint(vniStr, 10, 32)
-	if err != nil {
+	vni, res, _ := nativevpc.VNIFromPod(pod)
+	if res != nativevpc.Valid {
 		return 0
 	}
 	return uint32(vni)

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -673,7 +673,9 @@ func (k *K8sPodWatcher) updatePodHostData(oldPod, newPod *slim_corev1.Pod, oldPo
 				if slices.Contains(newKeys, oldKey) {
 					continue
 				}
-				npc := k.ipcache.Delete(oldKey, source.Kubernetes)
+				// Match on the pod as well: the address may already have been
+				// handed to another pod, whose entry must not be removed here.
+				npc := k.ipcache.DeleteOnMetadataMatch(oldKey, source.Kubernetes, newPod.Namespace, newPod.Name)
 				if npc {
 					namedPortsChanged = true
 				}

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -21,6 +21,7 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"strconv"
 
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/annotation"
@@ -575,6 +576,29 @@ func (k *K8sPodWatcher) deleteK8sPodV1(pod *slim_corev1.Pod) error {
 	return err
 }
 
+// podVNI returns the Virtual Network Identifier (VNI) of the pod in
+// native-vpc mode, read from the pod's tunnel_key annotation
+// (option.Config.NativeVPCVNIAnnotation, e.g. ovn.kubernetes.io/tunnel_key).
+// Returns 0 when native-vpc mode is disabled or the annotation is missing or
+// invalid, in which case the pod uses the plain cluster-wide IP scheme.
+func podVNI(pod *slim_corev1.Pod) uint32 {
+	if !option.Config.EnableNativeVPC || option.Config.NativeVPCVNIAnnotation == "" {
+		return 0
+	}
+	if pod == nil {
+		return 0
+	}
+	vniStr, ok := pod.Annotations[option.Config.NativeVPCVNIAnnotation]
+	if !ok || vniStr == "" {
+		return 0
+	}
+	vni, err := strconv.ParseUint(vniStr, 10, 32)
+	if err != nil {
+		return 0
+	}
+	return uint32(vni)
+}
+
 func (k *K8sPodWatcher) updatePodHostData(oldPod, newPod *slim_corev1.Pod, oldPodIPs, newPodIPs k8sTypes.IPSlice) error {
 	if newPod.Spec.HostNetwork {
 		k.logger.Debug("Pod is using host networking",
@@ -585,6 +609,23 @@ func (k *K8sPodWatcher) updatePodHostData(oldPod, newPod *slim_corev1.Pod, oldPo
 	}
 
 	var namedPortsChanged bool
+
+	// VNI (from the tunnel_key annotation) used to scope ipcache entries in
+	// native-vpc mode. Zero for non-native-vpc pods.
+	vni := podVNI(newPod)
+
+	// In native-vpc mode every non-hostNetwork pod must carry a non-zero VNI
+	// (the OVN subnet's tunnel key). A missing/zero VNI is an error: registering
+	// nothing under the plain-IP scheme would collide with overlapping VPC
+	// subnets. The endpoint-create path rejects such pods too; this guards
+	// already-running pods that cannot be re-created (e.g. created by an
+	// out-of-date kube-ovn before the tunnel_key backfill).
+	if option.Config.EnableNativeVPC && vni == 0 {
+		k.logger.Error("native-vpc pod is missing a valid tunnel_key annotation; skipping ipcache registration",
+			logfields.K8sPodName, newPod.Namespace+"/"+newPod.Name,
+		)
+		return nil
+	}
 
 	ipSliceEqual := oldPodIPs != nil && oldPodIPs.DeepEqual(&newPodIPs)
 
@@ -599,7 +640,7 @@ func (k *K8sPodWatcher) updatePodHostData(oldPod, newPod *slim_corev1.Pod, oldPo
 					found = true
 				}
 				if !found {
-					npc := k.ipcache.Delete(oldPodIP, source.Kubernetes)
+					npc := k.ipcache.Delete(ipcache.KeyWithVNI(oldPodIP, vni), source.Kubernetes)
 					if npc {
 						namedPortsChanged = true
 					}
@@ -659,9 +700,13 @@ func (k *K8sPodWatcher) updatePodHostData(oldPod, newPod *slim_corev1.Pod, oldPo
 		// Initial mapping of podIP <-> hostIP <-> identity. The mapping is
 		// later updated once the allocator has determined the real identity.
 		// If the endpoint remains unmanaged, the identity remains untouched.
-		npc, err := k.ipcache.Upsert(podIP, hostIP, hostKey, k8sMeta, ipcache.Identity{
+		// In native-vpc mode the entry is keyed by IP+VNI (from the
+		// tunnel_key annotation) so that overlapping IPs in different VPCs
+		// can coexist.
+		npc, err := k.ipcache.Upsert(ipcache.KeyWithVNI(podIP, vni), hostIP, hostKey, k8sMeta, ipcache.Identity{
 			ID:     identity.ReservedIdentityUnmanaged,
 			Source: source.Kubernetes,
+			Vni:    vni,
 		})
 		if npc {
 			namedPortsChanged = true
@@ -714,7 +759,8 @@ func (k *K8sPodWatcher) deletePodHostData(pod *slim_corev1.Pod) (bool, error) {
 		// a small race condition exists here as deletion could occur in
 		// parallel based on another event but it doesn't matter as the
 		// identity is going away
-		id, exists := k.ipcache.LookupByIP(podIP)
+		ipKey := ipcache.KeyWithVNI(podIP, podVNI(pod))
+		id, exists := k.ipcache.LookupByIP(ipKey)
 		if !exists {
 			skipped = true
 			errs = append(errs, fmt.Sprintf("identity for IP %s does not exist in case", podIP))
@@ -727,7 +773,7 @@ func (k *K8sPodWatcher) deletePodHostData(pod *slim_corev1.Pod) (bool, error) {
 			continue
 		}
 
-		k.ipcache.DeleteOnMetadataMatch(podIP, source.Kubernetes, pod.Namespace, pod.Name)
+		k.ipcache.DeleteOnMetadataMatch(ipKey, source.Kubernetes, pod.Namespace, pod.Name)
 	}
 
 	if len(errs) != 0 {

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -624,21 +624,32 @@ func (k *K8sPodWatcher) updatePodHostData(oldPod, newPod *slim_corev1.Pod, oldPo
 
 	ipSliceEqual := oldPodIPs != nil && oldPodIPs.DeepEqual(&newPodIPs)
 
+	// An entry is identified by its (VNI, IP) key, so an unchanged address set
+	// does not imply an unchanged set of entries: a pod that moves to another
+	// VPC keeps its address, and the entry of the VPC it left has to go. The
+	// keys are therefore compared, and the old ones are rebuilt with the VNI
+	// they were written under - deleting them with the new VNI would target an
+	// entry that never existed and leave the real one behind.
+	oldVNI := podVNI(oldPod)
+	newKeys := make([]string, 0, len(newPodIPs))
+	for _, podIP := range newPodIPs {
+		newKeys = append(newKeys, ipcache.KeyWithVNI(podIP, vni))
+	}
+	keySliceEqual := ipSliceEqual && oldVNI == vni
+
 	defer func() {
-		if !ipSliceEqual {
-			// delete all IPs that were not added regardless if the insertion of the
+		if !keySliceEqual {
+			// delete all keys that were not added regardless if the insertion of the
 			// entry in the ipcache map was successful or not because we will not
 			// receive any other event with these old IP addresses.
 			for _, oldPodIP := range oldPodIPs {
-				var found bool
-				if slices.Contains(newPodIPs, oldPodIP) {
-					found = true
+				oldKey := ipcache.KeyWithVNI(oldPodIP, oldVNI)
+				if slices.Contains(newKeys, oldKey) {
+					continue
 				}
-				if !found {
-					npc := k.ipcache.Delete(ipcache.KeyWithVNI(oldPodIP, vni), source.Kubernetes)
-					if npc {
-						namedPortsChanged = true
-					}
+				npc := k.ipcache.Delete(oldKey, source.Kubernetes)
+				if npc {
+					namedPortsChanged = true
 				}
 			}
 		}
@@ -652,9 +663,10 @@ func (k *K8sPodWatcher) updatePodHostData(oldPod, newPod *slim_corev1.Pod, oldPo
 	specEqual := oldPod != nil && newPod.Spec.DeepEqual(&oldPod.Spec)
 	hostIPEqual := oldPod != nil && newPod.Status.HostIP == oldPod.Status.HostIP
 
-	// if spec, host IPs, and pod IPs are the same there no need to perform the remaining
-	// operations
-	if specEqual && hostIPEqual && ipSliceEqual {
+	// if spec, host IPs, and pod keys are the same there no need to perform the
+	// remaining operations. A VPC change makes the keys differ even when every
+	// address is unchanged, and the new key still has to be written.
+	if specEqual && hostIPEqual && keySliceEqual {
 		return nil
 	}
 

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -159,6 +159,22 @@ const (
 	// LabelSourceFQDN is the label source for IPs resolved by fqdn lookups
 	LabelSourceFQDN = "fqdn"
 
+	// LabelSourceVNI is the label source for the native-vpc identity label
+	// "vni:io-cilium-native-vpc-vni=<vni>". It is injected from the kube-ovn
+	// tunnel_key annotation and
+	// gives the policy/identity layer the same VNI scope used by the
+	// (VNI, IP) ipcache/datapath key. VNI is a logical-switch/subnet property;
+	// it must not be confused with kube-ovn's aggregate VPC object (one VPC can
+	// contain several subnets with different VNIs).
+	LabelSourceVNI = "vni"
+
+	// VNIKey is the internal label key used with LabelSourceVNI. Use a
+	// Cilium-owned, collision-resistant key rather than the generic "vni":
+	// Labels is keyed by label Key (not Source), so a user Kubernetes label
+	// named "vni" could otherwise prevent the mandatory VNI source label from
+	// being injected and collapse identities across VNIs.
+	VNIKey = "io-cilium-native-vpc-vni"
+
 	// LabelSourceReservedKeyPrefix is the prefix of a reserved label
 	LabelSourceReservedKeyPrefix = LabelSourceReserved + "."
 

--- a/pkg/labelsfilter/filter.go
+++ b/pkg/labelsfilter/filter.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 var (
@@ -27,8 +28,13 @@ const (
 	// LPCfgFileVersion represents the version of a Label Prefix Configuration File
 	LPCfgFileVersion = 1
 
-	// reservedLabelsPattern is the prefix pattern for all reserved labels
+	// reservedLabelsPattern is the prefix pattern for all reserved labels.
 	reservedLabelsPattern = labels.LabelSourceReserved + ":.*"
+	// vniLabelsPattern is the mandatory identity prefix for native-vpc: the
+	// VNI identity label is the policy-plane subnet/logical-switch discriminator
+	// and must never be demoted to an information label by --labels whitelist
+	// configuration.
+	vniLabelsPattern = labels.LabelSourceVNI + ":.*"
 )
 
 // LabelPrefix is the cilium's representation of a container label.
@@ -189,6 +195,15 @@ func ParseLabelPrefixCfg(logger *slog.Logger, prefixes, nodePrefixes []string, f
 		}
 	}
 
+	// Native-vpc policy correctness requires VNI identity label to remain an identity
+	// label even in whitelist mode. Append the required prefixes to the final
+	// list for diagnostics/visibility; filterLabels below also hard-keeps the
+	// sources so an explicit ignore rule cannot override the invariant.
+	if option.Config.EnableNativeVPC {
+		ensureLabelPrefix(cfg, reservedLabelsPattern)
+		ensureLabelPrefix(cfg, vniLabelsPattern)
+	}
+
 	validLabelPrefixes = cfg
 	validNodeLabelPrefixes = nodeCfg
 
@@ -214,6 +229,22 @@ type labelPrefixCfg struct {
 	// whitelist if true, indicates that an inclusive rule has to match
 	// in order for the label to be considered
 	whitelist bool `exhaustruct:"optional"`
+}
+
+// ensureLabelPrefix appends an inclusive required prefix if it is not already
+// present. It is used for identity dimensions that policy correctness depends
+// on (reserved labels and, in native-vpc mode, the VNI identity label).
+func ensureLabelPrefix(cfg *labelPrefixCfg, pattern string) {
+	for _, p := range cfg.LabelPrefixes {
+		if !p.Ignore && p.Source+":"+p.Prefix == pattern {
+			return
+		}
+	}
+	p, err := parseLabelPrefix(pattern)
+	if err != nil {
+		panic(fmt.Sprintf("BUG: unable to parse required label prefix %q: %s", pattern, err))
+	}
+	cfg.LabelPrefixes = append(cfg.LabelPrefixes, p)
 }
 
 // defaultLabelPrefixCfg returns a default LabelPrefixCfg using the latest
@@ -306,6 +337,17 @@ func (cfg *labelPrefixCfg) filterLabels(lbls labels.Labels) (identityLabels, inf
 	identityLabels = labels.Labels{}
 	informationLabels = labels.Labels{}
 	for k, v := range lbls {
+		// Security invariants override user filtering. Reserved labels are
+		// always identity labels. In native-vpc mode the VNI identity label is equally
+		// mandatory: demoting it would merge equal-labeled endpoints from
+		// different VNIs into one numeric identity and make fromEndpoints
+		// subnet-blind even though the ipcache/datapath remain VNI-scoped.
+		if v.Source == labels.LabelSourceReserved ||
+			(option.Config.EnableNativeVPC && v.Source == labels.LabelSourceVNI) {
+			identityLabels[k] = v
+			continue
+		}
+
 		included, ignored := 0, 0
 
 		for _, p := range cfg.LabelPrefixes {

--- a/pkg/labelsfilter/filter_test.go
+++ b/pkg/labelsfilter/filter_test.go
@@ -13,6 +13,7 @@ import (
 
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 func TestFilterLabels(t *testing.T) {
@@ -71,6 +72,36 @@ func TestFilterLabels(t *testing.T) {
 	// Making sure we are deep copying the labels
 	allLabels["id.lizards"] = labels.NewLabel("id.lizards", "web", "I can change this and doesn't affect any one")
 	require.Equal(t, wanted, filtered)
+}
+
+func TestNativeVPCMandatoryIdentityLabelsInWhitelistMode(t *testing.T) {
+	oldEnable := option.Config.EnableNativeVPC
+	t.Cleanup(func() { option.Config.EnableNativeVPC = oldEnable })
+	option.Config.EnableNativeVPC = true
+
+	// Inclusive entries enable whitelist mode. Explicit ignore rules for the
+	// two mandatory sources must not override their security invariants.
+	err := ParseLabelPrefixCfg(hivetest.Logger(t), []string{
+		"k8s:app",
+		labels.LabelSourceVNI + ":!.*",
+		labels.LabelSourceReserved + ":!.*",
+	}, nil, "")
+	require.NoError(t, err)
+
+	input := labels.Labels{
+		"app":             labels.NewLabel("app", "web", labels.LabelSourceK8s),
+		labels.VNIKey:     labels.NewLabel(labels.VNIKey, "36", labels.LabelSourceVNI),
+		labels.IDNameInit: labels.NewLabel(labels.IDNameInit, "", labels.LabelSourceReserved),
+		"other":           labels.NewLabel("other", "ignored", labels.LabelSourceK8s),
+	}
+	identityLabels, infoLabels := Filter(input)
+
+	require.Contains(t, identityLabels, "app")
+	require.Contains(t, identityLabels, labels.VNIKey,
+		"the VNI label must remain an identity label in whitelist mode")
+	require.Contains(t, identityLabels, labels.IDNameInit,
+		"reserved labels must remain identity labels in whitelist mode")
+	require.Contains(t, infoLabels, "other")
 }
 
 func TestDefaultFilterLabels(t *testing.T) {

--- a/pkg/maps/fragmap/fragmap.go
+++ b/pkg/maps/fragmap/fragmap.go
@@ -44,7 +44,7 @@ func newMap(registry *metrics.Registry, maxMapEntries int, getEventBufferConfig 
 	if option.Config.EnableIPv4FragmentsTracking {
 		m.bpfMapV4 = bpf.NewMap(mapNameIPv4,
 			ebpf.LRUHash,
-			&FragmentKey4{},
+			fragmentKey4(),
 			&FragmentValue4{},
 			maxMapEntries,
 			0,
@@ -70,7 +70,7 @@ func newMap(registry *metrics.Registry, maxMapEntries int, getEventBufferConfig 
 // This should only be used from components which aren't capable of using hive - mainly the cilium-dbg.
 // It needs to initialized beforehand via the Cilium Agent.
 func OpenMap4(logger *slog.Logger) (*bpf.Map, error) {
-	return bpf.OpenMap(bpf.MapPath(logger, mapNameIPv4), &FragmentKey4{}, &FragmentValue4{})
+	return bpf.OpenMap(bpf.MapPath(logger, mapNameIPv4), fragmentKey4(), &FragmentValue4{})
 }
 
 // OpenMap6 opens the pre-initialized IPv6 fragments map for access.
@@ -103,6 +103,53 @@ type FragmentKey4 struct {
 	ID         uint16     `align:"id"`
 	Proto      uint8      `align:"proto"`
 	_          uint8
+}
+
+// FragmentKey4NativeVPC is the native-vpc variant of FragmentKey4: the C
+// struct gains a VNI field when the datapath is compiled with
+// ENABLE_NATIVE_VPC, so that two pods sharing a source IP in different VPCs
+// cannot collide on the 16-bit IP identifier and have the non-first fragments
+// of one datagram classified with the other's L4 ports.
+//
+// The fields are repeated rather than embedded so that the C/Go align checker
+// verifies every field offset, not just the appended one.
+//
+// The agent only uses these types to create and dump the map, so selecting the
+// layout at map creation time is sufficient. Deployments without native-vpc
+// keep the upstream layout byte for byte.
+type FragmentKey4NativeVPC struct {
+	DestAddr   types.IPv4 `align:"daddr"`
+	SourceAddr types.IPv4 `align:"saddr"`
+	ID         uint16     `align:"id"`
+	Proto      uint8      `align:"proto"`
+	_          uint8      `align:"pad"`
+	VNI        uint32     `align:"vni"`
+}
+
+func (k *FragmentKey4NativeVPC) New() bpf.MapKey { return &FragmentKey4NativeVPC{} }
+
+func (k *FragmentKey4NativeVPC) NativeID() uint16 { return byteorder.NetworkToHost16(k.ID) }
+
+func (k *FragmentKey4NativeVPC) String() string {
+	return fmt.Sprintf("%s --> %s, %d, %d, vni:%d",
+		k.SourceAddr, k.DestAddr, k.Proto, k.NativeID(), k.VNI)
+}
+
+// FragmentKey4Type returns the map key layout matching the compiled datapath,
+// for consumers that need the type itself (map creation, the align checker).
+func FragmentKey4Type() any {
+	if option.Config.EnableNativeVPC {
+		return FragmentKey4NativeVPC{}
+	}
+	return FragmentKey4{}
+}
+
+// fragmentKey4 returns the map key layout matching the compiled datapath.
+func fragmentKey4() bpf.MapKey {
+	if option.Config.EnableNativeVPC {
+		return &FragmentKey4NativeVPC{}
+	}
+	return &FragmentKey4{}
 }
 
 // FragmentValue4 must match 'struct ipv4_frag_l4ports' in "bpf/lib/ipv4.h".

--- a/pkg/maps/fragmap/fragmap.go
+++ b/pkg/maps/fragmap/fragmap.go
@@ -6,6 +6,7 @@ package fragmap
 import (
 	"fmt"
 	"log/slog"
+	"unsafe"
 
 	"github.com/cilium/ebpf"
 
@@ -70,7 +71,28 @@ func newMap(registry *metrics.Registry, maxMapEntries int, getEventBufferConfig 
 // This should only be used from components which aren't capable of using hive - mainly the cilium-dbg.
 // It needs to initialized beforehand via the Cilium Agent.
 func OpenMap4(logger *slog.Logger) (*bpf.Map, error) {
-	return bpf.OpenMap(bpf.MapPath(logger, mapNameIPv4), fragmentKey4(), &FragmentValue4{})
+	path := bpf.MapPath(logger, mapNameIPv4)
+	return bpf.OpenMap(path, pinnedFragmentKey4(path), &FragmentValue4{})
+}
+
+// pinnedFragmentKey4 selects the key layout of the map that is actually pinned
+// on this node.
+//
+// The layout depends on whether the datapath was compiled with native-vpc (the
+// key then carries a VNI), and tools such as cilium-dbg do not share the
+// agent's configuration - deciding from option.Config alone would make them
+// decode the map with a key of the wrong size.
+func pinnedFragmentKey4(path string) bpf.MapKey {
+	if m, err := ebpf.LoadPinnedMap(path, nil); err == nil {
+		defer m.Close()
+		if m.KeySize() == uint32(unsafe.Sizeof(FragmentKey4NativeVPC{})) {
+			return &FragmentKey4NativeVPC{}
+		}
+		return &FragmentKey4{}
+	}
+	// The map is not pinned (yet): fall back to what this process is
+	// configured for.
+	return fragmentKey4()
 }
 
 // OpenMap6 opens the pre-initialized IPv6 fragments map for access.

--- a/pkg/maps/fragmap/native_vpc_test.go
+++ b/pkg/maps/fragmap/native_vpc_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
 package fragmap
 
 import (

--- a/pkg/maps/fragmap/native_vpc_test.go
+++ b/pkg/maps/fragmap/native_vpc_test.go
@@ -1,0 +1,29 @@
+package fragmap
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// TestFragmentKey4NativeVPCLayout pins the Go/C contract for both layouts of
+// cilium_ipv4_frag_datagrams: without native-vpc the key is byte-identical to
+// upstream, and with native-vpc it gains exactly the 4-byte VNI scope that
+// prevents two VPCs sharing a source IP from colliding on the IP identifier.
+func TestFragmentKey4NativeVPCLayout(t *testing.T) {
+	require.Equal(t, uintptr(12), unsafe.Sizeof(FragmentKey4{}),
+		"must match struct ipv4_frag_id without ENABLE_NATIVE_VPC")
+	require.Equal(t, uintptr(16), unsafe.Sizeof(FragmentKey4NativeVPC{}),
+		"must match struct ipv4_frag_id with ENABLE_NATIVE_VPC")
+
+	prev := option.Config.EnableNativeVPC
+	t.Cleanup(func() { option.Config.EnableNativeVPC = prev })
+
+	option.Config.EnableNativeVPC = false
+	require.IsType(t, &FragmentKey4{}, fragmentKey4())
+	option.Config.EnableNativeVPC = true
+	require.IsType(t, &FragmentKey4NativeVPC{}, fragmentKey4())
+}

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -131,13 +131,15 @@ func NewKey(ip net.IP, mask net.IPMask, clusterID uint16) Key {
 // Must be in sync with struct ipcache_vni_key in <bpf/lib/eps.h>.
 // The VNI is part of the LPM static prefix, so the trie matches on VNI+IP.
 //
-// Layout note: the trailing Pad2 field is REQUIRED. Go rounds the struct size
-// up to the field alignment (26 bytes -> 28), and getVniStaticPrefixBits()
-// derives the LPM static prefix from unsafe.Sizeof. Without an explicit pad,
-// Go computes 64 static bits while the packed C struct computes 48, so BPF
-// lookups in cilium_ipcache_vni never match Go-written entries (and the map
-// key size 28 vs 26 makes the agent-created map incompatible with the one in
-// the BPF ELF). Pad2 must be mirrored in the C struct.
+// Layout rule (identical to Key/struct ipcache_key): **every non-IP field must
+// precede the IP field**, because the LPM static prefix is derived from
+// sizeof(VniKey) - sizeof(Prefixlen) - sizeof(IP) and is then added to the IP
+// prefix length. Pad2 therefore sits before IP: it rounds the non-IP part to 8
+// bytes (the Go struct cannot be packed) and keeps both languages at a 64-bit
+// static prefix. With the padding after the IP the static prefix would be
+// inflated by 16 bits, which happens to work for host prefixes (the extra bits
+// land on zeroed padding) but makes any shorter prefix match only addresses
+// whose remaining bytes are zero.
 //
 // This is the "local ClusterID" split: upstream addresses overlapping IPs
 // across clusters with a cluster_id field in the ipcache key; here the
@@ -148,13 +150,16 @@ type VniKey struct {
 	Vni       uint32 `align:"vni"`
 	Pad1      uint8  `align:"pad1"`
 	Family    uint8  `align:"family"`
+	// Pad2 keeps the non-IP part at 8 bytes and unsafe.Sizeof(VniKey{}) equal
+	// to sizeof(struct ipcache_vni_key) (28 bytes).
+	Pad2 [2]byte `align:"pad2"`
 	// represents both IPv6 and IPv4 (in the lowest four bytes)
 	IP types.IPv6 `align:"$union0"`
-	// Pad2 keeps unsafe.Sizeof(VniKey{}) == sizeof(struct ipcache_vni_key)
-	// (28 bytes) and the static prefix at 64 bits on both sides.
-	Pad2 [2]byte `align:"pad2"`
 }
 
+// getVniStaticPrefixBits returns the number of LPM key bits that precede the
+// IP field. It must equal the byte offset of IP within the key data (i.e.
+// after Prefixlen) times 8; the test in this package pins that invariant.
 func getVniStaticPrefixBits() uint32 {
 	staticMatchSize := unsafe.Sizeof(VniKey{})
 	staticMatchSize -= unsafe.Sizeof(VniKey{}.Prefixlen)

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -125,6 +125,98 @@ func NewKey(ip net.IP, mask net.IPMask, clusterID uint16) Key {
 	return result
 }
 
+// VniKey implements the bpf.MapKey interface for the native-vpc VNI-scoped
+// ipcache map (cilium_ipcache_vni).
+//
+// Must be in sync with struct ipcache_vni_key in <bpf/lib/eps.h>.
+// The VNI is part of the LPM static prefix, so the trie matches on VNI+IP.
+//
+// Layout note: the trailing Pad2 field is REQUIRED. Go rounds the struct size
+// up to the field alignment (26 bytes -> 28), and getVniStaticPrefixBits()
+// derives the LPM static prefix from unsafe.Sizeof. Without an explicit pad,
+// Go computes 64 static bits while the packed C struct computes 48, so BPF
+// lookups in cilium_ipcache_vni never match Go-written entries (and the map
+// key size 28 vs 26 makes the agent-created map incompatible with the one in
+// the BPF ELF). Pad2 must be mirrored in the C struct.
+//
+// This is the "local ClusterID" split: upstream addresses overlapping IPs
+// across clusters with a cluster_id field in the ipcache key; here the
+// kube-ovn tunnel_key (VNI) plays that role for VPCs within one cluster,
+// without touching the cluster_id semantics (see ipcache.ipcache.go).
+type VniKey struct {
+	Prefixlen uint32 `align:"lpm_key"`
+	Vni       uint32 `align:"vni"`
+	Pad1      uint8  `align:"pad1"`
+	Family    uint8  `align:"family"`
+	// represents both IPv6 and IPv4 (in the lowest four bytes)
+	IP types.IPv6 `align:"$union0"`
+	// Pad2 keeps unsafe.Sizeof(VniKey{}) == sizeof(struct ipcache_vni_key)
+	// (28 bytes) and the static prefix at 64 bits on both sides.
+	Pad2 [2]byte `align:"pad2"`
+}
+
+func getVniStaticPrefixBits() uint32 {
+	staticMatchSize := unsafe.Sizeof(VniKey{})
+	staticMatchSize -= unsafe.Sizeof(VniKey{}.Prefixlen)
+	staticMatchSize -= unsafe.Sizeof(VniKey{}.IP)
+	return uint32(staticMatchSize) * 8
+}
+
+func getVniPrefixLen(prefixBits int) uint32 {
+	return getVniStaticPrefixBits() + uint32(prefixBits)
+}
+
+// NewVniKey returns a VniKey based on the provided IP address, mask, and VNI.
+// The address family is automatically detected.
+func NewVniKey(ip net.IP, mask net.IPMask, vni uint32) VniKey {
+	result := VniKey{}
+
+	ones, _ := mask.Size()
+	if ip4 := ip.To4(); ip4 != nil {
+		if mask == nil {
+			ones = net.IPv4len * 8
+		}
+		result.Prefixlen = getVniPrefixLen(ones)
+		result.Family = bpf.EndpointKeyIPv4
+		copy(result.IP[:], ip4)
+	} else {
+		if mask == nil {
+			ones = net.IPv6len * 8
+		}
+		result.Prefixlen = getVniPrefixLen(ones)
+		result.Family = bpf.EndpointKeyIPv6
+		copy(result.IP[:], ip)
+	}
+
+	result.Vni = vni
+
+	return result
+}
+
+func (k VniKey) String() string {
+	var (
+		addr netip.Addr
+		ok   bool
+	)
+
+	switch k.Family {
+	case bpf.EndpointKeyIPv4:
+		addr, ok = netip.AddrFromSlice(k.IP[:net.IPv4len])
+		if !ok {
+			return "<unknown>"
+		}
+	case bpf.EndpointKeyIPv6:
+		addr = netip.AddrFrom16(k.IP)
+	default:
+		return "<unknown>"
+	}
+
+	prefixLen := int(k.Prefixlen - getVniStaticPrefixBits())
+	return fmt.Sprintf("%s@vni:%d", netip.PrefixFrom(addr, prefixLen).String(), k.Vni)
+}
+
+func (k *VniKey) New() bpf.MapKey { return &VniKey{} }
+
 // RemoteEndpointInfoFlags represents various flags that can be attached to
 // remote endpoints in the IPCache.
 type RemoteEndpointInfoFlags uint8
@@ -299,4 +391,34 @@ func IPCacheMapV1() *Map {
 		}
 	})
 	return oldIPcache
+}
+
+// VniName is the canonical name for the native-vpc VNI-scoped IPCache map.
+// Entries are keyed by (VNI, IP) so that overlapping IPs from different VPCs
+// can coexist. It is only used in native-vpc mode.
+const VniName = "cilium_ipcache_vni"
+
+var (
+	vniIpcache     *Map
+	onceVniIpcache = &sync.Once{}
+)
+
+func newIPCacheVniMap(name string) *bpf.Map {
+	return bpf.NewMap(
+		name,
+		ebpf.LPMTrie,
+		&VniKey{},
+		&RemoteEndpointInfo{},
+		MaxEntries,
+		unix.BPF_F_NO_PREALLOC|unix.BPF_F_RDONLY_PROG)
+}
+
+// IPCacheVniMap gets the native-vpc VNI-scoped ipcache Map singleton.
+func IPCacheVniMap(registry *metrics.Registry) *Map {
+	onceVniIpcache.Do(func() {
+		vniIpcache = &Map{
+			Map: *newIPCacheVniMap(VniName).WithCache().WithPressureMetric(registry),
+		}
+	})
+	return vniIpcache
 }

--- a/pkg/maps/ipcache/ipcache_test.go
+++ b/pkg/maps/ipcache/ipcache_test.go
@@ -4,7 +4,13 @@
 package ipcache
 
 import (
+	"net"
 	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/bpf"
 )
 
 func TestRemoteEndpointInfoFlagsStringReturnsCorrectValue(t *testing.T) {
@@ -40,4 +46,55 @@ func TestRemoteEndpointInfoFlagsStringReturnsCorrectValue(t *testing.T) {
 			)
 		}
 	}
+}
+
+func TestVniKeyConstruction(t *testing.T) {
+	// Cross-language layout contract: struct ipcache_vni_key in bpf/lib/eps.h
+	// is __packed and MUST have the same size (28 bytes) so that the LPM
+	// static prefix (64 bits) computed by getVniStaticPrefixBits() matches
+	// IPCACHE_VNI_STATIC_PREFIX on the BPF side. If this fails, BPF lookups in
+	// cilium_ipcache_vni never match Go-written entries and the agent-created
+	// map is incompatible with the BPF ELF (ErrMapIncompatible).
+	require.Equal(t, uint64(28), uint64(unsafe.Sizeof(VniKey{})),
+		"VniKey size must stay in sync with struct ipcache_vni_key in bpf/lib/eps.h")
+	require.Equal(t, uint32(64), getVniStaticPrefixBits(),
+		"static prefix must match IPCACHE_VNI_STATIC_PREFIX (64 bits) in bpf/lib/eps.h")
+	require.Equal(t, uint64(10), uint64(unsafe.Offsetof(VniKey{}.IP)),
+		"IP offset must match the packed C union offset")
+
+	ip := net.ParseIP("192.168.1.2")
+	mask := net.CIDRMask(32, 32)
+	k := NewVniKey(ip, mask, 36)
+
+	require.Equal(t, uint32(36), k.Vni)
+	require.Equal(t, bpf.EndpointKeyIPv4, k.Family)
+	// static prefix (vni 32 + pad1 8 + family 8 + pad2 16) + /32
+	require.Equal(t, getVniStaticPrefixBits()+32, k.Prefixlen)
+	require.Equal(t, "192.168.1.2/32@vni:36", k.String())
+
+	// /24 CIDR entry in the VNI map.
+	k24 := NewVniKey(net.ParseIP("192.168.1.0"), net.CIDRMask(24, 32), 17)
+	require.Equal(t, getVniStaticPrefixBits()+24, k24.Prefixlen)
+	require.Equal(t, "192.168.1.0/24@vni:17", k24.String())
+
+	// IPv6.
+	k6 := NewVniKey(net.ParseIP("fd00::1"), net.CIDRMask(128, 128), 10)
+	require.Equal(t, bpf.EndpointKeyIPv6, k6.Family)
+	require.Equal(t, getVniStaticPrefixBits()+128, k6.Prefixlen)
+	require.Equal(t, "fd00::1/128@vni:10", k6.String())
+}
+
+func TestVniKeyDifferentVNIsAreDistinct(t *testing.T) {
+	ip := net.ParseIP("192.168.1.3")
+	mask := net.CIDRMask(32, 32)
+	a := NewVniKey(ip, mask, 36)
+	b := NewVniKey(ip, mask, 17)
+
+	// Same IP, different VNI -> different keys (the core of the fix).
+	require.NotEqual(t, a, b)
+	// Prefixlen encodes the LPM prefix length (static bits + IP bits) and is
+	// identical for both /32 entries; the VNI field is what distinguishes them.
+	require.Equal(t, a.Prefixlen, b.Prefixlen)
+	require.Equal(t, uint32(36), a.Vni)
+	require.Equal(t, uint32(17), b.Vni)
 }

--- a/pkg/maps/ipcache/ipcache_test.go
+++ b/pkg/maps/ipcache/ipcache_test.go
@@ -59,8 +59,16 @@ func TestVniKeyConstruction(t *testing.T) {
 		"VniKey size must stay in sync with struct ipcache_vni_key in bpf/lib/eps.h")
 	require.Equal(t, uint32(64), getVniStaticPrefixBits(),
 		"static prefix must match IPCACHE_VNI_STATIC_PREFIX (64 bits) in bpf/lib/eps.h")
-	require.Equal(t, uint64(10), uint64(unsafe.Offsetof(VniKey{}.IP)),
+	require.Equal(t, uint64(12), uint64(unsafe.Offsetof(VniKey{}.IP)),
 		"IP offset must match the packed C union offset")
+
+	// The real invariant behind the static prefix: it must cover exactly the
+	// key bits that precede the IP. If padding is placed after the IP the two
+	// numbers diverge, and every entry shorter than a host prefix silently
+	// stops matching (only addresses whose remaining bytes are zero would).
+	ipBitOffset := uint32(unsafe.Offsetof(VniKey{}.IP)-unsafe.Sizeof(VniKey{}.Prefixlen)) * 8
+	require.Equal(t, ipBitOffset, getVniStaticPrefixBits(),
+		"the static prefix must equal the bit offset of the IP field within the LPM key data")
 
 	ip := net.ParseIP("192.168.1.2")
 	mask := net.CIDRMask(32, 32)
@@ -72,10 +80,14 @@ func TestVniKeyConstruction(t *testing.T) {
 	require.Equal(t, getVniStaticPrefixBits()+32, k.Prefixlen)
 	require.Equal(t, "192.168.1.2/32@vni:36", k.String())
 
-	// /24 CIDR entry in the VNI map.
+	// /24 CIDR entry in the VNI map: the prefix length must cover the static
+	// part plus exactly 24 IP bits, so that the trie matches every address of
+	// the subnet and not only those ending in zero.
 	k24 := NewVniKey(net.ParseIP("192.168.1.0"), net.CIDRMask(24, 32), 17)
 	require.Equal(t, getVniStaticPrefixBits()+24, k24.Prefixlen)
 	require.Equal(t, "192.168.1.0/24@vni:17", k24.String())
+	require.Equal(t, uint32(unsafe.Offsetof(VniKey{}.IP)-unsafe.Sizeof(VniKey{}.Prefixlen))*8+24, k24.Prefixlen,
+		"a /24 must match on the first three IP bytes only")
 
 	// IPv6.
 	k6 := NewVniKey(net.ParseIP("fd00::1"), net.CIDRMask(128, 128), 10)

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -261,6 +261,31 @@ func (m *lxcMap) WriteEndpoint(f EndpointFrontend) error {
 	return nil
 }
 
+// ownsEntry reports whether the entry currently stored under key belongs to
+// the given endpoint id (or does not exist at all).
+//
+// cilium_lxc is keyed by the bare IP. In native-vpc mode two endpoints of
+// different VPCs may legitimately share an IP on the same node, in which case
+// the last writer wins. Deleting such a key unconditionally on endpoint
+// teardown would remove the *other* VPC's entry, so deletion is made
+// compare-and-delete. The map is not authoritative for the native-vpc pod
+// datapath (bpf_lxc skips the endpoint-map fast path when the endpoint has a
+// VNI, and kube-ovn owns the host and tunnel datapath); it is kept for
+// diagnostics and for the non-overlapping majority of entries.
+func (m *lxcMap) ownsEntry(key *EndpointKey, id uint16) bool {
+	value, err := m.bpfMap.Lookup(key)
+	if err != nil {
+		// Missing (or unreadable) entry: nothing of another endpoint can be
+		// destroyed by proceeding.
+		return true
+	}
+	info, ok := value.(*EndpointInfo)
+	if !ok {
+		return true
+	}
+	return info.LxcID == id
+}
+
 // addHostEntry adds a special endpoint which represents the local host
 func (m *lxcMap) addHostEntry(addr netip.Addr) error {
 	key := newEndpointKey(addr)
@@ -286,7 +311,17 @@ func (m *lxcMap) DeleteEntry(addr netip.Addr) error {
 
 func (m *lxcMap) DeleteElement(logger *slog.Logger, f EndpointFrontend) []error {
 	var errors []error
+	id := uint16(f.GetID())
 	for _, k := range m.getBPFKeys(f) {
+		// Native-vpc: never delete an entry that a different endpoint (an
+		// overlapping IP in another VPC) currently owns.
+		if option.Config.EnableNativeVPC && !m.ownsEntry(k, id) {
+			logger.Debug("skipping endpoint map deletion of an entry owned by another endpoint",
+				"key", k.String(),
+				"endpointID", id,
+			)
+			continue
+		}
 		if err := m.bpfMap.Delete(k); err != nil {
 			errors = append(errors, fmt.Errorf("unable to delete key %v from %s: %w", k, bpf.MapPath(logger, mapName), err))
 		}

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
@@ -317,8 +318,8 @@ func (m *lxcMap) DeleteElement(logger *slog.Logger, f EndpointFrontend) []error 
 		// overlapping IP in another VPC) currently owns.
 		if option.Config.EnableNativeVPC && !m.ownsEntry(k, id) {
 			logger.Debug("skipping endpoint map deletion of an entry owned by another endpoint",
-				"key", k.String(),
-				"endpointID", id,
+				logfields.Key, k.String(),
+				logfields.EndpointID, id,
 			)
 			continue
 		}

--- a/pkg/maps/lxcmap/lxcmap.go
+++ b/pkg/maps/lxcmap/lxcmap.go
@@ -127,6 +127,10 @@ type EndpointFrontend interface {
 	SkipMasqueradeV4() bool
 	// SkipMasqueradeV6 indicates whether this endpoint should skip IPv6 masquerade for remote traffic
 	SkipMasqueradeV6() bool
+	// GetVNIID is the native-vpc scope of the endpoint, 0 when it is not in a
+	// VPC. The endpoint map is keyed by address alone, so the scope decides
+	// whether this endpoint may be represented in it at all.
+	GetVNIID() uint64
 }
 
 // getBPFKeys returns all keys which should represent this endpoint in the BPF
@@ -241,6 +245,27 @@ func (v *EndpointInfo) String() string {
 func (v *EndpointInfo) New() bpf.MapValue { return &EndpointInfo{} }
 
 func (m *lxcMap) WriteEndpoint(f EndpointFrontend) error {
+	// An endpoint that lives in a VPC is not representable here: the key is the
+	// address alone, so the entries of two endpoints that share an address in
+	// different VPCs are the same entry, and the second one written destroys
+	// the first. The datapath already refuses to use this map for such an
+	// endpoint (bpf_lxc takes the local-delivery fast path only when its
+	// compiled VNI is zero), so there is nothing to represent - writing would
+	// only produce a shared, wrong answer to "which endpoint owns this
+	// address?".
+	if f.GetVNIID() != 0 {
+		// An entry may exist from an agent that predates this rule. Remove it,
+		// but only if this endpoint is the one it names: another VPC's endpoint
+		// may legitimately own it.
+		id := uint16(f.GetID())
+		for _, key := range m.getBPFKeys(f) {
+			if owned, exists := m.ownsEntry(key, id); owned && exists {
+				_ = m.bpfMap.Delete(key)
+			}
+		}
+		return nil
+	}
+
 	info, err := m.getBPFValue(f)
 	if err != nil {
 		return err
@@ -273,18 +298,22 @@ func (m *lxcMap) WriteEndpoint(f EndpointFrontend) error {
 // datapath (bpf_lxc skips the endpoint-map fast path when the endpoint has a
 // VNI, and kube-ovn owns the host and tunnel datapath); it is kept for
 // diagnostics and for the non-overlapping majority of entries.
-func (m *lxcMap) ownsEntry(key *EndpointKey, id uint16) bool {
+// ownsEntry reports whether the entry under key is the one this endpoint wrote,
+// and whether it exists at all. An endpoint may only remove what it owns: with
+// native-vpc the key is shared by every endpoint that has this address, whatever
+// VPC it is in.
+func (m *lxcMap) ownsEntry(key *EndpointKey, id uint16) (owned, exists bool) {
 	value, err := m.bpfMap.Lookup(key)
 	if err != nil {
 		// Missing (or unreadable) entry: nothing of another endpoint can be
-		// destroyed by proceeding.
-		return true
+		// destroyed by proceeding, and there is nothing to remove either.
+		return true, false
 	}
 	info, ok := value.(*EndpointInfo)
 	if !ok {
-		return true
+		return true, true
 	}
-	return info.LxcID == id
+	return info.LxcID == id, true
 }
 
 // addHostEntry adds a special endpoint which represents the local host
@@ -314,14 +343,21 @@ func (m *lxcMap) DeleteElement(logger *slog.Logger, f EndpointFrontend) []error 
 	var errors []error
 	id := uint16(f.GetID())
 	for _, k := range m.getBPFKeys(f) {
-		// Native-vpc: never delete an entry that a different endpoint (an
-		// overlapping IP in another VPC) currently owns.
-		if option.Config.EnableNativeVPC && !m.ownsEntry(k, id) {
-			logger.Debug("skipping endpoint map deletion of an entry owned by another endpoint",
-				logfields.Key, k.String(),
-				logfields.EndpointID, id,
-			)
-			continue
+		if option.Config.EnableNativeVPC {
+			owned, exists := m.ownsEntry(k, id)
+			if !exists {
+				// An endpoint in a VPC never wrote one (see WriteEndpoint), so
+				// its removal is complete before it starts. Reporting a missing
+				// key as a failure would make every such deletion look broken.
+				continue
+			}
+			if !owned {
+				logger.Debug("skipping endpoint map deletion of an entry owned by another endpoint",
+					logfields.Key, k.String(),
+					logfields.EndpointID, id,
+				)
+				continue
+			}
 		}
 		if err := m.bpfMap.Delete(k); err != nil {
 			errors = append(errors, fmt.Errorf("unable to delete key %v from %s: %w", k, bpf.MapPath(logger, mapName), err))

--- a/pkg/maps/lxcmap/lxcmap_vni_privileged_test.go
+++ b/pkg/maps/lxcmap/lxcmap_vni_privileged_test.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package lxcmap
+
+import (
+	"net/netip"
+	"os"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/cilium/hive/hivetest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/ebpf"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/mac"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+// vniFrontend is the minimum an endpoint has to answer to be written into the
+// endpoint map.
+type vniFrontend struct {
+	id   uint64
+	ipv4 netip.Addr
+	vni  uint64
+}
+
+func (f vniFrontend) LXCMac() mac.MAC                       { return mac.MAC{0, 1, 2, 3, 4, 5} }
+func (f vniFrontend) GetNodeMAC() mac.MAC                   { return mac.MAC{6, 7, 8, 9, 10, 11} }
+func (f vniFrontend) GetIfIndex() int                       { return 7 }
+func (f vniFrontend) GetParentIfIndex() int                 { return 0 }
+func (f vniFrontend) GetID() uint64                         { return f.id }
+func (f vniFrontend) IPv4Address() netip.Addr               { return f.ipv4 }
+func (f vniFrontend) IPv6Address() netip.Addr               { return netip.Addr{} }
+func (f vniFrontend) GetIdentity() identity.NumericIdentity { return identity.NumericIdentity(1000) }
+func (f vniFrontend) IsAtHostNS() bool                      { return false }
+func (f vniFrontend) SkipMasqueradeV4() bool                { return false }
+func (f vniFrontend) SkipMasqueradeV6() bool                { return false }
+func (f vniFrontend) GetVNIID() uint64                      { return f.vni }
+
+// setupVNITest builds an endpoint map of its own. It deliberately does not use
+// the production name: that map is pinned, so a test opening it would be
+// editing the endpoint map of an agent running on the same machine.
+func setupVNITest(tb testing.TB) *lxcMap {
+	testutils.PrivilegedTest(tb)
+	bpf.CheckOrMountFS(hivetest.Logger(tb), "")
+	require.NoError(tb, rlimit.RemoveMemlock())
+
+	m := &lxcMap{bpfMap: bpf.NewMap(
+		"test_"+mapName+"_"+strconv.Itoa(os.Getpid())+"_"+strconv.Itoa(int(testCounter.Add(1))),
+		ebpf.Hash, &EndpointKey{}, &EndpointInfo{}, MaxEntries, 0,
+	)}
+	require.NoError(tb, m.bpfMap.CreateUnpinned())
+	tb.Cleanup(func() { _ = m.bpfMap.Close() })
+	return m
+}
+
+var testCounter atomic.Int32
+
+func countEntries(tb testing.TB, m *lxcMap) int {
+	entries, err := m.DumpToMap()
+	require.NoError(tb, err)
+	return len(entries)
+}
+
+// TestPrivilegedWriteEndpointVPCScope covers the rule that decides whether an
+// endpoint belongs in this map at all.
+//
+// The key is the address with no room for a scope, so two endpoints that share
+// an address in different VPCs would be one entry: the second CNI ADD would
+// take over the first one's entry, and the first one's CNI DEL would then find
+// an entry it does not own. An endpoint that is in a VPC therefore creates no
+// entry here, which is also what the datapath assumes - it consults this map
+// only for endpoints whose compiled VNI is zero.
+func TestPrivilegedWriteEndpointVPCScope(t *testing.T) {
+	addr := netip.MustParseAddr("10.99.0.12")
+
+	t.Run("an endpoint outside any VPC is represented", func(t *testing.T) {
+		m := setupVNITest(t)
+		require.NoError(t, m.WriteEndpoint(vniFrontend{id: 1, ipv4: addr}))
+		require.Equal(t, 1, countEntries(t, m))
+
+		require.Empty(t, m.DeleteElement(hivetest.Logger(t), vniFrontend{id: 1, ipv4: addr}))
+		require.Zero(t, countEntries(t, m))
+	})
+
+	t.Run("endpoints sharing an address in different VPCs create nothing", func(t *testing.T) {
+		prev := option.Config.EnableNativeVPC
+		option.Config.EnableNativeVPC = true
+		t.Cleanup(func() { option.Config.EnableNativeVPC = prev })
+		m := setupVNITest(t)
+		for _, vni := range []uint64{5, 7, 9} {
+			require.NoError(t, m.WriteEndpoint(vniFrontend{id: vni, ipv4: addr, vni: vni}))
+		}
+		require.Zero(t, countEntries(t, m),
+			"any entry would answer for whichever endpoint happened to write last")
+
+		// And a CNI DEL of one of them cannot affect the others.
+		require.Empty(t, m.DeleteElement(hivetest.Logger(t), vniFrontend{id: 7, ipv4: addr, vni: 7}))
+		require.Zero(t, countEntries(t, m))
+	})
+
+	t.Run("an entry left by an older agent is reclaimed by its owner", func(t *testing.T) {
+		m := setupVNITest(t)
+		require.NoError(t, m.WriteEndpoint(vniFrontend{id: 42, ipv4: addr}))
+		require.Equal(t, 1, countEntries(t, m))
+
+		// The same endpoint, now known to be in a VPC.
+		require.NoError(t, m.WriteEndpoint(vniFrontend{id: 42, ipv4: addr, vni: 5}))
+		require.Zero(t, countEntries(t, m))
+	})
+
+	t.Run("an entry owned by another endpoint is left alone", func(t *testing.T) {
+		m := setupVNITest(t)
+		require.NoError(t, m.WriteEndpoint(vniFrontend{id: 42, ipv4: addr}))
+
+		require.NoError(t, m.WriteEndpoint(vniFrontend{id: 43, ipv4: addr, vni: 5}))
+		require.Equal(t, 1, countEntries(t, m),
+			"endpoint 43 must not remove the entry endpoint 42 owns")
+	})
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -292,6 +292,13 @@ var (
 	// EndpointStateCount is the total count of the endpoints in various states.
 	EndpointStateCount = NoOpGaugeVec
 
+	// NativeVPCOverlappingIPs is the number of IP addresses on this node that
+	// are used by more than one local endpoint in different native-vpc VNIs.
+	// It is the precondition for conntrack entry sharing between VPCs (the CT
+	// key is the bare 5-tuple), so it must be alerted on. See
+	// Documentation/network/native-vpc.rst.
+	NativeVPCOverlappingIPs = NoOpGauge
+
 	// EndpointRegenerationTimeStats is the total time taken to regenerate
 	// endpoints, labeled by span name and status ("success" or "failure")
 	EndpointRegenerationTimeStats = NoOpObserverVec
@@ -624,6 +631,7 @@ type LegacyMetrics struct {
 	Endpoint                         metric.GaugeFunc
 	EndpointRegenerationTotal        metric.Vec[metric.Counter]
 	EndpointStateCount               metric.Vec[metric.Gauge]
+	NativeVPCOverlappingIPs          metric.Gauge
 	EndpointRegenerationTimeStats    metric.Vec[metric.Observer]
 	EndpointPropagationDelay         metric.Vec[metric.Observer]
 	Policy                           metric.Gauge
@@ -733,6 +741,13 @@ func NewLegacyMetrics() *LegacyMetrics {
 		},
 			[]string{"endpoint_state"},
 		),
+
+		NativeVPCOverlappingIPs: metric.NewGauge(metric.GaugeOpts{
+			ConfigName: Namespace + "_native_vpc_overlapping_ips",
+			Namespace:  Namespace,
+			Name:       "native_vpc_overlapping_ips",
+			Help:       "Number of IP addresses used by more than one local endpoint in different native-vpc VNIs. Conntrack entries are keyed by the bare 5-tuple, so a non-zero value means connections of different VPCs can share CT state on this node",
+		}),
 
 		EndpointRegenerationTimeStats: metric.NewHistogramVec(metric.HistogramOpts{
 			ConfigName: Namespace + "_endpoint_regeneration_time_stats_seconds",
@@ -1276,6 +1291,7 @@ func NewLegacyMetrics() *LegacyMetrics {
 	Endpoint = lm.Endpoint
 	EndpointRegenerationTotal = lm.EndpointRegenerationTotal
 	EndpointStateCount = lm.EndpointStateCount
+	NativeVPCOverlappingIPs = lm.NativeVPCOverlappingIPs
 	EndpointRegenerationTimeStats = lm.EndpointRegenerationTimeStats
 	EndpointPropagationDelay = lm.EndpointPropagationDelay
 	Policy = lm.Policy

--- a/pkg/monitor/api/types.go
+++ b/pkg/monitor/api/types.go
@@ -365,11 +365,14 @@ type IPCacheNotification struct {
 	EncryptKey uint8  `json:"encrypt-key"`
 	Namespace  string `json:"namespace,omitempty"`
 	PodName    string `json:"pod-name,omitempty"`
+	// Vni is the native-vpc VNI of the entry, so monitor/hubble events can
+	// distinguish overlapping IPs from different VPCs.
+	Vni uint32 `json:"vni,omitempty"`
 }
 
 // IPCacheUpsertedMessage constructs an agent notification message for ipcache upsertions
 func IPCacheUpsertedMessage(cidr string, id uint32, oldID *uint32, hostIP net.IP, oldHostIP net.IP,
-	encryptKey uint8, namespace, podName string) AgentNotifyMessage {
+	encryptKey uint8, namespace, podName string, vni uint32) AgentNotifyMessage {
 	notification := IPCacheNotification{
 		CIDR:        cidr,
 		Identity:    id,
@@ -379,6 +382,7 @@ func IPCacheUpsertedMessage(cidr string, id uint32, oldID *uint32, hostIP net.IP
 		EncryptKey:  encryptKey,
 		Namespace:   namespace,
 		PodName:     podName,
+		Vni:         vni,
 	}
 
 	return AgentNotifyMessage{
@@ -389,7 +393,7 @@ func IPCacheUpsertedMessage(cidr string, id uint32, oldID *uint32, hostIP net.IP
 
 // IPCacheDeletedMessage constructs an agent notification message for ipcache deletions
 func IPCacheDeletedMessage(cidr string, id uint32, oldID *uint32, hostIP net.IP, oldHostIP net.IP,
-	encryptKey uint8, namespace, podName string) AgentNotifyMessage {
+	encryptKey uint8, namespace, podName string, vni uint32) AgentNotifyMessage {
 	notification := IPCacheNotification{
 		CIDR:        cidr,
 		Identity:    id,
@@ -399,6 +403,7 @@ func IPCacheDeletedMessage(cidr string, id uint32, oldID *uint32, hostIP net.IP,
 		EncryptKey:  encryptKey,
 		Namespace:   namespace,
 		PodName:     podName,
+		Vni:         vni,
 	}
 
 	return AgentNotifyMessage{

--- a/pkg/nativevpc/annotation.go
+++ b/pkg/nativevpc/annotation.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// Package nativevpc holds the single interpretation of the kube-ovn
+// tunnel_key pod annotation for native-vpc mode.
+//
+// The annotation is the single source of truth for the VNI of a pod, and it is
+// read on several planes: endpoint creation and restore (control plane), the
+// pod watcher (cache plane) and, indirectly, the datapath and observability
+// planes. Every reader must apply the *same* decision table, otherwise the
+// planes diverge - e.g. an out-of-range value that endpoint creation rejects
+// but the pod watcher accepts would register an ipcache entry under a VNI that
+// no endpoint has.
+package nativevpc
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// MaxVNI is the upper bound for a native-vpc VNI (Virtual Network Identifier).
+// A Geneve/VXLAN VNI is a 24-bit value, and kube-ovn's tunnel_key uses the
+// same space.
+const MaxVNI = uint64(1<<24) - 1
+
+// Result describes the outcome of reading the tunnel_key annotation of a pod.
+type Result int
+
+const (
+	// NotInVPC means the pod is structurally not part of any VPC: it uses the
+	// host network stack. This is authoritative and immutable.
+	NotInVPC Result = iota
+	// Absent means the annotation is missing. kube-ovn guarantees a non-zero
+	// tunnel_key on every non-hostNetwork pod before CNI ADD, so this only
+	// happens for legacy pods, a stale pod object, or an error on the kube-ovn
+	// side.
+	Absent
+	// Invalid means the annotation is present but is 0, unparsable or out of
+	// range. It always violates the kube-ovn guarantee.
+	Invalid
+	// Valid means the annotation carries a usable VNI.
+	Valid
+)
+
+// VNIFromPod applies the native-vpc decision table to a pod and returns the
+// VNI (0 unless the result is Valid), the classification, and a descriptive
+// error for the Invalid case.
+//
+// Callers decide what to do with each result, but the direction is fixed:
+// never merge a VPC endpoint into the plain (bare-IP) scope on Absent or
+// Invalid, because that is the direction that mixes two VPCs. Endpoint
+// creation rejects the pod, the running-state paths keep the last known VNI,
+// and the pod watcher skips registration.
+func VNIFromPod(pod *slim_corev1.Pod) (uint64, Result, error) {
+	if !option.Config.EnableNativeVPC || option.Config.NativeVPCVNIAnnotation == "" {
+		return 0, NotInVPC, nil
+	}
+	if pod == nil {
+		return 0, Absent, nil
+	}
+	if pod.Spec.HostNetwork {
+		return 0, NotInVPC, nil
+	}
+
+	key := option.Config.NativeVPCVNIAnnotation
+	raw, ok := pod.Annotations[key]
+	if !ok || strings.TrimSpace(raw) == "" {
+		return 0, Absent, nil
+	}
+
+	vni, err := strconv.ParseUint(strings.TrimSpace(raw), 10, 64)
+	switch {
+	case err != nil:
+		return 0, Invalid, fmt.Errorf("annotation %q value %q is not a number: %w", key, raw, err)
+	case vni == 0:
+		return 0, Invalid, fmt.Errorf("annotation %q is 0: kube-ovn only ever writes a non-zero tunnel_key", key)
+	case vni > MaxVNI:
+		return 0, Invalid, fmt.Errorf("annotation %q value %d exceeds the maximum VNI (%d)", key, vni, MaxVNI)
+	}
+	return vni, Valid, nil
+}

--- a/pkg/nativevpc/annotation.go
+++ b/pkg/nativevpc/annotation.go
@@ -28,12 +28,21 @@ import (
 const MaxVNI = uint64(1<<24) - 1
 
 // Result describes the outcome of reading the tunnel_key annotation of a pod.
+//
+// The cases are kept apart on purpose: a caller must never have to re-derive
+// one of them (for example by looking at pod.Spec.HostNetwork itself), because
+// that is how the readers drifted apart before this package existed.
 type Result int
 
 const (
-	// NotInVPC means the pod is structurally not part of any VPC: it uses the
-	// host network stack. This is authoritative and immutable.
-	NotInVPC Result = iota
+	// Disabled means native-vpc is not in use, so every caller must behave
+	// exactly as it did before the feature existed.
+	Disabled Result = iota
+	// HostNetwork means the pod is structurally not part of any VPC: it uses
+	// the host network stack. Unlike a missing annotation this is immutable
+	// and authoritative, so it is the one signal that may reset an existing
+	// VPC scope to none.
+	HostNetwork
 	// Absent means the annotation is missing. kube-ovn guarantees a non-zero
 	// tunnel_key on every non-hostNetwork pod before CNI ADD, so this only
 	// happens for legacy pods, a stale pod object, or an error on the kube-ovn
@@ -57,13 +66,13 @@ const (
 // and the pod watcher skips registration.
 func VNIFromPod(pod *slim_corev1.Pod) (uint64, Result, error) {
 	if !option.Config.EnableNativeVPC || option.Config.NativeVPCVNIAnnotation == "" {
-		return 0, NotInVPC, nil
+		return 0, Disabled, nil
 	}
 	if pod == nil {
 		return 0, Absent, nil
 	}
 	if pod.Spec.HostNetwork {
-		return 0, NotInVPC, nil
+		return 0, HostNetwork, nil
 	}
 
 	key := option.Config.NativeVPCVNIAnnotation

--- a/pkg/nativevpc/annotation_test.go
+++ b/pkg/nativevpc/annotation_test.go
@@ -56,7 +56,7 @@ func TestVNIFromPod(t *testing.T) {
 		{name: "not a number", pod: pod("abc", false), wantRes: Invalid},
 		{name: "out of range", pod: pod("16777216", false), wantRes: Invalid},
 		{name: "way out of range", pod: pod("4294967295", false), wantRes: Invalid},
-		{name: "hostNetwork", pod: pod("36", true), wantRes: NotInVPC},
+		{name: "hostNetwork", pod: pod("36", true), wantRes: HostNetwork},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			vni, res, err := VNIFromPod(tc.pod)
@@ -75,7 +75,7 @@ func TestVNIFromPod(t *testing.T) {
 		defer func() { option.Config.EnableNativeVPC = true }()
 		vni, res, err := VNIFromPod(pod("36", false))
 		require.NoError(t, err)
-		require.Equal(t, NotInVPC, res)
+		require.Equal(t, Disabled, res, "callers must be able to tell 'mode off' from 'not in a VPC'")
 		require.Zero(t, vni)
 	})
 
@@ -84,6 +84,6 @@ func TestVNIFromPod(t *testing.T) {
 		defer func() { option.Config.NativeVPCVNIAnnotation = "ovn.kubernetes.io/tunnel_key" }()
 		_, res, err := VNIFromPod(pod("36", false))
 		require.NoError(t, err)
-		require.Equal(t, NotInVPC, res)
+		require.Equal(t, Disabled, res)
 	})
 }

--- a/pkg/nativevpc/annotation_test.go
+++ b/pkg/nativevpc/annotation_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package nativevpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// TestVNIFromPod pins the single decision table shared by endpoint creation,
+// endpoint restore and the pod watcher. Before it existed, the three readers
+// validated differently: the pod watcher accepted out-of-range values that
+// endpoint creation rejected, so the cache plane could hold an entry under a
+// VNI that no endpoint had.
+func TestVNIFromPod(t *testing.T) {
+	prevEnabled, prevKey := option.Config.EnableNativeVPC, option.Config.NativeVPCVNIAnnotation
+	option.Config.EnableNativeVPC = true
+	option.Config.NativeVPCVNIAnnotation = "ovn.kubernetes.io/tunnel_key"
+	t.Cleanup(func() {
+		option.Config.EnableNativeVPC = prevEnabled
+		option.Config.NativeVPCVNIAnnotation = prevKey
+	})
+
+	pod := func(value string, hostNetwork bool) *slim_corev1.Pod {
+		p := &slim_corev1.Pod{
+			ObjectMeta: slim_metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+			Spec:       slim_corev1.PodSpec{HostNetwork: hostNetwork},
+		}
+		if value != "<none>" {
+			p.Annotations = map[string]string{option.Config.NativeVPCVNIAnnotation: value}
+		}
+		return p
+	}
+
+	for _, tc := range []struct {
+		name    string
+		pod     *slim_corev1.Pod
+		wantVNI uint64
+		wantRes Result
+	}{
+		{name: "valid", pod: pod("36", false), wantVNI: 36, wantRes: Valid},
+		{name: "valid with spaces", pod: pod(" 36 ", false), wantVNI: 36, wantRes: Valid},
+		{name: "max", pod: pod("16777215", false), wantVNI: MaxVNI, wantRes: Valid},
+		{name: "absent", pod: pod("<none>", false), wantRes: Absent},
+		{name: "empty", pod: pod("", false), wantRes: Absent},
+		{name: "blank", pod: pod("   ", false), wantRes: Absent},
+		{name: "nil pod", pod: nil, wantRes: Absent},
+		{name: "zero", pod: pod("0", false), wantRes: Invalid},
+		{name: "negative", pod: pod("-1", false), wantRes: Invalid},
+		{name: "not a number", pod: pod("abc", false), wantRes: Invalid},
+		{name: "out of range", pod: pod("16777216", false), wantRes: Invalid},
+		{name: "way out of range", pod: pod("4294967295", false), wantRes: Invalid},
+		{name: "hostNetwork", pod: pod("36", true), wantRes: NotInVPC},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			vni, res, err := VNIFromPod(tc.pod)
+			require.Equal(t, tc.wantRes, res)
+			require.Equal(t, tc.wantVNI, vni)
+			if tc.wantRes == Invalid {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+
+	t.Run("disabled mode is inert", func(t *testing.T) {
+		option.Config.EnableNativeVPC = false
+		defer func() { option.Config.EnableNativeVPC = true }()
+		vni, res, err := VNIFromPod(pod("36", false))
+		require.NoError(t, err)
+		require.Equal(t, NotInVPC, res)
+		require.Zero(t, vni)
+	})
+
+	t.Run("empty annotation key is inert", func(t *testing.T) {
+		option.Config.NativeVPCVNIAnnotation = ""
+		defer func() { option.Config.NativeVPCVNIAnnotation = "ovn.kubernetes.io/tunnel_key" }()
+		_, res, err := VNIFromPod(pod("36", false))
+		require.NoError(t, err)
+		require.Equal(t, NotInVPC, res)
+	})
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2278,6 +2278,14 @@ func (c *DaemonConfig) validateNativeVPC() error {
 		// across nodes.
 		return fmt.Errorf("native-vpc mode is incompatible with --%s: CiliumEndpointSlice cannot carry the per-endpoint VNI", EnableCiliumEndpointSlice)
 	}
+	if c.EnableEndpointRoutes {
+		// A per-endpoint route is a kernel route to the address, and the
+		// routing table has no notion of a VPC: the endpoints sharing an
+		// address would install one route between them, so the last one to
+		// regenerate would receive the traffic of all of them and the first
+		// CNI DEL would remove the route the others still need.
+		return fmt.Errorf("native-vpc mode is incompatible with --%s: a per-endpoint route is keyed by address alone, which overlapping VPC subnets make ambiguous", EnableEndpointRoutes)
+	}
 	return nil
 }
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2253,10 +2253,23 @@ func (c *DaemonConfig) Validate(vp *viper.Viper) error {
 		return err
 	}
 
-	if c.EnableNativeVPC && c.NativeVPCVNIAnnotation == "" {
-		return fmt.Errorf("native-vpc mode is enabled but --%s is empty", NativeVPCVNIAnnotationName)
+	if err := c.validateNativeVPC(); err != nil {
+		return err
 	}
 
+	return nil
+}
+
+func (c *DaemonConfig) validateNativeVPC() error {
+	if !c.EnableNativeVPC {
+		return nil
+	}
+	if c.NativeVPCVNIAnnotation == "" {
+		return fmt.Errorf("native-vpc mode is enabled but --%s is empty", NativeVPCVNIAnnotationName)
+	}
+	if c.TunnelingEnabled() {
+		return fmt.Errorf("native-vpc mode requires --%s=%s: kube-ovn owns the host/tunnel datapath and Cilium bpf_overlay uses a plain-IP ipcache", RoutingMode, RoutingModeNative)
+	}
 	return nil
 }
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2270,6 +2270,14 @@ func (c *DaemonConfig) validateNativeVPC() error {
 	if c.TunnelingEnabled() {
 		return fmt.Errorf("native-vpc mode requires --%s=%s: kube-ovn owns the host/tunnel datapath and Cilium bpf_overlay uses a plain-IP ipcache", RoutingMode, RoutingModeNative)
 	}
+	if c.EnableCiliumEndpointSlice {
+		// CiliumEndpointSlice packs endpoints as CoreCiliumEndpoint, which
+		// carries no object metadata and therefore cannot transport the
+		// native-vpc VNI annotation. Remote endpoints would silently be
+		// registered without a VNI (or skipped), breaking identity resolution
+		// across nodes.
+		return fmt.Errorf("native-vpc mode is incompatible with --%s: CiliumEndpointSlice cannot carry the per-endpoint VNI", EnableCiliumEndpointSlice)
+	}
 	return nil
 }
 

--- a/pkg/option/native_vpc_test.go
+++ b/pkg/option/native_vpc_test.go
@@ -43,6 +43,18 @@ func TestValidateNativeVPC(t *testing.T) {
 			wantErr: "enable-cilium-endpoint-slice",
 		},
 		{
+			// A per-endpoint route is a kernel route to the address, and the
+			// routing table cannot express which VPC that address belongs to.
+			name: "per-endpoint routes rejected",
+			config: DaemonConfig{
+				EnableNativeVPC:        true,
+				NativeVPCVNIAnnotation: "ovn.kubernetes.io/tunnel_key",
+				RoutingMode:            RoutingModeNative,
+				EnableEndpointRoutes:   true,
+			},
+			wantErr: "enable-endpoint-routes",
+		},
+		{
 			name: "native routing accepted",
 			config: DaemonConfig{
 				EnableNativeVPC:        true,

--- a/pkg/option/native_vpc_test.go
+++ b/pkg/option/native_vpc_test.go
@@ -33,6 +33,16 @@ func TestValidateNativeVPC(t *testing.T) {
 			wantErr: "routing-mode=native",
 		},
 		{
+			name: "cilium endpoint slice rejected",
+			config: DaemonConfig{
+				EnableNativeVPC:           true,
+				NativeVPCVNIAnnotation:    "ovn.kubernetes.io/tunnel_key",
+				RoutingMode:               RoutingModeNative,
+				EnableCiliumEndpointSlice: true,
+			},
+			wantErr: "enable-cilium-endpoint-slice",
+		},
+		{
 			name: "native routing accepted",
 			config: DaemonConfig{
 				EnableNativeVPC:        true,

--- a/pkg/option/native_vpc_test.go
+++ b/pkg/option/native_vpc_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package option
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateNativeVPC(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  DaemonConfig
+		wantErr string
+	}{
+		{
+			name: "missing annotation",
+			config: DaemonConfig{
+				EnableNativeVPC: true,
+				RoutingMode:     RoutingModeNative,
+			},
+			wantErr: "native-vpc-vni-annotation",
+		},
+		{
+			name: "tunnel mode rejected",
+			config: DaemonConfig{
+				EnableNativeVPC:        true,
+				NativeVPCVNIAnnotation: "ovn.kubernetes.io/tunnel_key",
+				RoutingMode:            RoutingModeTunnel,
+			},
+			wantErr: "routing-mode=native",
+		},
+		{
+			name: "native routing accepted",
+			config: DaemonConfig{
+				EnableNativeVPC:        true,
+				NativeVPCVNIAnnotation: "ovn.kubernetes.io/tunnel_key",
+				RoutingMode:            RoutingModeNative,
+			},
+		},
+		{
+			name: "native-vpc disabled ignores routing mode",
+			config: DaemonConfig{
+				EnableNativeVPC: false,
+				RoutingMode:     RoutingModeTunnel,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.validateNativeVPC()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/policy/api/vni_label_test.go
+++ b/pkg/policy/api/vni_label_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package api_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy/api"
+	types "github.com/cilium/cilium/pkg/policy/types"
+)
+
+// TestVNILabelSelectorMatch verifies that the control plane injects a VNI
+// identity label (source "vni", key labels.VNIKey, value "<vni>"), and a
+// CNP selector on labels.VNIKey selects exactly that logical
+// switch/subnet scope. Different VNIs must not match, even if they belong to
+// the same aggregate kube-ovn VPC.
+func TestVNILabelSelectorMatch(t *testing.T) {
+	vniLabel := labels.NewLabel(labels.VNIKey, "36", labels.LabelSourceVNI)
+	require.Equal(t, "vni:io-cilium-native-vpc-vni=36", vniLabel.String())
+
+	es := api.NewESFromMatchRequirements(map[string]string{labels.VNIKey: "36"}, nil)
+	sel := types.NewLabelSelector(es)
+
+	require.True(t, sel.Matches(labels.LabelArray{vniLabel}))
+	require.False(t, sel.Matches(labels.LabelArray{labels.NewLabel(labels.VNIKey, "17", labels.LabelSourceVNI)}))
+}

--- a/pkg/proxy/accesslog/endpoint/epinfo.go
+++ b/pkg/proxy/accesslog/endpoint/epinfo.go
@@ -16,8 +16,15 @@ import (
 )
 
 // EndpointLookup is any type which maps from IP to the endpoint owning that IP.
+//
+// LookupCiliumID is part of the contract because the proxy usually already
+// knows the endpoint id: resolving by id is exact, while a bare-IP lookup is
+// ambiguous in native-vpc mode. Declaring it here rather than type-asserting
+// it at the call site means a rename cannot silently degrade the access log to
+// the bare-IP path.
 type EndpointLookup interface {
 	LookupIP(ip netip.Addr) (ep *endpoint.Endpoint)
+	LookupCiliumID(id uint16) *endpoint.Endpoint
 }
 
 // endpointInfoRegistry provides a default implementation of the logger.EndpointInfoRegistry interface.
@@ -60,13 +67,11 @@ func (r *endpointInfoRegistry) FillEndpointInfo(ctx context.Context, info *acces
 		if ep != nil {
 			info.ID = ep.GetID()
 		}
-	} else if lookupByID, ok := r.endpointManager.(interface {
-		LookupCiliumID(id uint16) *endpoint.Endpoint
-	}); ok {
+	} else {
 		// The proxy already knows the local endpoint: resolve it by ID (never
 		// by bare IP, which is ambiguous with overlapping VPC subnets) so that
 		// the native-vpc VNI below is exact.
-		ep = lookupByID.LookupCiliumID(uint16(info.ID))
+		ep = r.endpointManager.LookupCiliumID(uint16(info.ID))
 	}
 
 	// Native-vpc: record the (VNI, IP) scope of the endpoint so that the

--- a/pkg/proxy/accesslog/endpoint/epinfo.go
+++ b/pkg/proxy/accesslog/endpoint/epinfo.go
@@ -56,7 +56,7 @@ func (r *endpointInfoRegistry) FillEndpointInfo(ctx context.Context, info *acces
 	// This will fail if the IP does not correspond to an endpoint on this node.
 	var ep *endpoint.Endpoint
 	if info.ID == 0 {
-		ep = r.endpointManager.LookupIP(addr)
+		ep = endpointmanager.LookupIPUnambiguous(r.endpointManager, addr)
 		if ep != nil {
 			info.ID = ep.GetID()
 		}
@@ -77,9 +77,12 @@ func (r *endpointInfoRegistry) FillEndpointInfo(ctx context.Context, info *acces
 			}
 		}
 
-		// Fall back to ipcache
+		// Fall back to ipcache. Native-vpc: use the unambiguous lookup so a
+		// VNI-scoped entry is resolved when exactly one VPC uses the IP (L7
+		// accesslog is best-effort; the generic key-exact lookup cannot see
+		// "<ip>@vni:<vni>" entries and would degrade to WORLD).
 		if info.Identity == 0 && addr.IsValid() {
-			ID, exists := r.ipcache.LookupByIP(addr.String())
+			ID, exists := r.ipcache.LookupSecIDByIPUnambiguous(addr)
 			if exists {
 				info.Identity = uint64(ID.ID)
 			}

--- a/pkg/proxy/accesslog/endpoint/epinfo.go
+++ b/pkg/proxy/accesslog/endpoint/epinfo.go
@@ -60,6 +60,26 @@ func (r *endpointInfoRegistry) FillEndpointInfo(ctx context.Context, info *acces
 		if ep != nil {
 			info.ID = ep.GetID()
 		}
+	} else if lookupByID, ok := r.endpointManager.(interface {
+		LookupCiliumID(id uint16) *endpoint.Endpoint
+	}); ok {
+		// The proxy already knows the local endpoint: resolve it by ID (never
+		// by bare IP, which is ambiguous with overlapping VPC subnets) so that
+		// the native-vpc VNI below is exact.
+		ep = lookupByID.LookupCiliumID(uint16(info.ID))
+	}
+
+	// Native-vpc: record the (VNI, IP) scope of the endpoint so that the
+	// observability plane (Hubble L7 flows) can resolve pod metadata with the
+	// exact VNI-scoped key instead of a bare IP.
+	if info.VNIID == 0 {
+		if ep != nil {
+			info.VNIID = ep.GetVNIID()
+		} else if addr.IsValid() {
+			if id, exists := r.ipcache.LookupSecIDByIPUnambiguous(addr); exists {
+				info.VNIID = uint64(id.Vni)
+			}
+		}
 	}
 
 	// Only resolve the security identity if not passed in, as it may have changed since

--- a/pkg/proxy/accesslog/record.go
+++ b/pkg/proxy/accesslog/record.go
@@ -84,6 +84,13 @@ type EndpointInfo struct {
 	// Identity is the security identity of the endpoint
 	Identity uint64
 
+	// VNIID is the native-vpc VNI (kube-ovn tunnel_key) scoping the endpoint
+	// IP. Zero means the endpoint is not in a VPC scope. It is required to
+	// resolve (VNI, IP) in the observability plane: in native-vpc mode the
+	// same IP may exist in several VPCs, so a bare-IP lookup on the Hubble
+	// side is ambiguous.
+	VNIID uint64
+
 	// Labels is the list of security relevant labels of the endpoint.
 	// Shared, do not mutate!
 	Labels labels.LabelArray

--- a/pkg/proxy/endpoint/endpoint.go
+++ b/pkg/proxy/endpoint/endpoint.go
@@ -16,6 +16,10 @@ type EndpointInfoSource interface {
 	GetIPv4Address() string
 	GetIPv6Address() string
 	GetNamedPort(ingress bool, name string, proto u8proto.U8proto) uint16
+	// GetVNIID reports the native-vpc scope of the endpoint, 0 when it is not
+	// in a VPC. The proxy identifies an endpoint by address, so the scope is
+	// what says whether that address is unambiguous.
+	GetVNIID() uint64
 }
 
 // EndpointUpdater returns information about an endpoint being proxied and

--- a/pkg/testutils/endpoint.go
+++ b/pkg/testutils/endpoint.go
@@ -33,6 +33,7 @@ type TestEndpoint struct {
 	isHost      bool
 	State       string
 	NetNsCookie uint64
+	VNIID       uint64
 }
 
 func NewTestEndpoint(t testing.TB) TestEndpoint {
@@ -80,6 +81,8 @@ func (e *TestEndpoint) StringID() string { return "42" }
 func (e *TestEndpoint) GetIdentity() identity.NumericIdentity { return e.Identity.ID }
 
 func (e *TestEndpoint) GetEndpointNetNsCookie() uint64 { return e.NetNsCookie }
+
+func (e *TestEndpoint) GetVNIID() uint64 { return e.VNIID }
 
 func (e *TestEndpoint) GetSecurityIdentity() *identity.Identity { return e.Identity }
 

--- a/standalone-dns-proxy/pkg/client/client.go
+++ b/standalone-dns-proxy/pkg/client/client.go
@@ -62,6 +62,11 @@ type IPtoEndpointInfo struct {
 	IP       []netip.Addr
 	ID       uint64
 	Identity identity.NumericIdentity
+	VNI      uint32
+}
+
+func VNIIPKey(vni uint32, ip netip.Addr) string {
+	return fmt.Sprintf("%d\x00%s", vni, ip.Unmap())
 }
 
 var (
@@ -85,19 +90,17 @@ var (
 		FromString: index.Uint64String,
 		Unique:     true,
 	}
-	IdIPToEndpointIndex = statedb.Index[IPtoEndpointInfo, netip.Addr]{
-		Name: "ip",
+	IdIPToEndpointIndex = statedb.Index[IPtoEndpointInfo, string]{
+		Name: "vni-ip",
 		FromObject: func(e IPtoEndpointInfo) index.KeySet {
 			keys := make([]index.Key, 0, len(e.IP))
 			for _, ip := range e.IP {
-				keys = append(keys, index.NetIPAddr(ip))
+				keys = append(keys, index.String(VNIIPKey(e.VNI, ip)))
 			}
 			return index.NewKeySet(keys...)
 		},
-		FromKey: func(key netip.Addr) index.Key {
-			return index.NetIPAddr(key)
-		},
-		FromString: index.NetIPAddrString,
+		FromKey:    func(key string) index.Key { return index.String(key) },
+		FromString: index.FromString,
 		Unique:     true,
 	}
 	PrefixToIdentityIndex = statedb.Index[PrefixToIdentity, netip.Prefix]{
@@ -520,6 +523,7 @@ func (c *GRPCClient) updateIPToEndpoint(mappings []*pb.IdentityToEndpointMapping
 				IP:       ips,
 				ID:       epInfo.GetId(),
 				Identity: identity.NumericIdentity(mapping.GetIdentity()),
+				VNI:      epInfo.GetVni(),
 			})
 			if err != nil {
 				return err

--- a/standalone-dns-proxy/pkg/client/client_test.go
+++ b/standalone-dns-proxy/pkg/client/client_test.go
@@ -486,7 +486,7 @@ func checkMapping(t *testing.T, client *GRPCClient, ip string, expectedID uint64
 	rtxn := client.db.ReadTxn()
 	addr, err := netip.ParseAddr(ip)
 	require.NoError(t, err)
-	mapping, _, found := client.ipToEndpointTable.Get(rtxn, IdIPToEndpointIndex.Query(addr))
+	mapping, _, found := client.ipToEndpointTable.Get(rtxn, IdIPToEndpointIndex.Query(VNIIPKey(0, addr)))
 	if shouldExist {
 		require.True(t, found)
 		require.Equal(t, []netip.Addr{addr}, mapping.IP)

--- a/standalone-dns-proxy/pkg/lookup/lookup.go
+++ b/standalone-dns-proxy/pkg/lookup/lookup.go
@@ -37,9 +37,20 @@ func (r *rulesClient) LookupByIdentity(nid identity.NumericIdentity) []string {
 	return []string{}
 }
 
-// Note: isHost is always false because the standalone DNS proxy does not handle host endpoints yet.
+// LookupRegisteredEndpoint returns only non-VPC/plain entries. Native-vpc
+// callers must use LookupRegisteredEndpointWithVNI.
 func (r *rulesClient) LookupRegisteredEndpoint(endpointAddr netip.Addr) (endpt *endpoint.Endpoint, isHost bool, err error) {
-	info, _, found := r.ipToIdentityTable.Get(r.db.ReadTxn(), client.IdIPToEndpointIndex.Query(endpointAddr))
+	return r.lookupRegisteredEndpointWithVNI(endpointAddr, 0)
+}
+
+// LookupRegisteredEndpointWithVNI performs the exact (VNI, IP) lookup used by
+// native-vpc standalone DNS mappings.
+func (r *rulesClient) LookupRegisteredEndpointWithVNI(endpointAddr netip.Addr, vni uint32) (endpt *endpoint.Endpoint, isHost bool, err error) {
+	return r.lookupRegisteredEndpointWithVNI(endpointAddr, vni)
+}
+
+func (r *rulesClient) lookupRegisteredEndpointWithVNI(endpointAddr netip.Addr, vni uint32) (endpt *endpoint.Endpoint, isHost bool, err error) {
+	info, _, found := r.ipToIdentityTable.Get(r.db.ReadTxn(), client.IdIPToEndpointIndex.Query(client.VNIIPKey(vni, endpointAddr)))
 	if !found {
 		return nil, false, nil
 	}
@@ -53,12 +64,20 @@ func (r *rulesClient) LookupRegisteredEndpoint(endpointAddr netip.Addr) (endpt *
 
 // LookupSecIDByIP looks up the security ID for a given IP address
 // It is similar to ipcache.LookupSecIDByIP
+// LookupSecIDByIPUnambiguous implements the best-effort lookup required by
+// the in-agent DNS proxy interface. The standalone DNS proxy state currently
+// has no VNI-scoped key dimension, so its exact lookup is the best available
+// behavior (native-vpc does not use this standalone path).
+func (r *rulesClient) LookupSecIDByIPUnambiguous(ip netip.Addr) (secID ipcache.Identity, exists bool) {
+	return r.LookupSecIDByIP(ip)
+}
+
 func (r *rulesClient) LookupSecIDByIP(ip netip.Addr) (secID ipcache.Identity, exists bool) {
 	if !ip.IsValid() {
 		return ipcache.Identity{}, false
 	}
 	txn := r.db.ReadTxn()
-	info, _, found := r.ipToIdentityTable.Get(txn, client.IdIPToEndpointIndex.Query(ip))
+	info, _, found := r.ipToIdentityTable.Get(txn, client.IdIPToEndpointIndex.Query(client.VNIIPKey(0, ip)))
 	if found {
 		return ipcache.Identity{
 			ID:     info.Identity,

--- a/standalone-dns-proxy/pkg/messagehandler/messagehandler.go
+++ b/standalone-dns-proxy/pkg/messagehandler/messagehandler.go
@@ -55,6 +55,7 @@ func (m *messageHandler) NotifyOnDNSMsg(lookupTime time.Time, ep *endpoint.Endpo
 		Ttl:            TTL,
 		SourceIp:       []byte(sourceIp),
 		SourceIdentity: uint32(sourceIdentity.ID),
+		Vni:            uint32(ep.GetVNIID()),
 		ResponseCode:   uint32(rcode),
 	}
 	return m.ConnHandler.NotifyOnMsg(message)

--- a/test/native-vpc/00-setup.sh
+++ b/test/native-vpc/00-setup.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Creates three kube-ovn VPCs whose subnets share the SAME CIDR, one namespace
+# per VPC, and a client+server pod per VPC pinned to identical IPs.
+#
+# After this script every VPC holds a pod at 10.99.0.11 and one at 10.99.0.12,
+# i.e. three pods share each address and can only be told apart by their VNI.
+set -uo pipefail
+cd "$(dirname "$0")" && source ./lib.sh
+
+log "creating VPCs, subnets (all ${OVERLAP_CIDR}) and namespaces"
+for vpc in "${VPCS[@]}"; do
+  kubectl apply -f - >/dev/null <<YAML
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${vpc}
+  labels:
+    vni-test: "true"
+    vpc: ${vpc}
+---
+apiVersion: kubeovn.io/v1
+kind: Vpc
+metadata:
+  name: ${vpc}
+spec:
+  namespaces:
+  - ${vpc}
+---
+apiVersion: kubeovn.io/v1
+kind: Subnet
+metadata:
+  name: subnet-${vpc}
+spec:
+  vpc: ${vpc}
+  namespaces:
+  - ${vpc}
+  cidrBlock: ${OVERLAP_CIDR}
+  protocol: IPv4
+  # No NAT/gateway: the test is purely east-west inside each VPC.
+  natOutgoing: false
+YAML
+done
+
+log "waiting for the subnets to be ready"
+for vpc in "${VPCS[@]}"; do
+  for _ in $(seq 30); do
+    [[ -n "$(kubectl get subnet subnet-${vpc} -o jsonpath='{.status.v4availableIPs}' 2>/dev/null)" ]] && break
+    sleep 2
+  done
+done
+kubectl get subnet -o custom-columns=NAME:.metadata.name,VPC:.spec.vpc,CIDR:.spec.cidrBlock --no-headers | grep -E "subnet-vpc" | sed 's/^/    /'
+
+log "creating one client and one server pod per VPC, with identical IPs"
+for vpc in "${VPCS[@]}"; do
+  # The server serves two ports so that a port-scoped policy can be observed:
+  # PORT_ALLOWED must stay reachable, PORT_DENIED must not.
+  kubectl apply -f - >/dev/null <<YAML
+apiVersion: v1
+kind: Pod
+metadata:
+  name: server
+  namespace: ${vpc}
+  labels:
+    app: server
+    vni-test: "true"
+  annotations:
+    ovn.kubernetes.io/ip_address: "${SERVER_IP}"
+    ovn.kubernetes.io/logical_switch: subnet-${vpc}
+spec:
+  containers:
+  - name: c
+    image: docker.io/library/busybox:1.36
+    imagePullPolicy: IfNotPresent
+    command: ["sh","-c"]
+    args:
+    - |
+      mkdir -p /www && echo "hello from ${vpc}" > /www/index.html
+      httpd -p ${PORT_ALLOWED} -h /www
+      httpd -p ${PORT_DENIED} -h /www
+      sleep infinity
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: client
+  namespace: ${vpc}
+  labels:
+    app: client
+    vni-test: "true"
+  annotations:
+    ovn.kubernetes.io/ip_address: "${CLIENT_IP}"
+    ovn.kubernetes.io/logical_switch: subnet-${vpc}
+spec:
+  containers:
+  - name: c
+    image: docker.io/library/busybox:1.36
+    imagePullPolicy: IfNotPresent
+    command: ["sh","-c","sleep infinity"]
+YAML
+done
+
+log "waiting for pods"
+for vpc in "${VPCS[@]}"; do
+  wait_for_pod "$vpc" server || warn "${vpc}/server not Running"
+  wait_for_pod "$vpc" client || warn "${vpc}/client not Running"
+done
+
+echo
+log "topology"
+printf "    %-8s %-10s %-12s %-12s %s\n" VPC POD IP VNI NODE
+for vpc in "${VPCS[@]}"; do
+  for p in client server; do
+    printf "    %-8s %-10s %-12s %-12s %s\n" "$vpc" "$p" "$(pod_ip $vpc $p)" "$(pod_vni $vpc $p)" \
+      "$(kubectl -n $vpc get pod $p -o jsonpath='{.spec.nodeName}' 2>/dev/null)"
+  done
+done

--- a/test/native-vpc/10-verify-vni.sh
+++ b/test/native-vpc/10-verify-vni.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Verifies that Cilium keeps the three VPCs apart by (VNI, IP) on every plane,
+# even though all six pods use only two distinct IP addresses.
+set -uo pipefail
+cd "$(dirname "$0")" && source ./lib.sh
+
+log "control plane: every pod carries a distinct VNI from its subnet"
+declare -A VNI
+for vpc in "${VPCS[@]}"; do
+  VNI[$vpc]=$(pod_vni "$vpc" server)
+  [[ -n "${VNI[$vpc]}" ]] && pass "${vpc}: server has tunnel_key=${VNI[$vpc]}" || fail "${vpc}: server has no tunnel_key"
+done
+uniq_vnis=$(printf '%s\n' "${VNI[@]}" | sort -u | wc -l)
+assert_eq "3" "$uniq_vnis" "the three VPCs use three different VNIs"
+
+log "control plane: the same IP is used by all three VPCs"
+ips=$(for vpc in "${VPCS[@]}"; do echo "$(pod_ip "$vpc" server)"; done | sort -u)
+assert_eq "$SERVER_IP" "$ips" "all three servers share one address"
+
+log "control plane: each endpoint gets its own identity and a VNI identity label"
+eps=$(cilium_exec cilium-dbg endpoint list -o json)
+for vpc in "${VPCS[@]}"; do
+  vni=${VNI[$vpc]}
+  id=$(echo "$eps" | python3 -c "
+import json,sys
+eps=json.load(sys.stdin)
+for e in eps:
+    st=e.get('status',{})
+    lbls=(st.get('identity') or {}).get('labels') or []
+    ns=[l for l in lbls if l=='k8s:io.kubernetes.pod.namespace=$vpc']
+    srv=[l for l in lbls if l=='k8s:app=server']
+    if ns and srv:
+        print((st.get('identity') or {}).get('id'));break
+")
+  labels=$(echo "$eps" | python3 -c "
+import json,sys
+eps=json.load(sys.stdin)
+for e in eps:
+    st=e.get('status',{})
+    lbls=(st.get('identity') or {}).get('labels') or []
+    if 'k8s:io.kubernetes.pod.namespace=$vpc' in lbls and 'k8s:app=server' in lbls:
+        print(','.join(lbls));break
+")
+  assert_contains "$labels" "vni:io-cilium-native-vpc-vni=${vni}" "${vpc}: identity carries the VNI label"
+  echo "$id" > "/tmp/vni-id-${vpc}"
+done
+ids=$(cat /tmp/vni-id-vpc-a /tmp/vni-id-vpc-b /tmp/vni-id-vpc-c 2>/dev/null | sort -u | wc -l)
+assert_eq "3" "$ids" "three different numeric identities for the same IP"
+
+log "cache plane: the ipcache holds one entry per (VNI, IP)"
+ipc=$(cilium_exec cilium-dbg bpf ipcache list)
+for vpc in "${VPCS[@]}"; do
+  vni=${VNI[$vpc]}
+  assert_contains "$ipc" "${SERVER_IP}/32@vni:${vni}" "${vpc}: ${SERVER_IP} present under vni:${vni}"
+done
+n=$(echo "$ipc" | grep -c "${SERVER_IP}/32@vni:")
+assert_eq "3" "$n" "the shared address resolves to three separate ipcache entries"
+
+log "forwarding plane: each endpoint is loaded with its own VNI"
+for vpc in "${VPCS[@]}"; do
+  vni=${VNI[$vpc]}
+  epid=$(cilium_exec cilium-dbg endpoint get "vni-ipv4:${vni}:${SERVER_IP}" -o jsonpath='{[0].id}')
+  [[ -n "$epid" ]] && pass "${vpc}: endpoint resolvable by vni-ipv4:${vni}:${SERVER_IP} (id ${epid})" \
+                   || fail "${vpc}: no endpoint for vni-ipv4:${vni}:${SERVER_IP}"
+done
+
+log "conntrack plane: the overlap precondition is reported"
+overlap=$(cilium_exec cilium-dbg metrics list | awk '/native_vpc_overlapping_ips/{print int($NF)}')
+[[ "${overlap:-0}" -ge 2 ]] \
+  && pass "cilium_native_vpc_overlapping_ips=${overlap} (both shared addresses flagged)" \
+  || fail "cilium_native_vpc_overlapping_ips=${overlap:-unset}, expected >= 2"
+
+summary

--- a/test/native-vpc/15-key-uniqueness.sh
+++ b/test/native-vpc/15-key-uniqueness.sh
@@ -221,6 +221,51 @@ else
   fail "could not stop the agent for the outage check"
 fi
 
+log "a pod that comes back keeps its own mapping"
+# Two shapes of restart, with different consequences. A container that restarts
+# in place keeps its sandbox, so no CNI call happens and nothing may move. A pod
+# that is recreated goes through CNI DEL and ADD, and because Cilium's teardown
+# outlives the DEL, the previous endpoint's removal can arrive after the new one
+# has registered the same (VNI, IP) - the entry that survives must be the new
+# one's.
+RESTART_NS=vpc-b
+before_restart=$(fwd_keys "$SERVER_IP")
+cid=$(crictl ps -o json 2>/dev/null | python3 -c "
+import json,sys
+for c in json.load(sys.stdin).get('containers',[]):
+    l=c.get('labels',{})
+    if l.get('io.kubernetes.pod.namespace')=='${RESTART_NS}' and l.get('io.kubernetes.pod.name')=='server':
+        print(c['id']); break
+" 2>/dev/null)
+if [[ -n "$cid" ]]; then
+  crictl stop "$cid" >/dev/null 2>&1
+  for _ in $(seq 30); do
+    [[ "$(kubectl -n "$RESTART_NS" get pod server -o jsonpath='{.status.containerStatuses[0].restartCount}' 2>/dev/null)" != "0" ]] && break
+    sleep 2
+  done
+  sleep 5
+  assert_eq "$(kubectl -n "$RESTART_NS" get pod server -o jsonpath='{.status.podIP}')" "$SERVER_IP" \
+    "the restarted container keeps its address"
+  assert_eq "$before_restart" "$(fwd_keys "$SERVER_IP")" \
+    "an in-place container restart moves nothing"
+else
+  warn "container of ${RESTART_NS}/server not found, skipping the in-place restart check"
+fi
+
+# Recreate under the same name on the same address: namespace, name, address and
+# VNI are all unchanged, so only the endpoint tells the two apart.
+ep_before=$(control_ids "$SERVER_IP")
+kubectl -n "$VICTIM" delete pod server --wait=true --timeout=120s >/dev/null 2>&1
+make_victim_server
+ep_after=$(control_ids "$SERVER_IP")
+assert_eq "3" "$(cache_keys "$SERVER_IP" | grep -c .)" "the address is back in three VPCs"
+fwd_keys "$SERVER_IP" | grep -q "@vni:${VICTIM_VNI}$" \
+  && pass "the recreated pod owns ${SERVER_IP}@vni:${VICTIM_VNI}" \
+  || fail "the recreated pod has no entry: a late teardown removed it"
+[[ "$ep_before" != "$ep_after" ]] \
+  && pass "it is a different endpoint (${ep_before} -> ${ep_after})" \
+  || fail "the endpoint did not change, so the check proves nothing"
+
 log "the host stack holds no resource keyed by a shared address"
 # A per-endpoint route is a kernel route to the address, and the routing table
 # has no notion of a VPC: the pods sharing an address would install one route

--- a/test/native-vpc/15-key-uniqueness.sh
+++ b/test/native-vpc/15-key-uniqueness.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# 15 - (VNI, IP) is the key, on every plane that can be observed.
+#
+# The premise is that a pod's VNI and IP are fixed for the whole life of its CNI
+# attachment. What has to hold then is narrow and checkable:
+#
+#   after CNI ADD  - the pod owns exactly one resource per plane, under its own
+#                    (VNI, IP), and it collides with nothing that the pods with
+#                    the same address in the other VPCs own;
+#   after CNI DEL  - exactly that pod's resources are gone and every other VPC's
+#                    resources on the same address are untouched.
+#
+# The fixture is built for this: three VPCs whose subnets share one CIDR, with a
+# client and a server on the same two addresses in each. Any place that keys by
+# address alone therefore holds one entry where there should be three - or three
+# endpoints' worth of state where there should be one.
+#
+# Planes with no observable state (conntrack, service, encryption/egress) are
+# covered by the startup rejections in 50-datapath.sh instead.
+
+set -uo pipefail
+cd "$(dirname "$0")" && source ./lib.sh
+
+# vni_of <vpc> - the VNI of a VPC, read from a pod that lives in it
+declare -A VNI
+for vpc in "${VPCS[@]}"; do VNI[$vpc]=$(pod_vni "$vpc" server); done
+
+# --- helpers, one per observable plane -------------------------------------
+
+# cache: userspace ipcache, scoped keys only
+cache_keys() { cilium_exec cilium-dbg ip list | awk -v ip="$1/32" '$1 ~ "^"ip"(@|$)" {print $1}' | sort; }
+
+# forwarding: the VNI-scoped BPF ipcache
+fwd_keys() { cilium_exec cilium-dbg bpf ipcache list | awk -v ip="$1/32" '$1 ~ "^"ip"(@|$)" {print $1}' | sort; }
+
+# forwarding: the address-keyed endpoint map, which must not describe VPC pods
+endpoint_map_rows() { cilium_exec cilium-dbg bpf endpoint list | grep -c "^$1:" ; }
+
+# control: endpoints known to the agent for this address
+control_ids() {
+  cilium_exec cilium-dbg endpoint list -o json | python3 -c "
+import json,sys
+ids=[]
+for e in json.load(sys.stdin):
+    st=e.get('status',{})
+    for a in (st.get('networking',{}) or {}).get('addressing',[]) or []:
+        if a.get('ipv4')=='$1': ids.append(e['id'])
+print(' '.join(str(i) for i in sorted(ids)))
+"
+}
+
+# policy: identities in use for this address, one per VPC
+identities_for() {
+  cilium_exec cilium-dbg bpf ipcache list | awk -v ip="$1/32" '$1 ~ "^"ip"@vni:" {print $2}' | sed 's/identity=//' | sort -n | tr '\n' ' ' | sed 's/ $//'
+}
+
+log "topology: three VPCs, one CIDR, the same two addresses in each"
+for vpc in "${VPCS[@]}"; do info "${vpc}: vni=${VNI[$vpc]} client=${CLIENT_IP} server=${SERVER_IP}"; done
+
+# --- after CNI ADD ---------------------------------------------------------
+
+log "cache plane: one key per VPC, and every key carries its scope"
+for ip in "$CLIENT_IP" "$SERVER_IP"; do
+  keys=$(cache_keys "$ip")
+  n=$(echo "$keys" | grep -c .)
+  assert_eq "3" "$n" "${ip}: three scoped ipcache keys"
+  unscoped=$(echo "$keys" | grep -cv "@vni:")
+  assert_eq "0" "${unscoped:-x}" "${ip}: no key without a scope"
+  for vpc in "${VPCS[@]}"; do
+    echo "$keys" | grep -q "@vni:${VNI[$vpc]}$" \
+      && pass "${ip}: ${vpc} owns ${ip}@vni:${VNI[$vpc]}" \
+      || fail "${ip}: no key for ${vpc} (vni ${VNI[$vpc]})"
+  done
+done
+
+log "forwarding plane: the datapath sees the same three, and nothing bare"
+for ip in "$CLIENT_IP" "$SERVER_IP"; do
+  n=$(fwd_keys "$ip" | grep -c "@vni:")
+  assert_eq "3" "$n" "${ip}: three scoped BPF ipcache entries"
+  bare=$(fwd_keys "$ip" | grep -cv "@vni:")
+  assert_eq "0" "${bare:-x}" "${ip}: nothing in the unscoped ipcache"
+done
+
+log "forwarding plane: the address-keyed endpoint map describes no VPC pod"
+# cilium_lxc has no room for a scope in its key, so an entry for a shared
+# address could only answer for whichever endpoint wrote last.
+for ip in "$CLIENT_IP" "$SERVER_IP"; do
+  assert_eq "0" "$(endpoint_map_rows "$ip")" "${ip}: no entry in the endpoint map"
+done
+
+log "control plane: three endpoints share the address, each addressable"
+for ip in "$CLIENT_IP" "$SERVER_IP"; do
+  ids=$(control_ids "$ip")
+  n=$(echo "$ids" | wc -w)
+  assert_eq "3" "$n" "${ip}: three endpoints (ids: ${ids})"
+done
+
+log "policy plane: three distinct identities on one address"
+for ip in "$CLIENT_IP" "$SERVER_IP"; do
+  ids=$(identities_for "$ip")
+  uniq_n=$(echo "$ids" | tr ' ' '\n' | sort -u | grep -c .)
+  assert_eq "3" "$uniq_n" "${ip}: identities are distinct per VPC (${ids})"
+done
+
+# --- after CNI DEL ---------------------------------------------------------
+
+VICTIM=vpc-b
+VICTIM_VNI=${VNI[$VICTIM]}
+log "deleting ${VICTIM}/server removes its resources and only its own"
+
+before_cache=$(cache_keys "$SERVER_IP" | grep -c .)
+kubectl -n "$VICTIM" delete pod server --wait=true >/dev/null 2>&1
+sleep 8
+
+after=$(cache_keys "$SERVER_IP")
+assert_eq "$((before_cache - 1))" "$(echo "$after" | grep -c .)" \
+  "one ipcache key fewer"
+echo "$after" | grep -q "@vni:${VICTIM_VNI}$" \
+  && fail "the deleted pod's key ${SERVER_IP}@vni:${VICTIM_VNI} survived" \
+  || pass "the deleted pod's key is gone"
+for vpc in vpc-a vpc-c; do
+  echo "$after" | grep -q "@vni:${VNI[$vpc]}$" \
+    && pass "${vpc} still owns ${SERVER_IP}@vni:${VNI[$vpc]}" \
+    || fail "${vpc} lost its key when ${VICTIM} was deleted"
+done
+
+fwd_after=$(fwd_keys "$SERVER_IP")
+assert_eq "2" "$(echo "$fwd_after" | grep -c '@vni:')" "two scoped datapath entries remain"
+echo "$fwd_after" | grep -q "@vni:${VICTIM_VNI}$" \
+  && fail "the datapath entry of the deleted pod survived" \
+  || pass "the datapath entry of the deleted pod is gone"
+
+assert_eq "2" "$(control_ids "$SERVER_IP" | wc -w)" "two endpoints remain on the address"
+
+log "the survivors still work"
+# The point of the previous checks is this one: deleting a pod in one VPC must
+# not disturb the pod that owns the same address in another VPC.
+res=$(try_connect vpc-c client "$SERVER_IP" "$PORT_ALLOWED")
+assert_eq "open" "$res" "vpc-c still reaches its own server on ${SERVER_IP}"
+
+log "recreating it restores exactly one key, in its own VPC"
+kubectl apply -f - >/dev/null <<YAML
+apiVersion: v1
+kind: Pod
+metadata:
+  name: server
+  namespace: ${VICTIM}
+  labels: {app: server, vni-test: "true"}
+  annotations:
+    ovn.kubernetes.io/ip_address: "${SERVER_IP}"
+    ovn.kubernetes.io/logical_switch: subnet-${VICTIM}
+spec:
+  containers:
+  - name: c
+    image: docker.io/library/busybox:1.36
+    imagePullPolicy: IfNotPresent
+    command: ["sh","-c"]
+    args:
+    - |
+      mkdir -p /www && echo "hello from ${VICTIM}" > /www/index.html
+      httpd -p ${PORT_ALLOWED} -h /www
+      httpd -p ${PORT_DENIED} -h /www
+      sleep infinity
+YAML
+kubectl -n "$VICTIM" wait --for=condition=Ready pod/server --timeout=120s >/dev/null 2>&1
+sleep 8
+
+restored=$(cache_keys "$SERVER_IP")
+assert_eq "3" "$(echo "$restored" | grep -c .)" "three keys again"
+echo "$restored" | grep -q "@vni:${VICTIM_VNI}$" \
+  && pass "${VICTIM} owns ${SERVER_IP}@vni:${VICTIM_VNI} again" \
+  || fail "${VICTIM} did not get its key back"
+assert_eq "0" "$(endpoint_map_rows "$SERVER_IP")" "still no entry in the endpoint map"
+
+summary

--- a/test/native-vpc/15-key-uniqueness.sh
+++ b/test/native-vpc/15-key-uniqueness.sh
@@ -106,6 +106,35 @@ done
 
 VICTIM=vpc-b
 VICTIM_VNI=${VNI[$VICTIM]}
+
+make_victim_server() {
+  kubectl apply -f - >/dev/null <<YAML
+apiVersion: v1
+kind: Pod
+metadata:
+  name: server
+  namespace: ${VICTIM}
+  labels: {app: server, vni-test: "true"}
+  annotations:
+    ovn.kubernetes.io/ip_address: "${SERVER_IP}"
+    ovn.kubernetes.io/logical_switch: subnet-${VICTIM}
+spec:
+  containers:
+  - name: c
+    image: docker.io/library/busybox:1.36
+    imagePullPolicy: IfNotPresent
+    command: ["sh","-c"]
+    args:
+    - |
+      mkdir -p /www && echo "hello from ${VICTIM}" > /www/index.html
+      httpd -p ${PORT_ALLOWED} -h /www
+      httpd -p ${PORT_DENIED} -h /www
+      sleep infinity
+YAML
+  kubectl -n "$VICTIM" wait --for=condition=Ready pod/server --timeout=120s >/dev/null 2>&1
+  sleep 8
+}
+
 log "deleting ${VICTIM}/server removes its resources and only its own"
 
 before_cache=$(cache_keys "$SERVER_IP" | grep -c .)
@@ -139,31 +168,7 @@ res=$(try_connect vpc-c client "$SERVER_IP" "$PORT_ALLOWED")
 assert_eq "open" "$res" "vpc-c still reaches its own server on ${SERVER_IP}"
 
 log "recreating it restores exactly one key, in its own VPC"
-kubectl apply -f - >/dev/null <<YAML
-apiVersion: v1
-kind: Pod
-metadata:
-  name: server
-  namespace: ${VICTIM}
-  labels: {app: server, vni-test: "true"}
-  annotations:
-    ovn.kubernetes.io/ip_address: "${SERVER_IP}"
-    ovn.kubernetes.io/logical_switch: subnet-${VICTIM}
-spec:
-  containers:
-  - name: c
-    image: docker.io/library/busybox:1.36
-    imagePullPolicy: IfNotPresent
-    command: ["sh","-c"]
-    args:
-    - |
-      mkdir -p /www && echo "hello from ${VICTIM}" > /www/index.html
-      httpd -p ${PORT_ALLOWED} -h /www
-      httpd -p ${PORT_DENIED} -h /www
-      sleep infinity
-YAML
-kubectl -n "$VICTIM" wait --for=condition=Ready pod/server --timeout=120s >/dev/null 2>&1
-sleep 8
+make_victim_server
 
 restored=$(cache_keys "$SERVER_IP")
 assert_eq "3" "$(echo "$restored" | grep -c .)" "three keys again"
@@ -171,6 +176,50 @@ echo "$restored" | grep -q "@vni:${VICTIM_VNI}$" \
   && pass "${VICTIM} owns ${SERVER_IP}@vni:${VICTIM_VNI} again" \
   || fail "${VICTIM} did not get its key back"
 assert_eq "0" "$(endpoint_map_rows "$SERVER_IP")" "still no entry in the endpoint map"
+
+log "a CNI DEL that happens while the agent is down is still reconciled"
+# The agent is the only thing that removes an entry, so the interesting case is
+# the one where it is not running when the pod goes away: on startup it must end
+# up with the keys of the pods that exist, which means removing the one that
+# does not - and only that one, while two other VPCs still use the address.
+agent_stop() {
+  kubectl -n "$CILIUM_NS" patch ds cilium --type=merge \
+    -p '{"spec":{"template":{"spec":{"nodeSelector":{"native-vpc-e2e/absent":"true"}}}}}' >/dev/null 2>&1
+  for _ in $(seq 60); do
+    [[ "$(kubectl -n "$CILIUM_NS" get pods -l k8s-app=cilium --no-headers 2>/dev/null | wc -l)" == "0" ]] && return 0
+    sleep 2
+  done
+  return 1
+}
+agent_start() {
+  kubectl -n "$CILIUM_NS" patch ds cilium --type=json \
+    -p '[{"op":"remove","path":"/spec/template/spec/nodeSelector/native-vpc-e2e~1absent"}]' >/dev/null 2>&1
+  kubectl -n "$CILIUM_NS" rollout status ds/cilium --timeout=300s >/dev/null 2>&1
+  sleep 15
+}
+
+if agent_stop; then
+  pass "the agent is stopped"
+  kubectl -n "$VICTIM" delete pod server --wait=true --timeout=120s >/dev/null 2>&1
+  info "deleted ${VICTIM}/server with no agent running"
+  agent_start
+
+  after_down=$(fwd_keys "$SERVER_IP")
+  echo "$after_down" | grep -q "@vni:${VICTIM_VNI}$" \
+    && fail "the key of the pod deleted during the outage survived the restart" \
+    || pass "the key of the pod deleted during the outage is gone"
+  for vpc in vpc-a vpc-c; do
+    echo "$after_down" | grep -q "@vni:${VNI[$vpc]}$" \
+      && pass "${vpc} kept ${SERVER_IP}@vni:${VNI[$vpc]} across the outage" \
+      || fail "${vpc} lost its key across the outage"
+  done
+  assert_eq "0" "$(endpoint_map_rows "$SERVER_IP")" "still nothing in the endpoint map"
+
+  make_victim_server
+  assert_eq "3" "$(cache_keys "$SERVER_IP" | grep -c .)" "the fixture is whole again"
+else
+  fail "could not stop the agent for the outage check"
+fi
 
 log "the host stack holds no resource keyed by a shared address"
 # A per-endpoint route is a kernel route to the address, and the routing table

--- a/test/native-vpc/15-key-uniqueness.sh
+++ b/test/native-vpc/15-key-uniqueness.sh
@@ -172,4 +172,49 @@ echo "$restored" | grep -q "@vni:${VICTIM_VNI}$" \
   || fail "${VICTIM} did not get its key back"
 assert_eq "0" "$(endpoint_map_rows "$SERVER_IP")" "still no entry in the endpoint map"
 
+log "the host stack holds no resource keyed by a shared address"
+# A per-endpoint route is a kernel route to the address, and the routing table
+# has no notion of a VPC: the pods sharing an address would install one route
+# between them. The mode that installs those routes is refused at startup, and
+# this is what that refusal is worth on the node.
+for ip in "$CLIENT_IP" "$SERVER_IP"; do
+  n=$(ip route show 2>/dev/null | grep -cE "^${ip} |^${ip}/32 ")
+  assert_eq "0" "${n:-x}" "${ip}: no host route to the shared address"
+done
+epr=$(kubectl -n "$CILIUM_NS" get cm cilium-config -o jsonpath='{.data.enable-endpoint-routes}' 2>/dev/null)
+assert_eq "" "${epr}" "per-endpoint routes are not enabled (the agent would refuse to start)"
+
+log "the operator interface acts on the scope it is given, and nothing else"
+# "cilium bpf ipcache delete <addr>" used to act on the unscoped map only: it
+# reported success while removing nothing, and its update twin would have put a
+# pod address into the space the datapath falls back to when a scoped lookup
+# misses. Both now require the scope to be stated.
+#
+# The check runs against a VPC the fixture does not use, so it can create and
+# remove an entry for an address that three real endpoints share without ever
+# touching what those endpoints own.
+SPARE_VNI=4094
+before=$(fwd_keys "$SERVER_IP" | grep -c "@vni:")
+before_ids=$(identities_for "$SERVER_IP")
+
+unscoped=$(kubectl -n "$CILIUM_NS" exec "$(cilium_pod)" -c cilium-agent -- \
+  cilium-dbg bpf ipcache delete "${SERVER_IP}/32" 2>&1; true)
+echo "$unscoped" | grep -qi "state the scope" \
+  && pass "an unscoped delete is refused and says what to do instead" \
+  || fail "an unscoped delete was accepted: ${unscoped}"
+
+cilium_exec cilium-dbg bpf ipcache update "${SERVER_IP}/32" --vni "$SPARE_VNI" --identity 4242 --tunnelendpoint 0.0.0.0 >/dev/null 2>&1
+sleep 1
+assert_eq "$((before + 1))" "$(fwd_keys "$SERVER_IP" | grep -c '@vni:')" \
+  "a scoped create adds exactly one entry"
+assert_eq "$before_ids" "$(identities_for "$SERVER_IP" | sed "s/4242//" | xargs)" \
+  "the entries of the real VPCs are untouched"
+
+cilium_exec cilium-dbg bpf ipcache delete "${SERVER_IP}/32" --vni "$SPARE_VNI" >/dev/null 2>&1
+sleep 1
+assert_eq "0" "$(fwd_keys "$SERVER_IP" | grep -c "@vni:${SPARE_VNI}$")" \
+  "a scoped delete removes exactly that entry"
+assert_eq "$before" "$(fwd_keys "$SERVER_IP" | grep -c '@vni:')" "the fixture is back as it was"
+assert_eq "$before_ids" "$(identities_for "$SERVER_IP")" "with the same identities"
+
 summary

--- a/test/native-vpc/20-policies.sh
+++ b/test/native-vpc/20-policies.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Applies one policy scenario per VPC. All three VPCs contain the same two IPs,
+# so the only thing that can keep the scenarios apart is the (VNI, IP) scoped
+# identity: a policy written for vpc-a must not affect the identical addresses
+# in vpc-b or vpc-c.
+#
+#   vpc-a : deny   - the server accepts nothing (default deny, no allow rule)
+#   vpc-b : port   - the server accepts only PORT_ALLOWED from the client
+#   vpc-c : open   - no policy at all
+set -uo pipefail
+cd "$(dirname "$0")" && source ./lib.sh
+
+log "vpc-a: default-deny on the server (no ingress allowed at all)"
+kubectl apply -f - >/dev/null <<YAML
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: deny-all
+  namespace: vpc-a
+spec:
+  endpointSelector:
+    matchLabels:
+      app: server
+  ingress:
+  # An empty fromEndpoints selects no peer: the endpoint is put under ingress
+  # enforcement and nothing is allowed, i.e. default deny. (An empty "ingress"
+  # list would not enable enforcement at all.)
+  - fromEndpoints: []
+YAML
+
+log "vpc-b: allow only tcp/${PORT_ALLOWED} from the client"
+kubectl apply -f - >/dev/null <<YAML
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-one-port
+  namespace: vpc-b
+spec:
+  endpointSelector:
+    matchLabels:
+      app: server
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        app: client
+    toPorts:
+    - ports:
+      - port: "${PORT_ALLOWED}"
+        protocol: TCP
+YAML
+
+log "vpc-c: no policy (unrestricted)"
+kubectl delete cnp --all -n vpc-c >/dev/null 2>&1 || true
+
+sleep 5
+log "the policies are accepted by the validator"
+# A CNP that fails validation can still change behaviour (an unparsable rule
+# ends up allowing nothing), so the suite asserts the status explicitly instead
+# of inferring correctness from the connectivity result.
+for ns in vpc-a vpc-b; do
+  for name in $(kubectl -n "$ns" get cnp -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+    msg=$(kubectl -n "$ns" get cnp "$name" -o jsonpath='{.status.conditions[?(@.type=="Valid")].message}' 2>/dev/null)
+    [[ "$msg" == "Policy validation succeeded" ]] \
+      && echo "    ${ns}/${name}: ${msg}" \
+      || { echo "    ${ns}/${name}: INVALID - ${msg}"; exit 1; }
+  done
+done
+
+log "policies in place"
+kubectl get cnp -A --no-headers 2>/dev/null | awk '{printf "    %-8s %s\n", $1, $2}'
+
+log "policy enforcement as seen by Cilium"
+cilium_exec cilium-dbg endpoint list | awk 'NR==1 || /server|client/' | head -10

--- a/test/native-vpc/30-connectivity.sh
+++ b/test/native-vpc/30-connectivity.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# The actual behaviour test. Every VPC runs the identical connection attempt
+# from 10.99.0.11 to 10.99.0.12 on two ports; only the policy of that VPC may
+# influence the result.
+#
+#   vpc-a (deny)  : both ports closed
+#   vpc-b (port)  : PORT_ALLOWED open, PORT_DENIED closed
+#   vpc-c (open)  : both ports open
+#
+# Because all three VPCs use the same two addresses, a wrong result here means
+# the (VNI, IP) scoping leaked: one VPC's policy would have decided another
+# VPC's traffic.
+set -uo pipefail
+cd "$(dirname "$0")" && source ./lib.sh
+
+declare -A EXPECT=(
+  ["vpc-a:${PORT_ALLOWED}"]=closed  ["vpc-a:${PORT_DENIED}"]=closed
+  ["vpc-b:${PORT_ALLOWED}"]=open    ["vpc-b:${PORT_DENIED}"]=closed
+  ["vpc-c:${PORT_ALLOWED}"]=open    ["vpc-c:${PORT_DENIED}"]=open
+)
+declare -A SCENARIO=( [vpc-a]="deny-all" [vpc-b]="allow tcp/${PORT_ALLOWED} only" [vpc-c]="no policy" )
+
+log "connectivity matrix: client ${CLIENT_IP} -> server ${SERVER_IP} (identical in all VPCs)"
+printf "    %-8s %-24s %-8s %-10s %-10s %s\n" VPC SCENARIO PORT EXPECTED ACTUAL RESULT
+for vpc in "${VPCS[@]}"; do
+  for port in "$PORT_ALLOWED" "$PORT_DENIED"; do
+    want=${EXPECT["${vpc}:${port}"]}
+    got=$(try_connect "$vpc" client "$SERVER_IP" "$port")
+    if [[ "$want" == "$got" ]]; then
+      PASS_COUNT=$((PASS_COUNT+1)); res="${GREEN}PASS${NC}"
+    else
+      FAIL_COUNT=$((FAIL_COUNT+1)); res="${RED}FAIL${NC}"
+    fi
+    printf "    %-8s %-24s %-8s %-10s %-10s %b\n" "$vpc" "${SCENARIO[$vpc]}" "$port" "$want" "$got" "$res"
+  done
+done
+
+echo
+log "cross-VPC proof: the deny policy of vpc-a must not affect the identical IP elsewhere"
+a=$(try_connect vpc-a client "$SERVER_IP" "$PORT_ALLOWED")
+c=$(try_connect vpc-c client "$SERVER_IP" "$PORT_ALLOWED")
+if [[ "$a" == "closed" && "$c" == "open" ]]; then
+  pass "same source IP, same destination IP, same port: denied in vpc-a, allowed in vpc-c"
+else
+  fail "cross-VPC scoping leaked (vpc-a=${a}, vpc-c=${c})"
+fi
+
+log "cross-VPC proof: the port policy of vpc-b must not leak into vpc-c"
+b=$(try_connect vpc-b client "$SERVER_IP" "$PORT_DENIED")
+c2=$(try_connect vpc-c client "$SERVER_IP" "$PORT_DENIED")
+if [[ "$b" == "closed" && "$c2" == "open" ]]; then
+  pass "tcp/${PORT_DENIED} blocked in vpc-b while open in vpc-c, for the same address pair"
+else
+  fail "port scoping leaked (vpc-b=${b}, vpc-c=${c2})"
+fi
+
+summary

--- a/test/native-vpc/35-policymap.sh
+++ b/test/native-vpc/35-policymap.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Policy plane, as the datapath sees it.
+#
+# The policy map is keyed by *identity*, never by address. With three VPCs on
+# the same addresses this is what makes a rule unambiguous: the peer allowed in
+# vpc-b is the identity of the client that carries vni=7, so the identical
+# address in vpc-a or vpc-c can never match it.
+set -uo pipefail
+cd "$(dirname "$0")" && source ./lib.sh
+
+for vpc in "${VPCS[@]}"; do
+  vni=$(pod_vni "$vpc" server)
+  ep=$(cilium_exec cilium-dbg endpoint get "vni-ipv4:${vni}:${SERVER_IP}" -o jsonpath='{[0].id}')
+  log "${vpc} (vni=${vni}) server endpoint ${ep}: ingress policy map"
+  pol=$(cilium_exec cilium-dbg bpf policy get "$ep")
+  echo "$pol" | grep -E "POLICY|Allow|Deny" | head -6 | sed 's/^/    /'
+
+  case "$vpc" in
+    vpc-a)
+      # default deny: no rule may allow the client
+      if echo "$pol" | grep -A 12 "Allow.*Ingress" | grep -q "k8s:app=client"; then
+        fail "vpc-a: the policy map allows the client although the policy denies everything"
+      else
+        pass "vpc-a: no ingress rule allows the client"
+      fi
+      ;;
+    vpc-b)
+      entry=$(echo "$pol" | awk '/Allow +Ingress/{f=1} f&&/8080\/TCP/{print;exit}')
+      [[ -n "$entry" ]] && pass "vpc-b: ingress allowed on 8080/TCP" || fail "vpc-b: no 8080/TCP allow entry"
+      echo "$pol" | grep -q "9090/TCP" \
+        && fail "vpc-b: 9090/TCP is present in the policy map" \
+        || pass "vpc-b: 9090/TCP is not allowed"
+      # the allowed peer must belong to the *same* VPC
+      # note: the table is padded with trailing spaces, so match the label itself
+      peer_vni=$(echo "$pol" | awk '/k8s:app=client/{f=1} f&&/vni:io-cilium-native-vpc-vni=/{print;exit}' \
+                 | grep -oE 'vni:io-cilium-native-vpc-vni=[0-9]+' | grep -oE '[0-9]+')
+      assert_eq "$vni" "${peer_vni:-none}" "vpc-b: the allowed peer identity carries the same VNI"
+      pkts=$(echo "$pol" | awk '/8080\/TCP/{print $(NF-2)}' | head -1)
+      [[ "${pkts:-0}" =~ ^[0-9]+$ && "${pkts:-0}" -gt 0 ]] \
+        && pass "vpc-b: the allow entry has matched real traffic (${pkts} packets)" \
+        || warn "vpc-b: no packet counter yet on the allow entry"
+      ;;
+    vpc-c)
+      # no policy: the endpoint is not under ingress enforcement at all
+      enf=$(cilium_exec cilium-dbg endpoint list -o json | python3 -c "
+import json,sys
+for e in json.load(sys.stdin):
+    if str(e.get('id'))=='${ep}':
+        print((e.get('status',{}).get('policy',{}).get('realized',{}) or {}).get('policy-enabled','?'));break
+")
+      [[ "$enf" == "none" || "$enf" == "egress" ]] \
+        && pass "vpc-c: ingress is not enforced (policy-enabled=${enf})" \
+        || fail "vpc-c: unexpected enforcement state '${enf}'"
+      ;;
+  esac
+  echo
+done
+
+log "the three servers are three different identities"
+ids=""
+for vpc in "${VPCS[@]}"; do
+  vni=$(pod_vni "$vpc" server)
+  ep=$(cilium_exec cilium-dbg endpoint get "vni-ipv4:${vni}:${SERVER_IP}" -o jsonpath='{[0].id}')
+  id=$(cilium_exec cilium-dbg endpoint get "$ep" -o jsonpath='{[0].status.identity.id}')
+  info "${vpc}: endpoint ${ep} identity ${id}"
+  ids="${ids}${id}\n"
+done
+assert_eq "3" "$(printf "$ids" | sort -u | grep -c .)" "three distinct identities behind one address"
+
+summary

--- a/test/native-vpc/40-observability.sh
+++ b/test/native-vpc/40-observability.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Verifies that the observability plane attributes the identical address pairs
+# to the right VPC: every flow must carry the VNI of the endpoint that produced
+# it, and the drops of vpc-a must not be mixed with the allowed traffic of the
+# other two VPCs.
+set -uo pipefail
+cd "$(dirname "$0")" && source ./lib.sh
+
+log "generating traffic in all three VPCs"
+for vpc in "${VPCS[@]}"; do
+  for port in "$PORT_ALLOWED" "$PORT_DENIED"; do
+    try_connect "$vpc" client "$SERVER_IP" "$port" >/dev/null
+  done
+done
+sleep 3
+
+log "collecting flows between the shared addresses"
+flows=$(cilium_exec hubble observe --last 200 -o json | python3 -c "
+import json,sys
+out=[]
+for line in sys.stdin:
+    try: f=json.loads(line).get('flow',{})
+    except Exception: continue
+    ip=f.get('IP',{}) or {}
+    if ip.get('source')!='${CLIENT_IP}' or ip.get('destination')!='${SERVER_IP}': continue
+    s=f.get('source',{}) or {}; d=f.get('destination',{}) or {}
+    l4=(f.get('l4',{}) or {}).get('TCP',{}) or {}
+    out.append({'svni':s.get('vni_id'),'dvni':d.get('vni_id'),'sns':s.get('namespace'),
+                'dns':d.get('namespace'),'verdict':f.get('verdict'),'dport':l4.get('destination_port')})
+print(json.dumps(out))
+")
+
+log "every flow carries a VNI on both endpoints"
+python3 - "$flows" <<'PY' > /tmp/vni-flow-report
+import json,sys
+flows=json.loads(sys.argv[1]) if sys.argv[1] else []
+missing=[f for f in flows if not f['svni'] or not f['dvni']]
+matched=[f for f in flows if f['svni'] and f['svni']==f['dvni']]
+print(f"total={len(flows)} with_vni={len(flows)-len(missing)} missing_vni={len(missing)} same_vni_both_sides={len(matched)}")
+byvni={}
+for f in flows:
+    byvni.setdefault((f['svni'],f['sns']),[]).append((f['verdict'],f['dport']))
+for (vni,ns),v in sorted(byvni.items(), key=lambda x:str(x[0])):
+    verdicts=sorted({x[0] for x in v})
+    print(f"  vni={vni} ns={ns} verdicts={verdicts} ports={sorted({x[1] for x in v if x[1]})}")
+PY
+cat /tmp/vni-flow-report | sed 's/^/    /'
+
+total=$(awk -F'[= ]' '/^total/{print $2}' /tmp/vni-flow-report)
+missing=$(awk '{for(i=1;i<=NF;i++) if($i ~ /^missing_vni=/){split($i,a,"=");print a[2]}}' /tmp/vni-flow-report | head -1)
+[[ "${total:-0}" -gt 0 ]] && pass "observed ${total} flows between the shared addresses" \
+                          || fail "no flows observed"
+assert_eq "0" "${missing:-x}" "every flow carries a VNI on both endpoints"
+
+log "each VPC appears under its own VNI"
+for vpc in "${VPCS[@]}"; do
+  vni=$(pod_vni "$vpc" server)
+  grep -q "vni=${vni} ns=${vpc}" /tmp/vni-flow-report \
+    && pass "${vpc}: flows attributed to vni=${vni}" \
+    || fail "${vpc}: no flows attributed to vni=${vni}"
+done
+
+log "the denied VPC shows drops, the open VPC does not"
+vni_a=$(pod_vni vpc-a server); vni_c=$(pod_vni vpc-c server)
+grep -q "vni=${vni_a} .*DROPPED" /tmp/vni-flow-report \
+  && pass "vpc-a (vni=${vni_a}) traffic is dropped" || fail "vpc-a shows no drops"
+if grep -q "vni=${vni_c} " /tmp/vni-flow-report && ! grep "vni=${vni_c} " /tmp/vni-flow-report | grep -q "DROPPED"; then
+  pass "vpc-c (vni=${vni_c}) traffic is not dropped"
+else
+  warn "vpc-c verdicts: $(grep "vni=${vni_c} " /tmp/vni-flow-report || echo none)"
+fi
+
+summary

--- a/test/native-vpc/45-hubble-vni.sh
+++ b/test/native-vpc/45-hubble-vni.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Hubble, in detail: can an operator actually see the forwarding-plane data of
+# each VPC's pods, keyed by VNI + IP?
+#
+# All three VPCs move packets between the same two addresses, so a flow record
+# is only useful if it carries the VPC scope. This script prints the per-VPC
+# forwarding data and asserts that
+#   * every flow carries VNI and identity on both endpoints,
+#   * the verdict/port pattern matches that VPC's policy,
+#   * the identities in the flows are the identities of *that* VPC's endpoints,
+#   * flows can be filtered per VPC through the VNI identity label.
+set -uo pipefail
+cd "$(dirname "$0")" && source ./lib.sh
+
+log "generating traffic in all three VPCs (both ports)"
+for vpc in "${VPCS[@]}"; do
+  for port in "$PORT_ALLOWED" "$PORT_DENIED"; do
+    try_connect "$vpc" client "$SERVER_IP" "$port" >/dev/null
+  done
+done
+sleep 4
+
+raw=$(cilium_exec hubble observe --last 300 -o json)
+
+for vpc in "${VPCS[@]}"; do
+  vni=$(pod_vni "$vpc" server)
+  cid=$(cilium_exec cilium-dbg endpoint get "vni-ipv4:${vni}:${CLIENT_IP}" -o jsonpath='{[0].status.identity.id}')
+  sid=$(cilium_exec cilium-dbg endpoint get "vni-ipv4:${vni}:${SERVER_IP}" -o jsonpath='{[0].status.identity.id}')
+
+  log "${vpc}: vni=${vni}  client identity=${cid}  server identity=${sid}"
+  report=$(echo "$raw" | VNI="$vni" SRC="$CLIENT_IP" DST="$SERVER_IP" python3 -c "
+import json,os,sys
+vni=int(os.environ['VNI']); src=os.environ['SRC']; dst=os.environ['DST']
+rows=[]
+for line in sys.stdin:
+    try: f=json.loads(line).get('flow',{})
+    except Exception: continue
+    ip=f.get('IP',{}) or {}
+    s=f.get('source',{}) or {}; d=f.get('destination',{}) or {}
+    if ip.get('source')!=src or ip.get('destination')!=dst: continue
+    if int(s.get('vni_id') or 0)!=vni: continue
+    l4=(f.get('l4',{}) or {}).get('TCP',{}) or {}
+    rows.append({'sv':s.get('vni_id'),'dv':d.get('vni_id'),'si':s.get('identity'),'di':d.get('identity'),
+                 'sp':s.get('pod_name'),'dp':d.get('pod_name'),'port':l4.get('destination_port'),
+                 'verdict':f.get('verdict'),'reason':f.get('drop_reason_desc')})
+agg={}
+for r in rows:
+    k=(r['port'],r['verdict'],r['reason'])
+    agg[k]=agg.get(k,0)+1
+print('FLOWS %d' % len(rows))
+for (port,verdict,reason),n in sorted(agg.items(), key=lambda x:str(x[0])):
+    print('  port=%-5s verdict=%-9s reason=%-22s count=%d' % (port,verdict,reason or '-',n))
+if rows:
+    r=rows[0]
+    print('  sample: %s(vni=%s,id=%s) -> %s(vni=%s,id=%s)' % (r['sp'],r['sv'],r['si'],r['dp'],r['dv'],r['di']))
+    print('IDS %s %s' % (r['si'], r['di']))
+    print('MISSING %d' % sum(1 for r in rows if not r['sv'] or not r['dv'] or not r['si'] or not r['di']))
+")
+  echo "$report" | grep -v '^IDS\|^MISSING\|^FLOWS' | sed 's/^/    /'
+  n=$(echo "$report" | awk '/^FLOWS/{print $2}')
+  miss=$(echo "$report" | awk '/^MISSING/{print $2}')
+  fids=$(echo "$report" | awk '/^IDS/{print $2" "$3}')
+
+  [[ "${n:-0}" -gt 0 ]] && pass "${vpc}: ${n} forwarding-plane records visible under vni=${vni}" \
+                        || fail "${vpc}: no flows visible for vni=${vni}"
+  assert_eq "0" "${miss:-x}" "${vpc}: every record carries VNI and identity on both endpoints"
+  assert_eq "${cid} ${sid}" "${fids:-none}" "${vpc}: the record identities are this VPC's endpoints"
+
+  case "$vpc" in
+    vpc-a) echo "$report" | grep -q "verdict=DROPPED" && pass "vpc-a: traffic is dropped as the policy says" || fail "vpc-a: expected drops" ;;
+    vpc-b)
+      echo "$report" | grep -qE "port=${PORT_ALLOWED} +verdict=FORWARDED" && pass "vpc-b: ${PORT_ALLOWED} forwarded" || fail "vpc-b: ${PORT_ALLOWED} not forwarded"
+      echo "$report" | grep -qE "port=${PORT_DENIED} +verdict=DROPPED" && pass "vpc-b: ${PORT_DENIED} dropped" || fail "vpc-b: ${PORT_DENIED} not dropped"
+      ;;
+    vpc-c)
+      echo "$report" | grep -q "verdict=DROPPED" && fail "vpc-c: unexpected drops" || pass "vpc-c: nothing is dropped"
+      ;;
+  esac
+  echo
+done
+
+log "flows can be filtered per VPC through the VNI identity label"
+for vpc in "${VPCS[@]}"; do
+  vni=$(pod_vni "$vpc" server)
+  out=$(cilium_exec hubble observe --last 300 --label "vni:io-cilium-native-vpc-vni=${vni}" -o json \
+        | python3 -c "
+import json,sys
+vnis=set()
+n=0
+for line in sys.stdin:
+    try: f=json.loads(line).get('flow',{})
+    except Exception: continue
+    n+=1
+    for side in ('source','destination'):
+        v=(f.get(side,{}) or {}).get('vni_id')
+        if v: vnis.add(int(v))
+print(n, sorted(vnis))
+")
+  cnt=$(echo "$out" | awk '{print $1}')
+  vset=$(echo "$out" | cut -d' ' -f2-)
+  info "${vpc}: --label vni:...=${vni} -> ${cnt} flows, VNIs seen ${vset}"
+  [[ "${cnt:-0}" -gt 0 ]] && pass "${vpc}: the label filter returns flows" || fail "${vpc}: label filter returned nothing"
+  [[ "$vset" == "[${vni}]" ]] && pass "${vpc}: the filter returns only vni=${vni}" \
+                              || fail "${vpc}: the filter leaked other VNIs: ${vset}"
+done
+
+summary

--- a/test/native-vpc/50-datapath.sh
+++ b/test/native-vpc/50-datapath.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Datapath and tooling checks: the BPF map layouts this feature introduced, the
+# per-endpoint load-time VNI, and the debug commands that must cope with
+# (VNI, IP) keys.
+#
+# Regression guards for two defects that reached a running cluster:
+#   * the full ipcache dump used to panic the agent on VNI keys, which made
+#     "cilium-dbg ip list" (GET /ipcache) fatal;
+#   * the fragment map key had no VPC scope, and later the C/Go layouts
+#     disagreed, which made the agent exit on the alignment check.
+set -uo pipefail
+cd "$(dirname "$0")" && source ./lib.sh
+
+log "the agent is healthy and running the native-vpc build"
+st=$(cilium_exec cilium-dbg status --brief)
+assert_eq "OK" "$st" "cilium-dbg status --brief"
+kubectl -n "$CILIUM_NS" logs "$(cilium_pod)" -c cilium-agent --tail=2000 2>/dev/null \
+  | grep -qiE "level=fatal|alignment check failed" \
+  && fail "the agent log contains a fatal error" \
+  || pass "no fatal error in the agent log"
+
+log "forwarding plane: the VNI-scoped ipcache map exists with the expected layout"
+vni_map=$(kubectl -n "$CILIUM_NS" exec "$(cilium_pod)" -c cilium-agent -- \
+  sh -c 'ls /sys/fs/bpf/tc/globals/cilium_ipcache_vni 2>/dev/null' 2>/dev/null)
+[[ -n "$vni_map" ]] && pass "cilium_ipcache_vni is pinned" || fail "cilium_ipcache_vni is missing"
+
+if command -v bpftool >/dev/null 2>&1; then
+  keysz=$(bpftool map show pinned /sys/fs/bpf/tc/globals/cilium_ipcache_vni 2>/dev/null | grep -oE 'key [0-9]+B' | grep -oE '[0-9]+')
+  assert_eq "28" "${keysz:-?}" "cilium_ipcache_vni key size (VNI + family + IP)"
+
+  # 16 bytes = the native-vpc fragment key (12 without the VPC scope). A wrong
+  # size here is what previously made the agent fail the alignment check.
+  fragsz=$(bpftool map show pinned /sys/fs/bpf/tc/globals/cilium_ipv4_frag_datagrams 2>/dev/null | grep -oE 'key [0-9]+B' | grep -oE '[0-9]+')
+  assert_eq "16" "${fragsz:-?}" "cilium_ipv4_frag_datagrams key size (VNI scoped)"
+else
+  warn "bpftool not available on the host, skipping map layout checks"
+fi
+
+log "forwarding plane: each endpoint is loaded with its own VNI"
+for vpc in "${VPCS[@]}"; do
+  vni=$(pod_vni "$vpc" server)
+  epid=$(cilium_exec cilium-dbg endpoint get "vni-ipv4:${vni}:${SERVER_IP}" -o jsonpath='{[0].id}')
+  loaded=$(kubectl -n "$CILIUM_NS" exec "$(cilium_pod)" -c cilium-agent -- \
+    sh -c "grep -o '\"VNIID\":[0-9]*' /var/run/cilium/state/${epid}/ep_config.json 2>/dev/null | head -1" 2>/dev/null)
+  assert_eq "\"VNIID\":${vni}" "$loaded" "${vpc}: endpoint ${epid} carries the load-time VNI"
+done
+
+log "cache plane: the full ipcache dump handles VNI keys (used to crash the agent)"
+# Keep the full listing: identities print on several lines, so truncating it
+# would hide the very rows this check is about.
+out=$(cilium_exec cilium-dbg ip list 2>&1)
+if [[ -n "$out" ]] && ! echo "$out" | grep -qi "panic\|error"; then
+  pass "cilium-dbg ip list works"
+else
+  fail "cilium-dbg ip list failed: $(echo "$out" | head -3)"
+fi
+st2=$(cilium_exec cilium-dbg status --brief)
+assert_eq "OK" "$st2" "the agent survived the full dump"
+# The listing must make the VPC scope visible: without it the three VPCs show
+# up as identical rows for the same address.
+n=$(echo "$out" | grep -c "@vni:")
+[[ "${n:-0}" -ge 3 ]] && pass "the listing shows the VPC scope (${n} entries)" \
+                      || fail "the listing does not show the VPC scope"
+distinct=$(echo "$out" | grep "${SERVER_IP}/32@vni:" | awk '{print $1}' | sort -u | wc -l)
+assert_eq "3" "$distinct" "the shared address appears as three distinguishable rows"
+
+log "observability tooling: a shared address resolves to every VPC that uses it"
+got=$(cilium_exec cilium-dbg bpf ipcache get "$SERVER_IP")
+for vpc in "${VPCS[@]}"; do
+  vni=$(pod_vni "$vpc" server)
+  assert_contains "$got" "@vni:${vni}" "bpf ipcache get ${SERVER_IP} reports vni:${vni}"
+done
+
+summary

--- a/test/native-vpc/55-vni-scope-change.sh
+++ b/test/native-vpc/55-vni-scope-change.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# 55 - the scope of an endpoint is not a mutable field.
+#
+# An ipcache entry is keyed by (VNI, IP), so "the address did not change" says
+# nothing about whether an entry is still the right one. Two rules follow, and
+# this test checks both against a live cluster:
+#
+#   1. a running pod does not move between VPCs because its tunnel_key
+#      annotation changed - the VNI is an identity and datapath dimension, and
+#      nothing here re-derives the identity, the CiliumEndpoint other nodes
+#      read, or the loaded BPF configuration. The annotation may drift; the
+#      endpoint keeps the VPC it was admitted with, including across an agent
+#      restart, and no entry is ever published under the VPC named by the
+#      drifted annotation.
+#
+#   2. a real move (delete and recreate in another VPC, keeping the address)
+#      leaves nothing behind: the entry of the old VPC is gone and only the new
+#      one remains. Because all three subnets share one CIDR, the same address
+#      is genuinely valid in both, which is exactly the case where a leftover
+#      entry would resolve to the wrong pod.
+
+set -uo pipefail
+cd "$(dirname "$0")" && source ./lib.sh
+
+PROBE_NS=vpc-c
+PROBE=vni-scope-probe
+PROBE_IP=10.99.0.31
+DRIFT_VNI=4095   # a VNI no subnet in the fixture uses
+
+cleanup_probe() { for ns in "${VPCS[@]}"; do kubectl -n "$ns" delete pod "$PROBE" --wait=true >/dev/null 2>&1; done; }
+trap cleanup_probe EXIT
+
+# entries_for <ip> - the VNIs under which the BPF ipcache holds that address
+entries_for() {
+  cilium_exec cilium-dbg bpf ipcache list | awk -v ip="$1/32" '$1 ~ "^"ip"@vni:" {sub(/.*@vni:/,"",$1); print $1}' | sort -n | tr '\n' ' ' | sed 's/ $//'
+}
+
+make_probe() {  # make_probe <namespace> <subnet>
+  cat <<EOF | kubectl apply -f - >/dev/null
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $PROBE
+  namespace: $1
+  labels: {app: $PROBE}
+  annotations:
+    ovn.kubernetes.io/logical_switch: $2
+    ovn.kubernetes.io/ip_address: $PROBE_IP
+spec:
+  nodeName: $(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+  containers:
+  - name: c
+    image: busybox:1.36
+    command: ["sleep","3600"]
+    imagePullPolicy: IfNotPresent
+  terminationGracePeriodSeconds: 1
+EOF
+  kubectl -n "$1" wait --for=condition=Ready "pod/$PROBE" --timeout=120s >/dev/null 2>&1
+  # kube-ovn writes tunnel_key as part of admitting the pod into the subnet; it
+  # can land slightly after the pod is Ready.
+  for _ in $(seq 30); do
+    [[ -n "$(pod_vni "$1" "$PROBE")" ]] && break
+    sleep 2
+  done
+  sleep 4
+}
+
+restart_agent() {
+  kubectl -n "$CILIUM_NS" rollout restart ds/cilium >/dev/null 2>&1
+  kubectl -n "$CILIUM_NS" rollout status ds/cilium --timeout=240s >/dev/null 2>&1
+  sleep 12
+}
+
+log "a pod is admitted into the VPC of its subnet"
+cleanup_probe
+make_probe "$PROBE_NS" "subnet-${PROBE_NS}"
+HOME_VNI=$(pod_vni "$PROBE_NS" "$PROBE")
+info "pod ${PROBE_NS}/${PROBE} ip=${PROBE_IP} vni=${HOME_VNI}"
+assert_eq "$HOME_VNI" "$(entries_for "$PROBE_IP")" \
+  "the address exists in exactly one VPC"
+
+log "the annotation drifts while the pod runs"
+# This is what an administrator changing a subnet's tunnel key looks like from
+# Cilium's side: the pod object changes, the datapath does not.
+kubectl -n "$PROBE_NS" annotate pod "$PROBE" "ovn.kubernetes.io/tunnel_key=${DRIFT_VNI}" --overwrite >/dev/null
+sleep 8
+assert_eq "$DRIFT_VNI" "$(pod_vni "$PROBE_NS" "$PROBE")" "the pod now claims another VPC"
+assert_eq "$HOME_VNI" "$(entries_for "$PROBE_IP")" \
+  "the running pod stays in the VPC it was admitted with"
+
+log "the drift survives an agent restart without being adopted"
+# The restart is the interesting half: restore re-reads the annotation, which is
+# how a pod that never had a VNI picks one up. Taking a *different* one here
+# would move the address into a VPC while the identity still names another.
+before=$(cilium_exec cilium-dbg bpf ipcache list | grep -c "@vni:")
+restart_agent
+assert_eq "$HOME_VNI" "$(entries_for "$PROBE_IP")" \
+  "after restore the address is still only in its own VPC"
+refusals=$(kubectl -n "$CILIUM_NS" logs "$(cilium_pod)" -c cilium-agent 2>/dev/null \
+  | grep -c "Ignoring native-vpc VNI change on an existing endpoint")
+if [[ "${refusals:-0}" -gt 0 ]]; then
+  pass "the refusal is reported (${refusals} log lines)"
+else
+  fail "restore adopted the drifted VNI silently, or did not report refusing it"
+fi
+after=$(cilium_exec cilium-dbg bpf ipcache list | grep -c "@vni:")
+assert_eq "$before" "$after" "the restart did not change the number of scoped entries"
+
+log "no entry is published under the VPC named by the drifted annotation"
+# The pod watcher keeps its own placeholder entries; those must not name a VPC
+# the endpoint refused either, including during the startup window in which the
+# endpoints are not restored yet.
+drifted=$(cilium_exec cilium-dbg bpf ipcache list | grep -c "@vni:${DRIFT_VNI}")
+assert_eq "0" "${drifted:-x}" "nothing exists in VPC ${DRIFT_VNI}"
+
+log "the identity still describes the VPC the pod is in"
+labels=$(cilium_exec cilium-dbg endpoint list -o json \
+  | python3 -c "
+import json,sys
+for e in json.load(sys.stdin):
+    st=e.get('status',{})
+    for a in (st.get('networking',{}) or {}).get('addressing',[]) or []:
+        if a.get('ipv4')=='${PROBE_IP}':
+            print(' '.join(st['identity']['labels'])); raise SystemExit
+")
+assert_contains "$labels" "vni:io-cilium-native-vpc-vni=${HOME_VNI}" \
+  "the identity label names the same VPC as the entry"
+
+log "moving the pod to another VPC leaves nothing behind"
+# The address is valid in every VPC of the fixture, so a leftover entry would
+# not be inert: it would answer for an address another VPC legitimately owns.
+cleanup_probe
+sleep 5
+assert_eq "" "$(entries_for "$PROBE_IP")" "deleting the pod removes its entry"
+
+make_probe vpc-a subnet-vpc-a
+NEW_VNI=$(pod_vni vpc-a "$PROBE")
+PROBE_NS=vpc-a
+info "recreated in vpc-a with the same address, vni=${NEW_VNI}"
+assert_eq "$NEW_VNI" "$(entries_for "$PROBE_IP")" \
+  "the address exists only in the new VPC (no entry left in VPC ${HOME_VNI})"
+
+log "cleanup"
+cleanup_probe
+sleep 4
+assert_eq "" "$(entries_for "$PROBE_IP")" "the fixture is left as it was found"
+
+summary

--- a/test/native-vpc/60-service.sh
+++ b/test/native-vpc/60-service.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Service plane: Cilium must not translate a service address for an endpoint
+# that has a VNI.
+#
+# A backend address is just an IP, and kube-ovn resolves it inside the sender's
+# own VPC, so translating it could send a client of one tenant to a pod of
+# another. Cilium therefore skips the service lookup for VPC endpoints and
+# leaves load balancing to kube-ovn. This check proves both halves: services
+# still work, and the flow record keeps the service address (which is also what
+# lets Hubble annotate it).
+#
+# The probe runs in the default VPC, which is the only one with cluster DNS.
+set -uo pipefail
+cd "$(dirname "$0")" && source ./lib.sh
+
+NS=default
+PROBE=vni-svc-probe
+DNS_IP=$(kubectl -n kube-system get svc -l k8s-app=kube-dns -o jsonpath='{.items[0].spec.clusterIP}' 2>/dev/null)
+[[ -z "$DNS_IP" ]] && DNS_IP=$(kubectl -n kube-system get svc kube-dns -o jsonpath='{.spec.clusterIP}' 2>/dev/null)
+
+log "cluster DNS service address: ${DNS_IP:-<none>}"
+[[ -n "$DNS_IP" ]] && pass "found the DNS ClusterIP" || { fail "no DNS ClusterIP"; summary; exit 1; }
+
+log "starting a probe pod in the default VPC"
+kubectl -n "$NS" delete pod "$PROBE" --wait=true >/dev/null 2>&1
+kubectl apply -f - >/dev/null <<YAML
+apiVersion: v1
+kind: Pod
+metadata: {name: ${PROBE}, namespace: ${NS}, labels: {app: ${PROBE}}}
+spec:
+  containers:
+  - {name: c, image: docker.io/library/busybox:1.36, imagePullPolicy: IfNotPresent,
+     command: ["sh","-c","sleep infinity"]}
+YAML
+wait_for_pod "$NS" "$PROBE" || { fail "probe pod did not start"; summary; exit 1; }
+vni=$(pod_vni "$NS" "$PROBE")
+[[ -n "$vni" ]] && pass "the probe is a VPC endpoint (vni=${vni})" || fail "probe has no VNI"
+
+log "the service still resolves (kube-ovn performs the load balancing)"
+if kubectl -n "$NS" exec "$PROBE" -- nslookup kubernetes.default.svc.cluster.local "$DNS_IP" 2>&1 | grep -q "Address"; then
+  pass "ClusterIP ${DNS_IP} works from a VPC endpoint"
+else
+  fail "ClusterIP ${DNS_IP} is unreachable from a VPC endpoint"
+fi
+
+log "the datapath did not rewrite the destination"
+kubectl -n "$NS" exec "$PROBE" -- nslookup kubernetes.default.svc.cluster.local "$DNS_IP" >/dev/null 2>&1
+sleep 3
+flows=$(cilium_exec hubble observe --last 100 -o json | python3 -c "
+import json,sys
+keep=[]
+for line in sys.stdin:
+    try: f=json.loads(line).get('flow',{})
+    except Exception: continue
+    ip=f.get('IP',{}) or {}
+    if ip.get('destination')=='${DNS_IP}':
+        s=f.get('source',{}) or {}
+        svc=f.get('destination_service',{}) or {}
+        keep.append((ip.get('source'),ip.get('destination'),s.get('vni_id'),svc.get('namespace'),svc.get('name')))
+for k in keep[:3]: print('  %s -> %s src_vni=%s svc=%s/%s' % k)
+print('count=%d' % len(keep))
+")
+echo "$flows" | sed 's/^/    /'
+cnt=$(echo "$flows" | awk -F= '/^count=/{print $2}')
+[[ "${cnt:-0}" -gt 0 ]] \
+  && pass "flows keep the service address as destination (not a backend address)" \
+  || fail "no flow towards ${DNS_IP}: the destination may have been rewritten"
+echo "$flows" | grep -q "svc=kube-system/" \
+  && pass "Hubble annotates the flow with the service name" \
+  || warn "no service annotation on the flow"
+
+log "the VPC endpoint's own address is not a service backend in the BPF maps"
+lb=$(cilium_exec cilium-dbg bpf lb list | grep -c "${SERVER_IP}" || true)
+assert_eq "0" "${lb:-0}" "the overlapping address is not programmed as a backend"
+
+kubectl -n "$NS" delete pod "$PROBE" --wait=false >/dev/null 2>&1
+summary

--- a/test/native-vpc/70-lifecycle.sh
+++ b/test/native-vpc/70-lifecycle.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Lifecycle plane: the state that ties an endpoint to its VPC must survive a
+# restart, and must not be lost when the annotation temporarily disappears.
+#
+#   * the CiliumEndpoint carries the VNI so that the agents of other nodes can
+#     scope the endpoint (dropping this annotation used to make every remote
+#     endpoint lose its VPC);
+#   * an annotation that disappears from a running pod must not downgrade the
+#     endpoint into the shared plain scope - that is the direction that merges
+#     two VPCs;
+#   * after an agent restart the VNI, the identities and the VNI-scoped ipcache
+#     must come back, and the policy behaviour must be unchanged;
+#   * deleting one VPC's pod must not disturb the entries of the other VPCs.
+set -uo pipefail
+cd "$(dirname "$0")" && source ./lib.sh
+
+log "the CiliumEndpoint carries the VNI annotation"
+for vpc in "${VPCS[@]}"; do
+  vni=$(pod_vni "$vpc" server)
+  cep=$(kubectl -n "$vpc" get cep server -o jsonpath='{.metadata.annotations.native-vpc\.cilium\.io/vni}' 2>/dev/null)
+  assert_eq "$vni" "$cep" "${vpc}: CiliumEndpoint annotation matches the pod's tunnel_key"
+done
+
+log "removing the annotation from a running pod must not drop its VPC scope"
+before=$(cilium_exec cilium-dbg endpoint get "vni-ipv4:$(pod_vni vpc-b server):${SERVER_IP}" -o jsonpath='{[0].id}')
+kubectl -n vpc-b annotate pod server ovn.kubernetes.io/tunnel_key- >/dev/null 2>&1
+sleep 8
+after=$(cilium_exec cilium-dbg endpoint get "vni-ipv4:$(kubectl -n vpc-b get cep server -o jsonpath='{.metadata.annotations.native-vpc\.cilium\.io/vni}' 2>/dev/null):${SERVER_IP}" -o jsonpath='{[0].id}' 2>/dev/null)
+assert_eq "$before" "$after" "vpc-b: the endpoint keeps its VPC scope without the annotation"
+still=$(try_connect vpc-b client "$SERVER_IP" "$PORT_ALLOWED")
+assert_eq "open" "$still" "vpc-b: policy still behaves as before"
+# put it back so the rest of the suite sees a consistent cluster
+kubectl -n vpc-b annotate pod server "ovn.kubernetes.io/tunnel_key=7" --overwrite >/dev/null 2>&1
+
+log "restarting the agent and re-checking every plane"
+kubectl -n "$CILIUM_NS" rollout restart ds/cilium >/dev/null 2>&1
+kubectl -n "$CILIUM_NS" rollout status ds/cilium --timeout=180s >/dev/null 2>&1
+for _ in $(seq 30); do [[ "$(cilium_exec cilium-dbg status --brief)" == "OK" ]] && break; sleep 4; done
+assert_eq "OK" "$(cilium_exec cilium-dbg status --brief)" "the agent is healthy again"
+
+for vpc in "${VPCS[@]}"; do
+  vni=$(pod_vni "$vpc" server)
+  epid=$(cilium_exec cilium-dbg endpoint get "vni-ipv4:${vni}:${SERVER_IP}" -o jsonpath='{[0].id}')
+  [[ -n "$epid" ]] && pass "${vpc}: endpoint restored with vni ${vni} (id ${epid})" \
+                   || fail "${vpc}: endpoint lost its VNI across the restart"
+done
+ipc=$(cilium_exec cilium-dbg bpf ipcache list)
+n=$(echo "$ipc" | grep -c "${SERVER_IP}/32@vni:")
+assert_eq "3" "$n" "the VNI-scoped ipcache was repopulated"
+
+log "policy behaviour is unchanged after the restart"
+assert_eq "closed" "$(try_connect vpc-a client "$SERVER_IP" "$PORT_ALLOWED")" "vpc-a still denies"
+assert_eq "open"   "$(try_connect vpc-b client "$SERVER_IP" "$PORT_ALLOWED")" "vpc-b still allows tcp/${PORT_ALLOWED}"
+assert_eq "closed" "$(try_connect vpc-b client "$SERVER_IP" "$PORT_DENIED")"  "vpc-b still blocks tcp/${PORT_DENIED}"
+assert_eq "open"   "$(try_connect vpc-c client "$SERVER_IP" "$PORT_ALLOWED")" "vpc-c still open"
+
+log "deleting one VPC's pod leaves the other VPCs untouched"
+kubectl -n vpc-a delete pod server --wait=true >/dev/null 2>&1
+sleep 6
+ipc=$(cilium_exec cilium-dbg bpf ipcache list)
+gone=$(echo "$ipc" | grep -c "${SERVER_IP}/32@vni:$(pod_vni vpc-b server)" || true)
+left=$(echo "$ipc" | grep -c "${SERVER_IP}/32@vni:" || true)
+assert_eq "1" "${gone:-0}" "vpc-b's entry for the shared address survived"
+assert_eq "2" "${left:-0}" "exactly the deleted VPC's entry disappeared"
+assert_eq "open" "$(try_connect vpc-c client "$SERVER_IP" "$PORT_ALLOWED")" "vpc-c is unaffected by the deletion"
+
+summary

--- a/test/native-vpc/80-logs.sh
+++ b/test/native-vpc/80-logs.sh
@@ -50,16 +50,20 @@ log "every warning is one of the expected ones"
 #  1. the conntrack overlap notice this feature emits on purpose - the fixture
 #     co-locates overlapping addresses, so it *must* appear;
 #  2. leftover "<id>_next" state directories from endpoint regeneration, which
-#     the restorer skips (upstream behaviour, not related to this feature).
+#     the restorer skips (upstream behaviour, not related to this feature);
+#  3. the refusal to move an endpoint between VPCs on a drifted annotation,
+#     which 55-vni-scope-change.sh provokes on purpose.
 warns=$(kubectl -n "$CILIUM_NS" logs "$AGENT" -c cilium-agent 2>/dev/null | grep 'level=warn' || true)
 total=$(echo "$warns" | grep -c . || true)
 overlap=$(echo "$warns" | grep -c "local endpoints of different VPCs share an IP" || true)
 stale=$(echo "$warns" | grep -c "Couldn't find state, ignoring endpoint" || true)
+scope=$(echo "$warns" | grep -c "Ignoring native-vpc VNI change on an existing endpoint" || true)
 other=$(echo "$warns" | grep -v "local endpoints of different VPCs share an IP" \
-                      | grep -v "Couldn't find state, ignoring endpoint" | grep -c . || true)
-info "warnings: ${total} total = ${overlap} conntrack-overlap + ${stale} stale-state + ${other} other"
+                      | grep -v "Couldn't find state, ignoring endpoint" \
+                      | grep -v "Ignoring native-vpc VNI change on an existing endpoint" | grep -c . || true)
+info "warnings: ${total} total = ${overlap} conntrack-overlap + ${stale} stale-state + ${scope} refused-scope-change + ${other} other"
 assert_eq "0" "${other:-x}" "no unexpected warnings"
-[[ "${other:-0}" != "0" ]] && echo "$warns" | grep -v "share an IP" | grep -v "Couldn't find state" \
+[[ "${other:-0}" != "0" ]] && echo "$warns" | grep -v "share an IP" | grep -v "Couldn't find state" | grep -v "Ignoring native-vpc VNI change" \
   | cut -c1-160 | tail -5 | sed 's/^/    /'
 
 # The overlap warning is not noise: it is the conntrack-plane signal, and the

--- a/test/native-vpc/80-logs.sh
+++ b/test/native-vpc/80-logs.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Log and counter review.
+#
+# A feature that keeps overlapping addresses apart can easily "work" while the
+# agent complains in the background - a missing annotation, an ipcache entry it
+# refuses to write, a datapath drop with an unexpected reason. This script
+# fails on any error, on any warning that is not explicitly expected, and on
+# any datapath drop from the pod path other than the policy drops the test
+# scenarios ask for.
+set -uo pipefail
+cd "$(dirname "$0")" && source ./lib.sh
+
+AGENT=$(cilium_pod)
+OPERATOR=$(kubectl -n "$CILIUM_NS" get pod -l io.cilium/app=operator -o name 2>/dev/null | head -1)
+
+log "no error or fatal in the agent log"
+errs=$(kubectl -n "$CILIUM_NS" logs "$AGENT" -c cilium-agent 2>/dev/null | grep -cE 'level=(error|fatal)')
+assert_eq "0" "${errs:-x}" "agent error/fatal lines"
+[[ "${errs:-0}" != "0" ]] && kubectl -n "$CILIUM_NS" logs "$AGENT" -c cilium-agent 2>/dev/null \
+  | grep -E 'level=(error|fatal)' | tail -5 | sed 's/^/    /'
+
+log "every policy currently in the cluster is valid"
+# Judge the current state, not the log history: a policy that was rejected
+# earlier in the session and then corrected would otherwise fail this check
+# forever.
+invalid=0
+for ns in "${VPCS[@]}"; do
+  for name in $(kubectl -n "$ns" get cnp -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+    msg=$(kubectl -n "$ns" get cnp "$name" -o jsonpath='{.status.conditions[?(@.type=="Valid")].message}' 2>/dev/null)
+    info "${ns}/${name}: ${msg:-<no status>}"
+    [[ "$msg" == "Policy validation succeeded" ]] || invalid=$((invalid+1))
+  done
+done
+assert_eq "0" "$invalid" "no invalid CiliumNetworkPolicy"
+
+if [[ -n "$OPERATOR" ]]; then
+  log "operator errors, classified"
+  oerrs=$(kubectl -n "$CILIUM_NS" logs "$OPERATOR" 2>/dev/null | grep -E 'level=(error|fatal)' || true)
+  n_all=$(echo "$oerrs" | grep -c . || true)
+  # "Detected invalid CNP" is only meaningful if a policy is *still* invalid,
+  # which the check above covers.
+  n_other=$(echo "$oerrs" | grep -v "Detected invalid CNP" | grep -c . || true)
+  info "operator: ${n_all} error lines, ${n_other} unrelated to CNP validation"
+  assert_eq "0" "${n_other:-x}" "no operator error outside CNP validation"
+  [[ "${n_other:-0}" != "0" ]] && echo "$oerrs" | grep -v "Detected invalid CNP" | tail -3 | cut -c1-160 | sed 's/^/    /'
+fi
+
+log "every warning is one of the expected ones"
+# Expected warnings:
+#  1. the conntrack overlap notice this feature emits on purpose - the fixture
+#     co-locates overlapping addresses, so it *must* appear;
+#  2. leftover "<id>_next" state directories from endpoint regeneration, which
+#     the restorer skips (upstream behaviour, not related to this feature).
+warns=$(kubectl -n "$CILIUM_NS" logs "$AGENT" -c cilium-agent 2>/dev/null | grep 'level=warn' || true)
+total=$(echo "$warns" | grep -c . || true)
+overlap=$(echo "$warns" | grep -c "local endpoints of different VPCs share an IP" || true)
+stale=$(echo "$warns" | grep -c "Couldn't find state, ignoring endpoint" || true)
+other=$(echo "$warns" | grep -v "local endpoints of different VPCs share an IP" \
+                      | grep -v "Couldn't find state, ignoring endpoint" | grep -c . || true)
+info "warnings: ${total} total = ${overlap} conntrack-overlap + ${stale} stale-state + ${other} other"
+assert_eq "0" "${other:-x}" "no unexpected warnings"
+[[ "${other:-0}" != "0" ]] && echo "$warns" | grep -v "share an IP" | grep -v "Couldn't find state" \
+  | cut -c1-160 | tail -5 | sed 's/^/    /'
+
+# The overlap warning is not noise: it is the conntrack-plane signal, and the
+# fixture deliberately triggers it.
+[[ "${overlap:-0}" -gt 0 ]] \
+  && pass "the conntrack overlap warning was emitted (${overlap}x), as expected for this fixture" \
+  || fail "the conntrack overlap warning is missing although the fixture overlaps addresses"
+
+log "no native-vpc specific complaint"
+for pat in "missing a valid VNI" "skipping ipcache registration" \
+           "keeping the last known VNI" "does not match the pod annotation" \
+           "alignment check failed" "unable to parse ipcache key"; do
+  n=$(kubectl -n "$CILIUM_NS" logs "$AGENT" -c cilium-agent 2>/dev/null | grep -c "$pat" || true)
+  assert_eq "0" "${n:-x}" "no '${pat}' message"
+done
+
+log "drops on the test addresses are policy drops only"
+# Hubble carries a structured drop reason, so classify there rather than
+# parsing the counter table (whose REASON column is multi-word, and whose
+# "Interface" rows are REASON_PLAINTEXT forwards, not drops).
+drops=$(cilium_exec hubble observe --last 400 -o json | SRC="$CLIENT_IP" DST="$SERVER_IP" python3 -c "
+import json,os,sys
+from collections import Counter
+src=os.environ['SRC']; dst=os.environ['DST']
+mine=Counter(); other=Counter()
+for line in sys.stdin:
+    try: f=json.loads(line).get('flow',{})
+    except Exception: continue
+    if f.get('verdict')!='DROPPED': continue
+    ip=f.get('IP',{}) or {}
+    reason=f.get('drop_reason_desc') or '?'
+    if ip.get('source')==src and ip.get('destination')==dst:
+        mine[reason]+=1
+    else:
+        other[reason]+=1
+print('MINE ' + ','.join('%s=%d'%kv for kv in sorted(mine.items())))
+print('OTHER ' + ','.join('%s=%d'%kv for kv in sorted(other.items())))
+")
+echo "$drops" | sed 's/^/    /'
+mine=$(echo "$drops" | awk '/^MINE/{print $2}')
+bad=$(echo "$mine" | tr ',' '\n' | grep -v '^POLICY_DENIED=' | grep -c . || true)
+assert_eq "0" "${bad:-x}" "every drop between the test addresses is POLICY_DENIED"
+echo "$mine" | grep -q "POLICY_DENIED=" \
+  && pass "policy drops observed for the deny/port scenarios" \
+  || fail "no policy drop observed although two VPCs deny traffic"
+
+log "other drops in the cluster are explained"
+# With enable-ipv6=false the pods still emit IPv6 link-local traffic (NDP,
+# mDNS), which the datapath drops as an unsupported protocol. That is
+# environmental, not a VPC scoping problem.
+v6=$(kubectl -n "$CILIUM_NS" get cm cilium-config -o jsonpath='{.data.enable-ipv6}' 2>/dev/null)
+info "enable-ipv6=${v6}"
+otherd=$(echo "$drops" | awk '/^OTHER/{print $2}')
+info "other drop reasons: ${otherd:-none}"
+unexplained=$(echo "$otherd" | tr ',' '\n' \
+  | grep -vE '^(UNSUPPORTED_L2_PROTOCOL|UNSUPPORTED_L3_PROTOCOL|STALE_OR_UNROUTABLE_IP|POLICY_DENIED)=' \
+  | grep -c . || true)
+assert_eq "0" "${unexplained:-x}" "no unexplained drop reason anywhere"
+
+log "kube-ovn is not complaining about the overlapping subnets"
+# "the vpc X not standby yet, requeue" is kube-ovn reconciling a subnet before
+# its VPC router is ready; it retries and settles. Anything else would be worth
+# looking at, e.g. a complaint about the overlapping CIDRs.
+kovn=$(kubectl -n kube-system logs -l app=kube-ovn-controller --tail=500 2>/dev/null | grep -iE '\berror\b' || true)
+# Transient reconcile races while a VPC/subnet is being created or deleted:
+# the controller requeues and settles. They say nothing about the CIDR overlap.
+transient=$(echo "$kovn" | grep -cE "not standby yet|not found, requeuing|v4 using ip range is empty" || true)
+rest=$(echo "$kovn" | grep -vE "not standby yet|not found, requeuing|v4 using ip range is empty" | grep -c . || true)
+info "kube-ovn-controller: ${transient} transient requeues, ${rest} other errors"
+assert_eq "0" "${rest:-x}" "kube-ovn reports no error about the overlapping subnets"
+for vpc in "${VPCS[@]}"; do
+  ready=$(kubectl get subnet "subnet-${vpc}" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)
+  assert_eq "True" "${ready:-?}" "subnet-${vpc} is Ready now"
+done
+[[ "${rest:-0}" != "0" ]] && echo "$kovn" | grep -v "not standby yet" | tail -3 | cut -c1-160 | sed 's/^/    /'
+true
+
+summary

--- a/test/native-vpc/80-logs.sh
+++ b/test/native-vpc/80-logs.sh
@@ -128,15 +128,26 @@ log "kube-ovn is not complaining about the overlapping subnets"
 # its VPC router is ready; it retries and settles. Anything else would be worth
 # looking at, e.g. a complaint about the overlapping CIDRs.
 kovn=$(kubectl -n kube-system logs -l app=kube-ovn-controller --tail=500 2>/dev/null | grep -iE '\berror\b' || true)
-# Transient reconcile races while a VPC/subnet is being created or deleted:
-# the controller requeues and settles. They say nothing about the CIDR overlap.
-transient=$(echo "$kovn" | grep -cE "not standby yet|not found, requeuing|v4 using ip range is empty" || true)
-rest=$(echo "$kovn" | grep -vE "not standby yet|not found, requeuing|v4 using ip range is empty" | grep -c . || true)
+# Transient reconcile races while a VPC/subnet is being created or deleted: the
+# controller requeues and settles. They say nothing about the CIDR overlap.
+# "datapath binding not found" is the window between creating a logical switch
+# and OVN binding it, during which the switch has no tunnel key yet - the very
+# value this feature reads. It is asserted below to have settled.
+TRANSIENT="not standby yet|not found, requeuing|v4 using ip range is empty|datapath binding not found"
+transient=$(echo "$kovn" | grep -cE "$TRANSIENT" || true)
+rest=$(echo "$kovn" | grep -vE "$TRANSIENT" | grep -c . || true)
 info "kube-ovn-controller: ${transient} transient requeues, ${rest} other errors"
 assert_eq "0" "${rest:-x}" "kube-ovn reports no error about the overlapping subnets"
 for vpc in "${VPCS[@]}"; do
   ready=$(kubectl get subnet "subnet-${vpc}" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null)
   assert_eq "True" "${ready:-?}" "subnet-${vpc} is Ready now"
+  # The tunnel key is what this feature is built on, so "the controller could
+  # not read one yet" is only acceptable if it can now. Read it from the subnet
+  # rather than from a pod: earlier scripts delete pods on purpose.
+  key=$(kubectl get subnet "subnet-${vpc}" -o jsonpath='{.status.tunnelKey}' 2>/dev/null)
+  [[ -n "$key" && "$key" != "0" ]] \
+    && pass "subnet-${vpc} has settled on a tunnel key (${key})" \
+    || fail "subnet-${vpc} still has no usable tunnel key"
 done
 [[ "${rest:-0}" != "0" ]] && echo "$kovn" | grep -v "not standby yet" | tail -3 | cut -c1-160 | sed 's/^/    /'
 true

--- a/test/native-vpc/90-cleanup.sh
+++ b/test/native-vpc/90-cleanup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Removes everything the suite created.
+set -uo pipefail
+cd "$(dirname "$0")" && source ./lib.sh
+
+log "deleting policies and pods"
+for vpc in "${VPCS[@]}"; do
+  kubectl -n "$vpc" delete cnp --all --wait=false >/dev/null 2>&1
+  kubectl -n "$vpc" delete pod --all --wait=false >/dev/null 2>&1
+done
+sleep 5
+
+log "deleting subnets, VPCs and namespaces"
+for vpc in "${VPCS[@]}"; do
+  kubectl delete subnet "subnet-${vpc}" --wait=false >/dev/null 2>&1
+  kubectl delete vpc "$vpc" --wait=false >/dev/null 2>&1
+  kubectl delete ns "$vpc" --wait=false >/dev/null 2>&1
+done
+
+log "waiting for the namespaces to go away"
+for _ in $(seq 30); do
+  left=$(kubectl get ns -l vni-test=true --no-headers 2>/dev/null | wc -l)
+  [[ "$left" == "0" ]] && break
+  sleep 2
+done
+kubectl get ns -l vni-test=true --no-headers 2>/dev/null | sed 's/^/    still present: /'
+
+log "overlap metric after cleanup"
+cilium_exec cilium-dbg metrics list | grep native_vpc_overlapping_ips | sed 's/^/    /'

--- a/test/native-vpc/README.md
+++ b/test/native-vpc/README.md
@@ -1,0 +1,168 @@
+# native-vpc (VNI) end-to-end test suite
+
+Proves that Cilium keeps **overlapping IPs** apart by `(VNI, IP)` when kube-ovn
+provides several VPCs with the same subnet.
+
+## Fixture
+
+Three kube-ovn VPCs, each with a subnet using the **same** CIDR `10.99.0.0/24`,
+and each holding two pods pinned to the **same two addresses**:
+
+| VPC   | VNI (tunnel_key) | client       | server       | policy scenario              |
+|-------|------------------|--------------|--------------|------------------------------|
+| vpc-a | e.g. 5           | 10.99.0.11   | 10.99.0.12   | default deny (nothing works) |
+| vpc-b | e.g. 7           | 10.99.0.11   | 10.99.0.12   | only tcp/8080 allowed        |
+| vpc-c | e.g. 9           | 10.99.0.11   | 10.99.0.12   | no policy (everything works) |
+
+Every connection attempt in the suite uses the identical address pair
+`10.99.0.11 -> 10.99.0.12`, so any wrong result means one VPC's policy decided
+another VPC's traffic.
+
+## Scripts
+
+| Script                | What it does                                                                 |
+|-----------------------|------------------------------------------------------------------------------|
+| `00-setup.sh`         | creates the VPCs, the overlapping subnets, the namespaces and the six pods    |
+| `10-verify-vni.sh`    | asserts the control/cache/forwarding/conntrack state is scoped per VNI        |
+| `20-policies.sh`      | applies the three policy scenarios                                            |
+| `30-connectivity.sh`  | runs the connectivity matrix and the cross-VPC leak checks                    |
+| `35-policymap.sh`     | the identity-keyed policy map of each server, as the datapath sees it          |
+| `40-observability.sh` | asserts Hubble attributes every flow to the right VPC                         |
+| `45-hubble-vni.sh`    | per-VPC forwarding-plane records (VNI+IP+identity+verdict) and VNI filtering   |
+| `50-datapath.sh`      | BPF map layouts, per-endpoint load-time VNI, and the debug tooling             |
+| `60-service.sh`       | services are resolved by kube-ovn, not rewritten by Cilium                     |
+| `70-lifecycle.sh`     | CEP annotation, annotation loss, agent restart, pod deletion                   |
+| `80-logs.sh`          | log and counter review: no errors, only expected warnings, explained drops     |
+| `90-cleanup.sh`       | removes everything                                                            |
+| `run-all.sh`          | runs the whole suite and prints one verdict                                   |
+
+```bash
+./run-all.sh        # full run
+./90-cleanup.sh     # tear down
+```
+
+## What each check proves
+
+**10-verify-vni.sh** (17 checks)
+- each subnet hands out a different `ovn.kubernetes.io/tunnel_key`;
+- the three servers really share one address;
+- each endpoint's identity carries `vni:io-cilium-native-vpc-vni=<vni>` and the
+  three identities are distinct — this is what makes policy VPC-aware;
+- the ipcache holds three separate entries `10.99.0.12/32@vni:{5,7,9}`;
+- each endpoint is resolvable by its `vni-ipv4:<vni>:<ip>` identifier;
+- `cilium_native_vpc_overlapping_ips` reports the two shared addresses. This is
+  the conntrack-plane precondition: the CT key has no VPC scope, so co-locating
+  overlapping IPs on one node is only safe while this metric is watched.
+
+**30-connectivity.sh** (8 checks)
+- the six matrix cells behave exactly as the per-VPC policy says;
+- the same `10.99.0.11 -> 10.99.0.12:8080` is *denied* in vpc-a and *allowed* in
+  vpc-c;
+- `tcp/9090` is blocked in vpc-b while open in vpc-c for the same address pair.
+
+**40-observability.sh** (7 checks)
+- every flow between the shared addresses carries a VNI on *both* endpoints;
+- flows group by VNI to the correct namespace;
+- vpc-a shows drops while vpc-c shows none, i.e. the verdicts are not mixed
+  between VPCs that share addressing.
+
+## Traceability: which check covers which fix
+
+Every behaviour this PR changed has at least one live check. The planes refer
+to the review in `Documentation/network/native-vpc.rst`.
+
+| Plane | Behaviour introduced or fixed                          | Covered by                       |
+|-------|--------------------------------------------------------|----------------------------------|
+| 1 control    | pod annotation becomes the endpoint VNI          | `10-verify-vni.sh`               |
+| 1 control    | the VNI becomes an identity label                | `10-verify-vni.sh`               |
+| 1 control    | the CiliumEndpoint carries the VNI to other nodes| `70-lifecycle.sh`                |
+| 1 control    | a lost annotation must not drop the VPC scope    | `70-lifecycle.sh`                |
+| 2 cache      | one ipcache entry per (VNI, IP)                  | `10-verify-vni.sh`               |
+| 2 cache      | the full dump copes with VNI keys (used to panic)| `50-datapath.sh`                 |
+| 2 cache      | deleting one VPC leaves the others intact        | `70-lifecycle.sh`                |
+| 3 forwarding | VNI-scoped ipcache map and its key layout        | `50-datapath.sh`                 |
+| 3 forwarding | per-endpoint load-time VNI in bpf_lxc            | `50-datapath.sh`                 |
+| 3 forwarding | endpoints addressable as `vni-ipv4:<vni>:<ip>`   | `10-verify-vni.sh`               |
+| 4 policy     | identities, and therefore policy, are VPC-scoped | `30-connectivity.sh`             |
+| 4 policy     | a policy of one VPC cannot affect another        | `30-connectivity.sh`             |
+| 4 policy     | the policy map is keyed by identity, not address | `35-policymap.sh`                |
+| 4 policy     | the allowed peer carries the same VNI            | `35-policymap.sh`                |
+| 4 policy     | the port scope is visible in the policy map      | `35-policymap.sh`                |
+| 5 conntrack  | the overlap precondition is observable           | `10-verify-vni.sh`               |
+| 6 service    | no service translation for VPC endpoints         | `60-service.sh`                  |
+| 6 service    | services still work (kube-ovn resolves them)     | `60-service.sh`                  |
+| 7 fragments  | the fragment key is VPC scoped                   | `50-datapath.sh` (key size)      |
+| 8 observ.    | flows carry the VNI on both endpoints            | `40-observability.sh`            |
+| 8 observ.    | verdicts are not mixed between VPCs              | `40-observability.sh`            |
+| 8 observ.    | the tooling shows the VPC scope                  | `50-datapath.sh`                 |
+| 8 observ.    | per-VPC forwarding records carry VNI+IP+identity | `45-hubble-vni.sh`               |
+| 8 observ.    | verdict/port pattern per VPC matches its policy  | `45-hubble-vni.sh`               |
+| 8 observ.    | flows are filterable by the VNI identity label   | `45-hubble-vni.sh`               |
+| 9 lifecycle  | a restart restores VNI, identities and ipcache   | `70-lifecycle.sh`                |
+| 9 lifecycle  | policy behaviour is unchanged after a restart    | `70-lifecycle.sh`                |
+| 10 assembly  | the agent starts in native-vpc mode              | `50-datapath.sh` (no fatal log)  |
+| all          | the run produces no error log and no unexpected  | `80-logs.sh`                     |
+|              | warning, drop reason or invalid policy           |                                  |
+
+Checks that stay in the Go unit tests because they cannot be provoked on a live
+cluster: the startup rejections (kube-proxy replacement, socket LB, egress
+gateway, masquerade, encryption, SRv6, VTEP, CiliumEndpointSlice,
+operator-managed identities, tunnel routing), the rejection of an API-supplied
+VNI that disagrees with the annotation, and the C/Go alignment of both datapath
+variants.
+
+Known gap, by design: conntrack state has no VPC scope. The suite therefore
+asserts the *precondition metric* rather than the absence of collisions; keep
+overlapping IPs of different VPCs on disjoint nodes.
+
+## Reading the evidence per layer
+
+Each script prints the raw data it asserts on, so a reviewer can check the
+layers by eye rather than trusting a boolean:
+
+| Layer                      | Command used                                       | What to look for                                   |
+|----------------------------|----------------------------------------------------|----------------------------------------------------|
+| pod / kube-ovn             | `kubectl get pod -o jsonpath=...tunnel_key`        | a different key per subnet, identical pod IPs       |
+| control (endpoint)         | `cilium-dbg endpoint list`                         | `vni:io-cilium-native-vpc-vni=<n>` and 3 identities |
+| control (CiliumEndpoint)   | `kubectl get cep -o jsonpath=...native-vpc...vni`  | the same VNI, so other nodes can scope the endpoint |
+| cache (ipcache)            | `cilium-dbg bpf ipcache list \| grep @vni:`         | one entry per (VNI, IP)                            |
+| cache (API/listing)        | `cilium-dbg ip list`                               | rows rendered as `<prefix>@vni:<n>`                |
+| forwarding (maps)          | `bpftool map show pinned .../cilium_ipcache_vni`   | lpm_trie, key 28B; fragment map key 16B            |
+| forwarding (per endpoint)  | `/var/run/cilium/state/<id>/ep_config.json`        | `"VNIID":<n>`                                      |
+| policy                     | `cilium-dbg bpf policy get <endpoint>`             | identity-keyed allow entries, port scope, counters |
+| conntrack (limitation)     | `cilium-dbg metrics list \| grep native_vpc`        | the overlap precondition                            |
+| observability              | `hubble observe -o json`                           | `vni_id` on both endpoints, verdicts per VPC        |
+| observability (filter)     | `hubble observe --label vni:io-cilium-...=<n>`     | only that VPC's flows                              |
+
+## What the logs are expected to contain
+
+`80-logs.sh` fails on anything not in this list, so the expected noise is
+documented rather than ignored:
+
+| Message                                                    | Why it is expected                                                        |
+|------------------------------------------------------------|---------------------------------------------------------------------------|
+| `local endpoints of different VPCs share an IP` (warn)      | emitted on purpose: the fixture co-locates overlapping addresses, which is the conntrack-plane precondition. The script *requires* it to appear |
+| `Couldn't find state, ignoring endpoint` for `<id>_next`    | upstream: leftover regeneration directories are skipped on restore        |
+| `UNSUPPORTED_L2/L3_PROTOCOL` drops                          | the cluster runs with `enable-ipv6=false` while the pods still emit IPv6 link-local traffic |
+| `STALE_OR_UNROUTABLE_IP` (a few packets)                    | stragglers from pods that were deleted during the run                     |
+| kube-ovn `not standby yet` / `not found, requeuing` / `v4 using ip range is empty` | reconcile races while a VPC or subnet is created or deleted; they settle   |
+
+Everything else - any `level=error`, any other warning, any other drop reason,
+any invalid CiliumNetworkPolicy - fails the run.
+
+## Requirements
+
+- kube-ovn with VPC support (tested with v1.15.10);
+- Cilium in native-vpc mode: `nativeVPC.enabled=true`,
+  `nativeVPC.vniAnnotation=ovn.kubernetes.io/tunnel_key`, `routingMode=native`,
+  CNI chaining `generic-veth` behind kube-ovn;
+- the `busybox:1.36` image present on the nodes (`imagePullPolicy: IfNotPresent`).
+
+## Notes
+
+- Pods are pinned to fixed addresses with `ovn.kubernetes.io/ip_address`, which
+  is what makes the overlap deterministic instead of accidental.
+- `vpc-a` uses `ingress: [{fromEndpoints: []}]` for default deny; an empty
+  `ingress: []` list would *not* enable enforcement.
+- Custom VPCs are isolated from the cluster network by design, so the pods have
+  no DNS or API access; every check is pure east-west traffic inside one VPC.

--- a/test/native-vpc/README.md
+++ b/test/native-vpc/README.md
@@ -24,6 +24,7 @@ another VPC's traffic.
 |-----------------------|------------------------------------------------------------------------------|
 | `00-setup.sh`         | creates the VPCs, the overlapping subnets, the namespaces and the six pods    |
 | `10-verify-vni.sh`    | asserts the control/cache/forwarding/conntrack state is scoped per VNI        |
+| `15-key-uniqueness.sh` | after CNI ADD each pod owns exactly one resource per plane under its own (VNI, IP); after CNI DEL only its own are gone |
 | `20-policies.sh`      | applies the three policy scenarios                                            |
 | `30-connectivity.sh`  | runs the connectivity matrix and the cross-VPC leak checks                    |
 | `35-policymap.sh`     | the identity-keyed policy map of each server, as the datapath sees it          |

--- a/test/native-vpc/README.md
+++ b/test/native-vpc/README.md
@@ -24,7 +24,7 @@ another VPC's traffic.
 |-----------------------|------------------------------------------------------------------------------|
 | `00-setup.sh`         | creates the VPCs, the overlapping subnets, the namespaces and the six pods    |
 | `10-verify-vni.sh`    | asserts the control/cache/forwarding/conntrack state is scoped per VNI        |
-| `15-key-uniqueness.sh` | after CNI ADD each pod owns exactly one resource per plane under its own (VNI, IP); after CNI DEL only its own are gone |
+| `15-key-uniqueness.sh` | after CNI ADD each pod owns exactly one resource per plane under its own (VNI, IP); after CNI DEL only its own are gone, including a DEL that happens while the agent is down; the host stack and the operator commands hold to the same rule |
 | `20-policies.sh`      | applies the three policy scenarios                                            |
 | `30-connectivity.sh`  | runs the connectivity matrix and the cross-VPC leak checks                    |
 | `35-policymap.sh`     | the identity-keyed policy map of each server, as the datapath sees it          |

--- a/test/native-vpc/README.md
+++ b/test/native-vpc/README.md
@@ -156,7 +156,7 @@ documented rather than ignored:
 | `Couldn't find state, ignoring endpoint` for `<id>_next`    | upstream: leftover regeneration directories are skipped on restore        |
 | `UNSUPPORTED_L2/L3_PROTOCOL` drops                          | the cluster runs with `enable-ipv6=false` while the pods still emit IPv6 link-local traffic |
 | `STALE_OR_UNROUTABLE_IP` (a few packets)                    | stragglers from pods that were deleted during the run                     |
-| kube-ovn `not standby yet` / `not found, requeuing` / `v4 using ip range is empty` | reconcile races while a VPC or subnet is created or deleted; they settle   |
+| kube-ovn `not standby yet` / `not found, requeuing` / `v4 using ip range is empty` / `datapath binding not found` | reconcile races while a VPC or subnet is created or deleted; the last one is the window before OVN binds the switch and the tunnel key exists. The suite asserts each subnet has settled on a key |
 
 Everything else - any `level=error`, any other warning, any other drop reason,
 any invalid CiliumNetworkPolicy - fails the run.

--- a/test/native-vpc/README.md
+++ b/test/native-vpc/README.md
@@ -29,6 +29,7 @@ another VPC's traffic.
 | `35-policymap.sh`     | the identity-keyed policy map of each server, as the datapath sees it          |
 | `40-observability.sh` | asserts Hubble attributes every flow to the right VPC                         |
 | `45-hubble-vni.sh`    | per-VPC forwarding-plane records (VNI+IP+identity+verdict) and VNI filtering   |
+| `55-vni-scope-change.sh` | the VPC of a running pod is not changed by an annotation; a real move leaves nothing behind |
 | `50-datapath.sh`      | BPF map layouts, per-endpoint load-time VNI, and the debug tooling             |
 | `60-service.sh`       | services are resolved by kube-ovn, not rewritten by Cilium                     |
 | `70-lifecycle.sh`     | CEP annotation, annotation loss, agent restart, pod deletion                   |
@@ -80,8 +81,14 @@ to the review in `Documentation/network/native-vpc.rst`.
 | 2 cache      | one ipcache entry per (VNI, IP)                  | `10-verify-vni.sh`               |
 | 2 cache      | the full dump copes with VNI keys (used to panic)| `50-datapath.sh`                 |
 | 2 cache      | deleting one VPC leaves the others intact        | `70-lifecycle.sh`                |
+| 2 cache      | a scope change is a delete plus an upsert, never | `55-vni-scope-change.sh`         |
+|              | a second entry under the abandoned VPC           |                                  |
+| 1 control    | a drifting annotation does not move a running    | `55-vni-scope-change.sh`         |
+|              | pod between VPCs, not even across a restart      |                                  |
 | 3 forwarding | VNI-scoped ipcache map and its key layout        | `50-datapath.sh`                 |
-| 3 forwarding | per-endpoint load-time VNI in bpf_lxc            | `50-datapath.sh`                 |
+| `50-datapath.sh`                 |
+| 3 forwarding | per-endpoint load-time VNI in bpf_lxc            | `55-vni-scope-change.sh` | the VPC of a running pod is not changed by an annotation; a real move leaves nothing behind |
+| `50-datapath.sh`                 |
 | 3 forwarding | endpoints addressable as `vni-ipv4:<vni>:<ip>`   | `10-verify-vni.sh`               |
 | 4 policy     | identities, and therefore policy, are VPC-scoped | `30-connectivity.sh`             |
 | 4 policy     | a policy of one VPC cannot affect another        | `30-connectivity.sh`             |
@@ -91,16 +98,19 @@ to the review in `Documentation/network/native-vpc.rst`.
 | 5 conntrack  | the overlap precondition is observable           | `10-verify-vni.sh`               |
 | 6 service    | no service translation for VPC endpoints         | `60-service.sh`                  |
 | 6 service    | services still work (kube-ovn resolves them)     | `60-service.sh`                  |
-| 7 fragments  | the fragment key is VPC scoped                   | `50-datapath.sh` (key size)      |
+| 7 fragments  | the fragment key is VPC scoped                   | `55-vni-scope-change.sh` | the VPC of a running pod is not changed by an annotation; a real move leaves nothing behind |
+| `50-datapath.sh` (key size)      |
 | 8 observ.    | flows carry the VNI on both endpoints            | `40-observability.sh`            |
 | 8 observ.    | verdicts are not mixed between VPCs              | `40-observability.sh`            |
-| 8 observ.    | the tooling shows the VPC scope                  | `50-datapath.sh`                 |
+| 8 observ.    | the tooling shows the VPC scope                  | `55-vni-scope-change.sh` | the VPC of a running pod is not changed by an annotation; a real move leaves nothing behind |
+| `50-datapath.sh`                 |
 | 8 observ.    | per-VPC forwarding records carry VNI+IP+identity | `45-hubble-vni.sh`               |
 | 8 observ.    | verdict/port pattern per VPC matches its policy  | `45-hubble-vni.sh`               |
 | 8 observ.    | flows are filterable by the VNI identity label   | `45-hubble-vni.sh`               |
 | 9 lifecycle  | a restart restores VNI, identities and ipcache   | `70-lifecycle.sh`                |
 | 9 lifecycle  | policy behaviour is unchanged after a restart    | `70-lifecycle.sh`                |
-| 10 assembly  | the agent starts in native-vpc mode              | `50-datapath.sh` (no fatal log)  |
+| 10 assembly  | the agent starts in native-vpc mode              | `55-vni-scope-change.sh` | the VPC of a running pod is not changed by an annotation; a real move leaves nothing behind |
+| `50-datapath.sh` (no fatal log)  |
 | all          | the run produces no error log and no unexpected  | `80-logs.sh`                     |
 |              | warning, drop reason or invalid policy           |                                  |
 

--- a/test/native-vpc/lib.sh
+++ b/test/native-vpc/lib.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Shared helpers for the native-vpc (VNI) end-to-end tests.
+# All tests run against a live cluster: kube-ovn provides three VPCs whose
+# subnets deliberately use the *same* CIDR, so every VPC contains pods with
+# identical IPs. Cilium must keep them apart by (VNI, IP).
+
+set -uo pipefail
+
+# Three VPCs, three subnets, all with the SAME CIDR: this overlap is the whole
+# point of the feature under test.
+export OVERLAP_CIDR="10.99.0.0/24"
+export VPCS=(vpc-a vpc-b vpc-c)
+# Fixed IPs so that every VPC has a client and a server on the *same* address.
+export CLIENT_IP="10.99.0.11"
+export SERVER_IP="10.99.0.12"
+export PORT_ALLOWED=8080
+export PORT_DENIED=9090
+
+export CILIUM_NS=kube-system
+export TEST_TIMEOUT=4
+
+RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[0;33m'; BLUE=$'\033[0;34m'; NC=$'\033[0m'
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+log()  { echo "${BLUE}==>${NC} $*"; }
+info() { echo "    $*"; }
+warn() { echo "${YELLOW}[warn]${NC} $*"; }
+
+pass() { PASS_COUNT=$((PASS_COUNT+1)); echo "${GREEN}[PASS]${NC} $*"; }
+fail() { FAIL_COUNT=$((FAIL_COUNT+1)); echo "${RED}[FAIL]${NC} $*"; }
+
+# assert_eq <expected> <actual> <description>
+assert_eq() {
+  if [[ "$1" == "$2" ]]; then pass "$3 (= $2)"; else fail "$3 (expected '$1', got '$2')"; fi
+}
+
+# assert_contains <haystack> <needle> <description>
+assert_contains() {
+  if [[ "$1" == *"$2"* ]]; then pass "$3"; else fail "$3 (missing '$2' in: $1)"; fi
+}
+
+summary() {
+  echo
+  echo "──────────────────────────────────────────────"
+  if [[ $FAIL_COUNT -eq 0 ]]; then
+    echo "${GREEN}ALL PASSED${NC}  (${PASS_COUNT} checks)"
+  else
+    echo "${RED}FAILURES: ${FAIL_COUNT}${NC}  (passed ${PASS_COUNT})"
+  fi
+  echo "──────────────────────────────────────────────"
+  [[ $FAIL_COUNT -eq 0 ]]
+}
+
+cilium_pod() {
+  kubectl -n "$CILIUM_NS" get pod -l k8s-app=cilium -o name 2>/dev/null | head -1
+}
+
+# cilium_exec <args...> - run cilium-dbg inside the agent
+cilium_exec() {
+  kubectl -n "$CILIUM_NS" exec "$(cilium_pod)" -c cilium-agent -- "$@" 2>/dev/null
+}
+
+# pod_vni <namespace> <pod> - the kube-ovn tunnel_key annotation
+pod_vni() {
+  kubectl -n "$1" get pod "$2" -o jsonpath='{.metadata.annotations.ovn\.kubernetes\.io/tunnel_key}' 2>/dev/null
+}
+
+pod_ip() {
+  kubectl -n "$1" get pod "$2" -o jsonpath='{.status.podIP}' 2>/dev/null
+}
+
+# try_connect <namespace> <client pod> <target ip> <port> -> prints "open"/"closed"
+try_connect() {
+  local ns=$1 pod=$2 ip=$3 port=$4
+  if kubectl -n "$ns" exec "$pod" -- wget -q -T "$TEST_TIMEOUT" -O- "http://${ip}:${port}/" >/dev/null 2>&1; then
+    echo open
+  else
+    echo closed
+  fi
+}
+
+wait_for_pod() {
+  local ns=$1 pod=$2 tries=${3:-60}
+  for _ in $(seq "$tries"); do
+    [[ "$(kubectl -n "$ns" get pod "$pod" -o jsonpath='{.status.phase}' 2>/dev/null)" == "Running" ]] && return 0
+    sleep 2
+  done
+  return 1
+}

--- a/test/native-vpc/run-all.sh
+++ b/test/native-vpc/run-all.sh
@@ -7,7 +7,7 @@ rc=0
 # Order matters: fixtures, state, policies, behaviour, observability, datapath
 # and tooling, service plane, and finally lifecycle (which restarts the agent
 # and deletes a pod, so it must run last).
-for step in 00-setup.sh 10-verify-vni.sh 20-policies.sh 30-connectivity.sh \
+for step in 00-setup.sh 10-verify-vni.sh 15-key-uniqueness.sh 20-policies.sh 30-connectivity.sh \
             35-policymap.sh 40-observability.sh 45-hubble-vni.sh 50-datapath.sh 55-vni-scope-change.sh \
             60-service.sh 70-lifecycle.sh 80-logs.sh; do
   echo

--- a/test/native-vpc/run-all.sh
+++ b/test/native-vpc/run-all.sh
@@ -8,7 +8,7 @@ rc=0
 # and tooling, service plane, and finally lifecycle (which restarts the agent
 # and deletes a pod, so it must run last).
 for step in 00-setup.sh 10-verify-vni.sh 20-policies.sh 30-connectivity.sh \
-            35-policymap.sh 40-observability.sh 45-hubble-vni.sh 50-datapath.sh \
+            35-policymap.sh 40-observability.sh 45-hubble-vni.sh 50-datapath.sh 55-vni-scope-change.sh \
             60-service.sh 70-lifecycle.sh 80-logs.sh; do
   echo
   echo "################ ${step} ################"

--- a/test/native-vpc/run-all.sh
+++ b/test/native-vpc/run-all.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Runs the whole suite from a clean slate and reports a single verdict.
+set -uo pipefail
+cd "$(dirname "$0")"
+
+rc=0
+# Order matters: fixtures, state, policies, behaviour, observability, datapath
+# and tooling, service plane, and finally lifecycle (which restarts the agent
+# and deletes a pod, so it must run last).
+for step in 00-setup.sh 10-verify-vni.sh 20-policies.sh 30-connectivity.sh \
+            35-policymap.sh 40-observability.sh 45-hubble-vni.sh 50-datapath.sh \
+            60-service.sh 70-lifecycle.sh 80-logs.sh; do
+  echo
+  echo "################ ${step} ################"
+  bash "./${step}" || rc=1
+done
+
+echo
+echo "################ verdict ################"
+if [[ $rc -eq 0 ]]; then
+  echo "native-vpc three-VPC overlap suite: PASSED"
+else
+  echo "native-vpc three-VPC overlap suite: FAILED"
+fi
+echo "(run ./90-cleanup.sh to remove the fixtures)"
+exit $rc


### PR DESCRIPTION
本质上就是个控制面的改动：

将 VNI + IP 替换掉（IP） 映射到 identity


 PR 总结：kube-ovn 多 VPC 重叠场景的 Cilium native-vpc 支持

 背景与目标

 kube-ovn 提供多 VPC，不同 VPC 可复用相同 IP 段（重叠子网）。参考： kubevon 侧 tun id 设置可靠性优化与一键恢复（自测合入）：https://github.com/qiniu/kube-ovn/pull/70


Cilium 需要以 VNI（kube-ovn 每个 OVN 逻辑交换机的 tunnel_key） 为作用域，在控制面、缓存面、转发面、切入面（可观察性）三个层次隔离"VNI + IP"，避免重叠
 IP 导致的错误身份判定（"部分可通"）。、

核心契约：每个非 hostNetwork 的 OVN pod 在 CNI ADD 前必须带有非零的 ovn.kubernetes.io/tunnel_key 注解。


 已知边界（设计使然，已文档化）

 1. 运行中注解迁移不热更新（控制/转发面不动）—— 恢复靠重启兜底
 2. CNI 链式顺序要求：kube-ovn 必须为 primary、cilium chained（generic-veth）在其后
 3. native-vpc 模式下所有受管 pod 必须有 VNI（upsertLocal 的 VNI=0 gate 是防碰撞的刻意约束）
 4. inter-VPC 可达性由 kube-ovn 逻辑路由/ACL 决定（默认隔离），不进 Cilium 策略层

 两个组件基于 CNI chanining 机制配合

 kube-ovn 侧保证"注解必达"（gate + 原子 patch + 重启 repair 队列 + 运行时 resync 安全网）；
cilium 侧实现"注解即事实源"的决策表与四面重刷兜底，并修复了 VNI ipcache 布局、vpc label 注入两个会
 实际阻断功能/策略的缺陷。


```

 完整的面清单（已写入设计文档「The ten planes」）

 ┌───────────────────────────────────────┬────────────────────────────────────────────────────────┐
 │ 面                                    │ (VNI, IP) 状态                                         │
 ├───────────────────────────────────────┼────────────────────────────────────────────────────────┤
 │ 控制面                                │ VNI 化 ✅                                              │
 ├───────────────────────────────────────┼────────────────────────────────────────────────────────┤
 │ 缓存面                                │ VNI 化 ✅                                              │
 ├───────────────────────────────────────┼────────────────────────────────────────────────────────┤
 │ 转发面                                │ VNI 化 ✅（cilium_lxc 非权威）                         │
 ├───────────────────────────────────────┼────────────────────────────────────────────────────────┤
 │ 切面（可观察性）                      │ VNI 化 ✅                                              │
 ├───────────────────────────────────────┼────────────────────────────────────────────────────────┤
 │ 策略面                                │ 经 identity 天然 VNI 化 ✅；CIDR/FQDN 与 L7 代理是边界 │
 ├───────────────────────────────────────┼────────────────────────────────────────────────────────┤
 │ 连接跟踪 / NAT 面                     │ ❌ 今天无法表达 (VNI,IP) —— 已文档化 + 运行时检测      │
 ├───────────────────────────────────────┼────────────────────────────────────────────────────────┤
 │ 服务 / 负载均衡面                     │ ❌ 按裸 IP —— 启动即拒绝                               │
 ├───────────────────────────────────────┼────────────────────────────────────────────────────────┤
 │ 加密 / egress gateway / masquerade 面 │ ❌ 按裸 IP —— 启动即拒绝                               │
 ├───────────────────────────────────────┼────────────────────────────────────────────────────────┤
 │ 生命周期面（升级/重启/修复）          │ 流程性，已文档化                                       │
 ├───────────────────────────────────────┼────────────────────────────────────────────────────────┤
 │ 装配面（hive 依赖图）                 │ 本轮发现 P0，已修 + 纳入验收门禁                       │
 └───────────────────────────────────────┴────────────────────────────────────────────────────────┘

```
